### PR TITLE
Add shareable profile URLs and fix tag counts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,6 +121,19 @@ function AppContent() {
     }
   }, [refreshCredits]);
 
+  // Handle shareable profile URL (?user=AUTHOR_ID)
+  const initialLoadRef = useRef(false);
+  useEffect(() => {
+    if (initialLoadRef.current) return;
+    const params = new URLSearchParams(window.location.search);
+    const userId = params.get('user');
+    if (userId && userId.length >= 12) {
+      initialLoadRef.current = true;
+      const scholarUrl = `https://scholar.google.com/citations?user=${encodeURIComponent(userId)}`;
+      handleSearch(scholarUrl);
+    }
+  }, [handleSearch]);
+
   // Anonymous usage tracking via localStorage
   const getAnonSearches = () => parseInt(localStorage.getItem('sf_searches') || '0');
   const incrementAnonSearches = () => {
@@ -183,6 +196,11 @@ function AppContent() {
 
       setProfileUrl(url);
       setData(sanitizedData);
+
+      // Update browser URL with shareable link
+      if (userId) {
+        window.history.replaceState({}, '', `?user=${encodeURIComponent(userId)}`);
+      }
     } catch (err) {
       let errorMessage: string;
 
@@ -211,6 +229,7 @@ function AppContent() {
     requestInProgressRef.current = false;
     setShowError(false);
     setPage('home');
+    window.history.replaceState({}, '', window.location.pathname);
   }, []);
 
   const handleNavigate = useCallback((newPage: Page) => {

--- a/src/components/TopicsList.tsx
+++ b/src/components/TopicsList.tsx
@@ -34,11 +34,10 @@ export function TopicsList({ topics = [], compact = false }: TopicsListProps) {
             className={`inline-flex items-center space-x-1 px-1.5 py-0.5 bg-[#eaf4f4] hover:bg-[#d5ecec] text-[#2d7d7d] rounded-full transition-colors ${
               compact ? 'text-[10px]' : 'text-xs'
             }`}
-            title={`${topicName} (${paperCount} papers)`}
+            title={topicName}
           >
             <Hash className={compact ? 'h-2.5 w-2.5' : 'h-3 w-3'} />
             <span>{topicName}</span>
-            {!compact && <span className="text-[#3d9494]">({paperCount})</span>}
           </a>
         );
       })}


### PR DESCRIPTION
## Summary
- **Shareable URLs**: Profiles now get a persistent URL like `scholarfolio.org/?user=xJaxiEEAAAAJ` that can be bookmarked and shared. The URL auto-updates when a profile loads and clears on reset.
- **Fix tags showing (0)**: Removed the misleading paper count `(0)` from topic tags — Google Scholar doesn't provide per-tag paper counts.

## Test plan
- [ ] Load a profile → verify browser URL updates to `?user=AUTHOR_ID`
- [ ] Copy the URL, open in new tab → verify profile auto-loads
- [ ] Click home/reset → verify URL clears back to `/`
- [ ] Verify `?payment=success` redirect still works after a Stripe checkout
- [ ] Verify topic tags display without `(0)` count

🤖 Generated with [Claude Code](https://claude.com/claude-code)