### PR TITLE
Fix journal name truncation in narrative profile

### DIFF
--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -21,8 +21,14 @@ function getTopVenues(publications: Author['publications'], limit: number): { na
   publications.forEach(pub => {
     const venue = pub.venue?.trim();
     if (venue && venue.length > 0) {
-      // Normalize: strip volume/issue/page info after first comma
-      const baseName = venue.replace(/,.*$/, '').replace(/\s+\d+.*$/, '').trim();
+      // Normalize: strip volume/issue/page info (e.g. ", vol. 15", ", 34(2)")
+      // but preserve commas that are part of journal names
+      const baseName = venue
+        .replace(/,\s*(?:vol\.?|no\.?|pp\.?|issue|pages?|supplement)\s.*/i, '')
+        .replace(/,\s*\d[\d()–\-\s]*$/, '')
+        .replace(/\s+\d+\s*\([\d–\-]+\)\s*$/, '')
+        .replace(/\s+\d+\s*$/, '')
+        .trim();
       if (baseName.length > 0) {
         const key = baseName.toLowerCase();
         const existing = venueCounts.get(key);


### PR DESCRIPTION
## Summary
- Fixed regex in `getTopVenues()` that stripped everything after the first comma, breaking journal names like "Proceedings of the ACM..." or names containing commas
- Now only strips known volume/issue/page patterns (vol., no., pp., digit-only suffixes)

## Test plan
- [ ] Check narrative profile for researchers with long journal names (e.g. "Proceedings of the...")
- [ ] Verify volume/issue info is still stripped correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)