### PR TITLE
Fix favicon cache, reduce hero spacing, update repo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ A ranking tool. A benchmarking system. A productivity scorecard. Numbers here ar
 ### Setup
 
 ```bash
-git clone https://github.com/JonasHeller1212/ScholarMetricsAnalyzer.git
-cd ScholarMetricsAnalyzer
+git clone https://github.com/JonasHeller1212/ResearchFolio.git
+cd ResearchFolio
 npm install
 ```
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Scholar Folio — your publication history, collaboration network, and research reach on one page." />
     <meta name="theme-color" content="#1e293b" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import { scholarService } from './services/scholar';
 
 const SOCIAL_LINKS = {
   linkedin: 'https://www.linkedin.com/in/hellerjonas/',
-  github: 'https://github.com/JonasHeller1212/ScholarMetricsAnalyzer'
+  github: 'https://github.com/JonasHeller1212/ResearchFolio'
 };
 
 type Page = 'home' | 'about' | 'terms' | 'privacy';

--- a/src/components/AboutPage.tsx
+++ b/src/components/AboutPage.tsx
@@ -69,7 +69,7 @@ export function AboutPage({ onBack }: AboutPageProps) {
             <p>
               Scholar Folio is open source.{' '}
               <a
-                href="https://github.com/JonasHeller1212/ScholarMetricsAnalyzer"
+                href="https://github.com/JonasHeller1212/ResearchFolio"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-[#2d7d7d] hover:underline inline-flex items-center gap-1"

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -71,7 +71,7 @@ export function LandingPage({ onSearch, loading, error, onNavigate }: LandingPag
               About
             </button>
             <a
-              href="https://github.com/JonasHeller1212/ScholarMetricsAnalyzer"
+              href="https://github.com/JonasHeller1212/ResearchFolio"
               target="_blank"
               rel="noopener noreferrer"
               className="nav-link text-xs font-medium text-gray-500 hover:text-gray-900 transition-colors inline-flex items-center gap-1"
@@ -97,7 +97,7 @@ export function LandingPage({ onSearch, loading, error, onNavigate }: LandingPag
                 About
               </button>
               <a
-                href="https://github.com/JonasHeller1212/ScholarMetricsAnalyzer"
+                href="https://github.com/JonasHeller1212/ResearchFolio"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="block text-sm text-gray-600 hover:text-gray-900"
@@ -110,7 +110,7 @@ export function LandingPage({ onSearch, loading, error, onNavigate }: LandingPag
       </nav>
 
       {/* Hero */}
-      <section className="relative pt-16 pb-14 px-6">
+      <section className="relative pt-16 pb-6 px-6">
         <div className="max-w-3xl mx-auto text-center">
           <h1 className="animate-fade-up animate-delay-150 font-serif text-5xl md:text-6xl lg:text-7xl font-bold tracking-tight text-[#1e293b] mb-4 leading-[1.05]">
             Know your


### PR DESCRIPTION
## Summary
- Add cache-bust param to favicon link so browsers pick up the new teal icon
- Reduce hero bottom padding (pb-14 → pb-6) to close the gap under "search by author name"
- Update all GitHub URLs from ScholarMetricsAnalyzer to ResearchFolio

## Test plan
- [ ] Verify new favicon shows in browser tab (may need hard refresh)
- [ ] Check spacing between hero and features section looks tight
- [ ] Confirm GitHub links point to ResearchFolio repo