### PR TITLE
Add Open Access stats via OpenAlex

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { SignUpWall } from './components/SignUpWall';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import type { Author } from './types/scholar';
 import { scholarService } from './services/scholar';
+import { openAlexService } from './services/openalex';
 
 const SOCIAL_LINKS = {
   linkedin: 'https://www.linkedin.com/in/hellerjonas/',
@@ -202,6 +203,15 @@ function AppContent() {
 
       setProfileUrl(url);
       setData(sanitizedData);
+
+      // Fetch Open Access stats from OpenAlex (non-blocking)
+      openAlexService.fetchOpenAccessStats(sanitizedData.name, sanitizedData.affiliation)
+        .then(oaStats => {
+          if (oaStats) {
+            setData(prev => prev ? { ...prev, openAccess: oaStats } : prev);
+          }
+        })
+        .catch(() => {}); // Silently ignore — OA stats are supplementary
 
       // Update browser URL with shareable link
       if (userId) {

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download } from 'lucide-react';
+import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock } from 'lucide-react';
 import { EmbedModal } from './EmbedModal';
 import { exportProfilePdf } from '../utils/pdfExport';
 import { SearchBar } from './SearchBar';
@@ -267,6 +267,35 @@ export function ProfileView({
                 />
               </div>
             </div>
+
+            {data.openAccess && (
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900 mb-3 flex items-center gap-2">
+                  <Unlock className="h-4 w-4 text-[#2d7d7d]" />
+                  Open Access
+                  <span className="text-[10px] font-normal text-gray-400">via OpenAlex</span>
+                </h3>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+                  <MetricsCard title="Open Access" value={`${data.openAccess.oaPercent}%`} subtitle={`${data.openAccess.oa} of ${data.openAccess.total}`} icon="publications" />
+                  {data.openAccess.gold > 0 && <MetricsCard title="Gold OA" value={data.openAccess.gold} icon="publications" />}
+                  {data.openAccess.green > 0 && <MetricsCard title="Green OA" value={data.openAccess.green} icon="publications" />}
+                  {data.openAccess.hybrid > 0 && <MetricsCard title="Hybrid OA" value={data.openAccess.hybrid} icon="publications" />}
+                  {data.openAccess.closed > 0 && <MetricsCard title="Closed Access" value={data.openAccess.closed} icon="publications" />}
+                </div>
+                {data.openAccess.orcid && (
+                  <div className="mt-3">
+                    <a
+                      href={`https://orcid.org/${data.openAccess.orcid}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] hover:underline"
+                    >
+                      ORCID: {data.openAccess.orcid}
+                    </a>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         )}
 

--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -439,8 +439,41 @@ export function generateNarrativeParagraphs(data: Author): string[] {
     return paragraphs;
 }
 
+function generateOpenAccessParagraph(data: Author): string | null {
+  const oa = data.openAccess;
+  if (!oa || oa.total === 0) return null;
+
+  let pctLabel: string;
+  if (oa.oaPercent >= 90) pctLabel = 'Nearly all';
+  else if (oa.oaPercent >= 70) pctLabel = `A large majority (${oa.oaPercent}%)`;
+  else if (oa.oaPercent >= 50) pctLabel = `Over half (${oa.oaPercent}%)`;
+  else if (oa.oaPercent >= 30) pctLabel = `About a third (${oa.oaPercent}%)`;
+  else if (oa.oaPercent >= 10) pctLabel = `A smaller share (${oa.oaPercent}%)`;
+  else pctLabel = `A small fraction (${oa.oaPercent}%)`;
+
+  let paragraph = `${pctLabel} of their indexed publications are openly accessible.`;
+
+  // Add breakdown if there's meaningful variety
+  const parts: string[] = [];
+  if (oa.gold > 0) parts.push(`${oa.gold} gold`);
+  if (oa.green > 0) parts.push(`${oa.green} green`);
+  if (oa.hybrid > 0) parts.push(`${oa.hybrid} hybrid`);
+  if (oa.bronze > 0) parts.push(`${oa.bronze} bronze`);
+
+  if (parts.length > 1) {
+    paragraph += ` This includes ${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]} open access publications.`;
+  }
+
+  if (oa.orcid) {
+    paragraph += ` Their ORCID identifier is ${oa.orcid}.`;
+  }
+
+  return paragraph;
+}
+
 export function ResearcherNarrative({ data }: ResearcherNarrativeProps) {
   const narrative = useMemo(() => generateNarrativeParagraphs(data), [data]);
+  const oaParagraph = useMemo(() => generateOpenAccessParagraph(data), [data]);
 
   return (
     <div>
@@ -452,6 +485,7 @@ export function ResearcherNarrative({ data }: ResearcherNarrativeProps) {
         {narrative.map((paragraph, i) => (
           <p key={i}>{paragraph}</p>
         ))}
+        {oaParagraph && <p>{oaParagraph}</p>}
       </div>
     </div>
   );

--- a/src/services/openalex/index.ts
+++ b/src/services/openalex/index.ts
@@ -1,14 +1,113 @@
 import { ApiError } from '../../utils/api';
-import type { JournalRanking } from '../../types/scholar';
+import type { JournalRanking, OpenAccessStats } from '../../types/scholar';
 import { rateLimiter } from '../scholar/rate-limiter';
 
 export class OpenAlexService {
   private readonly API_URL = 'https://api.openalex.org';
-  private readonly EMAIL = 'research-portfolio@example.com';
+  private readonly EMAIL = 'scholarfolio@scholarfolio.org';
 
   private readonly headers = {
-    'User-Agent': `ResearchPortfolio/1.0 (${this.EMAIL})`
+    'User-Agent': `ScholarFolio/1.0 (mailto:${this.EMAIL})`
   };
+
+  /**
+   * Search OpenAlex for an author by name + affiliation, return OA stats.
+   * Non-blocking — returns null on any failure.
+   */
+  public async fetchOpenAccessStats(name: string, affiliation: string): Promise<OpenAccessStats | null> {
+    try {
+      // Step 1: Find the author in OpenAlex
+      const authorId = await this.findAuthorId(name, affiliation);
+      if (!authorId) return null;
+
+      // Step 2: Get works grouped by OA status
+      await rateLimiter.acquireToken();
+      const worksUrl = `${this.API_URL}/works?filter=authorships.author.id:${authorId}&group_by=open_access.oa_status&per_page=0&mailto=${this.EMAIL}`;
+      const worksResponse = await fetch(worksUrl, {
+        headers: this.headers,
+        signal: AbortSignal.timeout(10000)
+      });
+
+      if (!worksResponse.ok) return null;
+      const worksData = await worksResponse.json();
+
+      const groups: Record<string, number> = {};
+      let total = 0;
+      for (const g of worksData.group_by || []) {
+        groups[g.key] = g.count;
+        total += g.count;
+      }
+
+      if (total === 0) return null;
+
+      const gold = groups['gold'] || 0;
+      const green = groups['green'] || 0;
+      const hybrid = groups['hybrid'] || 0;
+      const bronze = groups['bronze'] || 0;
+      const closed = groups['closed'] || 0;
+      const oa = gold + green + hybrid + bronze;
+
+      // Step 3: Get ORCID from author record
+      await rateLimiter.acquireToken();
+      const authorResponse = await fetch(`${this.API_URL}/authors/${authorId}?mailto=${this.EMAIL}`, {
+        headers: this.headers,
+        signal: AbortSignal.timeout(10000)
+      });
+      let orcid: string | undefined;
+      if (authorResponse.ok) {
+        const authorData = await authorResponse.json();
+        if (authorData.orcid) {
+          orcid = authorData.orcid.replace('https://orcid.org/', '');
+        }
+      }
+
+      return {
+        total,
+        oa,
+        gold,
+        green,
+        hybrid,
+        bronze,
+        closed,
+        oaPercent: Math.round((oa / total) * 100),
+        orcid,
+      };
+    } catch (error) {
+      console.warn('[OpenAlex] Error fetching OA stats:', error);
+      return null;
+    }
+  }
+
+  private async findAuthorId(name: string, affiliation: string): Promise<string | null> {
+    await rateLimiter.acquireToken();
+
+    // Search by name, optionally filtered by institution
+    let searchUrl = `${this.API_URL}/authors?search=${encodeURIComponent(name)}&per_page=5&mailto=${this.EMAIL}`;
+
+    const response = await fetch(searchUrl, {
+      headers: this.headers,
+      signal: AbortSignal.timeout(10000)
+    });
+
+    if (!response.ok) return null;
+    const data = await response.json();
+    const results = data.results || [];
+
+    if (results.length === 0) return null;
+    if (results.length === 1) return results[0].id;
+
+    // Multiple results — try to match by affiliation
+    const affiliationLower = affiliation.toLowerCase();
+    for (const author of results) {
+      const lastInstitution = author.last_known_institutions?.[0]?.display_name?.toLowerCase() || '';
+      const allInstitutions = (author.affiliations || []).map((a: any) => a.institution?.display_name?.toLowerCase() || '');
+      if (lastInstitution && affiliationLower.includes(lastInstitution)) return author.id;
+      if (allInstitutions.some((inst: string) => inst && affiliationLower.includes(inst))) return author.id;
+    }
+
+    // No affiliation match — return top result (OpenAlex ranks by relevance)
+    return results[0].id;
+  }
 
   public async getJournalMetrics(issn: string): Promise<JournalRanking | null> {
     await rateLimiter.acquireToken();

--- a/src/types/scholar.ts
+++ b/src/types/scholar.ts
@@ -59,6 +59,18 @@ export interface Metrics {
   topCoAuthorLastPaper: string;
 }
 
+export interface OpenAccessStats {
+  total: number;
+  oa: number;
+  gold: number;
+  green: number;
+  hybrid: number;
+  bronze: number;
+  closed: number;
+  oaPercent: number;
+  orcid?: string;
+}
+
 export interface Author {
   name: string;
   affiliation: string;
@@ -68,6 +80,7 @@ export interface Author {
   totalCitations: number;
   publications: Publication[];
   metrics: Metrics;
+  openAccess?: OpenAccessStats;
 }
 
 // Utility types


### PR DESCRIPTION
## Summary
- After Scholar profile loads, queries OpenAlex by author name + affiliation (non-blocking)
- Shows OA breakdown (gold/green/hybrid/bronze/closed) as metric cards in Impact Metrics tab
- Adds narrative paragraph: "X% of their publications are openly accessible..."
- Displays ORCID link when OpenAlex has one for the author
- No API key needed — OpenAlex is free with polite pool (mailto header)

## Test plan
- [ ] Search any researcher → OA section appears in Impact Metrics after brief delay
- [ ] Check OA percentages look reasonable
- [ ] ORCID link works when present
- [ ] Narrative includes OA paragraph
- [ ] Profile still loads fine if OpenAlex is down/slow

🤖 Generated with [Claude Code](https://claude.com/claude-code)