### PR TITLE
Fix citation graph: SerpAPI data is at cited_by.graph, not cited_by_g…

### DIFF
--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -71,6 +71,59 @@ function getMostCitedPaper(publications: Author['publications']): Author['public
   return publications.reduce((max, p) => p.citations > max.citations ? p : max, publications[0]);
 }
 
+/** Infer research methods/approaches from publication titles. */
+function inferResearchMethods(publications: Author['publications']): string[] {
+  const titleCorpus = publications.map(p => p.title.toLowerCase()).join(' ');
+
+  // Each pattern: [regex to test against joined titles, human-readable label]
+  const methodPatterns: [RegExp, string][] = [
+    [/\bmeta[- ]?analy/, 'meta-analysis'],
+    [/\brandomized|randomised|\brct\b/, 'randomized controlled trials'],
+    [/\bexperiment(?:al|s)?\b/, 'experimental methods'],
+    [/\blongitudinal\b/, 'longitudinal studies'],
+    [/\bcross[- ]?sectional\b/, 'cross-sectional analysis'],
+    [/\bsurvey(?:s|ing)?\b/, 'survey research'],
+    [/\binterview(?:s|ing)?\b/, 'interview-based research'],
+    [/\bethnograph/, 'ethnographic methods'],
+    [/\bqualitative\b/, 'qualitative methods'],
+    [/\bcase stud(?:y|ies)\b/, 'case study research'],
+    [/\bmachine learning|deep learning|\bneural net/, 'machine learning'],
+    [/\bnatural language processing|\bnlp\b/, 'natural language processing'],
+    [/\bsimulat(?:ion|ing|e)\b/, 'simulation'],
+    [/\bcomputational\b/, 'computational approaches'],
+    [/\bstatistical\b/, 'statistical analysis'],
+    [/\bregression\b/, 'regression analysis'],
+    [/\bstructural equation|(?:^|\b)sem\b/, 'structural equation modeling'],
+    [/\bgrounded theory\b/, 'grounded theory'],
+    [/\bsystematic review\b/, 'systematic reviews'],
+    [/\bliterature review\b/, 'literature reviews'],
+    [/\bempirical\b/, 'empirical analysis'],
+    [/\bfield (?:study|experiment|research)\b/, 'field research'],
+    [/\baction research\b/, 'action research'],
+    [/\bmixed[- ]?method/, 'mixed-methods research'],
+    [/\bgenome|genomic|proteomic|transcriptom/, 'genomics/proteomics'],
+    [/\bclinical trial/, 'clinical trials'],
+    [/\bcohort\b/, 'cohort studies'],
+    [/\bnetwork analysis\b/, 'network analysis'],
+    [/\btext mining|sentiment analysis/, 'text mining'],
+    [/\bbayesian\b/, 'Bayesian methods'],
+    [/\bdesign science\b/, 'design science'],
+    [/\barchival\b/, 'archival research'],
+    [/\beconometric/, 'econometric analysis'],
+    [/\bpanel data\b/, 'panel data analysis'],
+    [/\binstrumental variable/, 'instrumental variable methods'],
+    [/\bdifference[- ]?in[- ]?difference/, 'difference-in-differences'],
+  ];
+
+  const detected: string[] = [];
+  for (const [regex, label] of methodPatterns) {
+    if (regex.test(titleCorpus)) {
+      detected.push(label);
+    }
+  }
+  return detected.slice(0, 4); // Cap at 4 to keep the sentence readable
+}
+
 export function ResearcherNarrative({ data }: ResearcherNarrativeProps) {
   const narrative = useMemo(() => {
     const { publications, metrics, topics, name, totalCitations } = data;
@@ -110,6 +163,19 @@ export function ResearcherNarrative({ data }: ResearcherNarrativeProps) {
     if (career.firstYear > 0) {
       careerParagraph += ` Their publication record spans ${career.years} year${career.years !== 1 ? 's' : ''}, with the earliest indexed publication dating back to ${career.firstYear}.`;
     }
+
+    // Infer research methods from publication titles
+    const methods = inferResearchMethods(publications);
+    if (methods.length > 0) {
+      let methodsText: string;
+      if (methods.length === 1) {
+        methodsText = methods[0];
+      } else {
+        methodsText = methods.slice(0, -1).join(', ') + ' and ' + methods[methods.length - 1];
+      }
+      careerParagraph += ` Based on their publication titles, their work draws on ${methodsText}.`;
+    }
+
     paragraphs.push(careerParagraph);
 
     // Impact paragraph

--- a/supabase/functions/scholar/index.ts
+++ b/supabase/functions/scholar/index.ts
@@ -78,15 +78,17 @@ async function fetchViaSerpAPI(authorId: string) {
     paperCount: 0
   }));
 
-  // Extract actual citations-per-year from SerpAPI's cited_by_graph
+  // Extract actual citations-per-year from SerpAPI's cited_by.graph
+  // The graph lives under author.cited_by.graph (NOT top-level cited_by_graph).
+  // Each entry has { year: number, citations: number|string }.
   const citationsPerYear: Record<string, number> = {};
-  if (authorData.cited_by_graph) {
-    for (const entry of authorData.cited_by_graph) {
-      if (entry.year && entry.citations != null) {
-        citationsPerYear[String(entry.year)] = entry.citations;
-      }
+  const graph = authorData.cited_by?.graph || authorData.cited_by_graph || [];
+  for (const entry of graph) {
+    if (entry.year != null && entry.citations != null) {
+      citationsPerYear[String(entry.year)] = parseInt(String(entry.citations)) || 0;
     }
   }
+  console.log(`[SerpAPI] cited_by.graph: ${graph.length} entries, citationsPerYear keys: ${Object.keys(citationsPerYear).length}`);
 
   return {
     name: authorData.author?.name || "",
@@ -581,17 +583,25 @@ Deno.serve(async (req) => {
     }
 
     if (cached?.data) {
-      console.log("Cache hit for:", normalizedUrl);
-      return new Response(
-        JSON.stringify(cached.data),
-        {
-          headers: {
-            ...corsHeaders,
-            'Content-Type': 'application/json',
-            'X-Cache': 'HIT'
+      // Invalidate stale cache entries that are missing citation graph data
+      // (from before the cited_by.graph fix).
+      const hasCitationGraph = cached.data.metrics?.citationsPerYear
+        && Object.keys(cached.data.metrics.citationsPerYear).length > 0;
+      if (hasCitationGraph) {
+        console.log("Cache hit for:", normalizedUrl);
+        return new Response(
+          JSON.stringify(cached.data),
+          {
+            headers: {
+              ...corsHeaders,
+              'Content-Type': 'application/json',
+              'X-Cache': 'HIT'
+            }
           }
-        }
-      );
+        );
+      } else {
+        console.log("Cache hit but missing citationsPerYear — refetching:", normalizedUrl);
+      }
     }
 
     console.log("Cache miss, fetching fresh data");


### PR DESCRIPTION
…raph

The SerpAPI google_scholar_author response nests the citation histogram under cited_by.graph (with string citation values), but the code was reading from the non-existent top-level cited_by_graph field. This made citationsPerYear always empty, causing "Citation graph unavailable" and 0% growth for every profile.

Also:
- Parse citation values as integers (SerpAPI returns strings)
- Bust stale cache entries that are missing citation graph data
- Move currentYear declaration before first use (temporal dead zone fix)
- Add research methods sentence to researcher narrative inferred from publication titles

https://claude.ai/code/session_018YQbwSvKjiM6ncsunumqnu