### PR TITLE
Add Open Science tab, per-publication OA badges, ORCID button

### DIFF
--- a/src/components/OpenScienceTab.tsx
+++ b/src/components/OpenScienceTab.tsx
@@ -1,0 +1,154 @@
+import React, { useMemo } from 'react';
+import { Unlock, Lock, ExternalLink, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import type { Author, OaStatus } from '../types/scholar';
+
+const OA_COLORS: Record<OaStatus, { bg: string; fill: string; text: string; label: string; tooltip: string }> = {
+  gold: { bg: 'bg-amber-100', fill: 'bg-amber-400', text: 'text-amber-800', label: 'Gold', tooltip: 'Published in a fully open access journal' },
+  green: { bg: 'bg-emerald-100', fill: 'bg-emerald-400', text: 'text-emerald-800', label: 'Green', tooltip: 'Available via a repository (e.g. institutional or preprint server)' },
+  hybrid: { bg: 'bg-sky-100', fill: 'bg-sky-400', text: 'text-sky-800', label: 'Hybrid', tooltip: 'Open access article in a subscription journal' },
+  bronze: { bg: 'bg-orange-100', fill: 'bg-orange-400', text: 'text-orange-800', label: 'Bronze', tooltip: 'Free to read on publisher site, but without an open license' },
+  closed: { bg: 'bg-gray-100', fill: 'bg-gray-300', text: 'text-gray-600', label: 'Closed', tooltip: 'Not freely available' },
+};
+
+interface OpenScienceTabProps {
+  data: Author;
+}
+
+function OaTrend({ publications, publicationOa }: { publications: Author['publications']; publicationOa?: Record<string, { status: OaStatus }> }) {
+  const yearlyOa = useMemo(() => {
+    if (!publicationOa) return [];
+    const yearMap: Record<number, { total: number; oa: number }> = {};
+    for (const pub of publications) {
+      if (pub.year <= 0) continue;
+      const normalized = pub.title.toLowerCase().replace(/[^a-z0-9]/g, '');
+      const oaInfo = publicationOa[normalized];
+      if (!yearMap[pub.year]) yearMap[pub.year] = { total: 0, oa: 0 };
+      yearMap[pub.year].total++;
+      if (oaInfo && oaInfo.status !== 'closed') yearMap[pub.year].oa++;
+    }
+    return Object.entries(yearMap)
+      .map(([year, data]) => ({ year: parseInt(year), ...data, pct: Math.round((data.oa / data.total) * 100) }))
+      .sort((a, b) => a.year - b.year)
+      .filter(d => d.total >= 1);
+  }, [publications, publicationOa]);
+
+  if (yearlyOa.length < 2) return null;
+
+  const maxTotal = Math.max(...yearlyOa.map(d => d.total));
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+      <h3 className="text-sm font-semibold text-gray-900 mb-4">Open Access Over Time</h3>
+      <div className="space-y-1.5">
+        {yearlyOa.map(({ year, total, oa, pct }) => (
+          <div key={year} className="flex items-center gap-3 text-sm">
+            <span className="text-gray-500 w-12 text-xs shrink-0">{year}</span>
+            <div className="flex-1 bg-gray-100 rounded-full h-5 overflow-hidden relative" title={`${oa} of ${total} publications are open access (${pct}%)`}>
+              <div
+                className="absolute inset-y-0 left-0 bg-gray-300 rounded-full transition-all duration-300"
+                style={{ width: `${(total / maxTotal) * 100}%` }}
+              />
+              <div
+                className="absolute inset-y-0 left-0 bg-[#2d7d7d] rounded-full transition-all duration-300"
+                style={{ width: `${(oa / maxTotal) * 100}%` }}
+              />
+            </div>
+            <span className="text-xs text-gray-500 w-16 text-right shrink-0" title={`${oa}/${total} OA`}>
+              {pct}% OA
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center gap-4 mt-3 text-[10px] text-gray-400">
+        <span className="flex items-center gap-1"><span className="w-3 h-2 rounded bg-[#2d7d7d] inline-block" /> Open Access</span>
+        <span className="flex items-center gap-1"><span className="w-3 h-2 rounded bg-gray-300 inline-block" /> Closed</span>
+      </div>
+    </div>
+  );
+}
+
+export function OpenScienceTab({ data }: OpenScienceTabProps) {
+  const oa = data.openAccess;
+
+  if (!oa) {
+    return (
+      <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 text-center">
+        <Unlock className="h-8 w-8 text-gray-300 mx-auto mb-3" />
+        <p className="text-sm text-gray-500">Loading Open Access data from OpenAlex...</p>
+        <p className="text-xs text-gray-400 mt-1">This may take a few seconds</p>
+      </div>
+    );
+  }
+
+  const statuses: OaStatus[] = ['gold', 'green', 'hybrid', 'bronze', 'closed'];
+
+  return (
+    <div className="space-y-6">
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-5">
+          <div className="flex items-center gap-2 text-[#2d7d7d] mb-2"><Unlock className="h-4 w-4" /></div>
+          <div className="text-2xl font-bold text-gray-900">{oa.oaPercent}%</div>
+          <div className="text-xs text-gray-500 mt-0.5">Open Access</div>
+        </div>
+        {statuses.filter(s => oa[s] > 0).map(status => (
+          <div key={status} className="bg-white rounded-2xl border border-gray-100 shadow-card p-5" title={OA_COLORS[status].tooltip}>
+            <div className={`flex items-center gap-2 mb-2 ${OA_COLORS[status].text}`}>
+              {status === 'closed' ? <Lock className="h-4 w-4" /> : <Unlock className="h-4 w-4" />}
+            </div>
+            <div className="text-2xl font-bold text-gray-900">{oa[status]}</div>
+            <div className="text-xs text-gray-500 mt-0.5 cursor-help" title={OA_COLORS[status].tooltip}>{OA_COLORS[status].label} OA</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Visual breakdown bar */}
+      <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+        <h3 className="text-sm font-semibold text-gray-900 mb-4">Access Breakdown</h3>
+        <div className="h-8 rounded-full overflow-hidden flex">
+          {statuses.filter(s => oa[s] > 0).map(status => (
+            <div
+              key={status}
+              className={`${OA_COLORS[status].fill} transition-all duration-500 cursor-help`}
+              style={{ width: `${(oa[status] / oa.total) * 100}%` }}
+              title={`${OA_COLORS[status].label}: ${oa[status]} publications (${Math.round((oa[status] / oa.total) * 100)}%)`}
+            />
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-3 mt-3">
+          {statuses.filter(s => oa[s] > 0).map(status => (
+            <span key={status} className="flex items-center gap-1.5 text-xs text-gray-600 cursor-help" title={OA_COLORS[status].tooltip}>
+              <span className={`w-3 h-3 rounded ${OA_COLORS[status].fill}`} />
+              {OA_COLORS[status].label} ({oa[status]})
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* OA trend over time */}
+      <OaTrend publications={data.publications} publicationOa={oa.publicationOa} />
+
+      {/* ORCID */}
+      {oa.orcid && (
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+          <h3 className="text-sm font-semibold text-gray-900 mb-3">ORCID</h3>
+          <a
+            href={`https://orcid.org/${oa.orcid}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 text-sm text-[#2d7d7d] hover:underline"
+          >
+            <img src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" alt="ORCID" className="h-4 w-4" />
+            {oa.orcid}
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </div>
+      )}
+
+      {/* Attribution */}
+      <p className="text-[10px] text-gray-400 text-center">
+        Open Access data sourced from <a href="https://openalex.org" target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-500">OpenAlex</a>
+      </p>
+    </div>
+  );
+}

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock } from 'lucide-react';
+import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock, ExternalLink } from 'lucide-react';
 import { EmbedModal } from './EmbedModal';
 import { exportProfilePdf } from '../utils/pdfExport';
 import { SearchBar } from './SearchBar';
@@ -8,6 +8,7 @@ import { PublicationsList } from './PublicationsList';
 import { CitationsChart } from './CitationsChart';
 import { MetricsCard } from './MetricsCard';
 import { CitationNetwork } from './CitationNetwork';
+import { OpenScienceTab } from './OpenScienceTab';
 import { ResearcherNarrative } from './ResearcherNarrative';
 import { Logo } from './Logo';
 import type { Author } from '../types/scholar';
@@ -29,6 +30,7 @@ const tabs = [
   { id: 'metrics', label: 'Impact Metrics', icon: ChartBar },
   { id: 'trends', label: 'Citation Trends', icon: LineChart },
   { id: 'network', label: 'Co-author Network', icon: Network },
+  { id: 'openscience', label: 'Open Science', icon: Unlock },
   { id: 'publications', label: 'Publications', icon: BookOpen },
 ] as const;
 
@@ -163,6 +165,19 @@ export function ProfileView({
                     <Download className="h-3 w-3" />
                     PDF
                   </button>
+                  {data.openAccess?.orcid && (
+                    <a
+                      href={`https://orcid.org/${data.openAccess.orcid}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1.5 text-xs text-[#a6ce39] hover:text-[#8ab52f] bg-[#f3f9e8] hover:bg-[#e8f2d4] px-2.5 py-1 rounded-full transition-colors font-medium"
+                      title="View ORCID profile"
+                    >
+                      <img src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" alt="ORCID" className="h-3 w-3" />
+                      ORCID
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
+                  )}
                 </div>
                 {data.topics && data.topics.length > 0 && (
                   <TopicsList topics={data.topics} />
@@ -268,34 +283,6 @@ export function ProfileView({
               </div>
             </div>
 
-            {data.openAccess && (
-              <div>
-                <h3 className="text-sm font-semibold text-gray-900 mb-3 flex items-center gap-2">
-                  <Unlock className="h-4 w-4 text-[#2d7d7d]" />
-                  Open Access
-                  <span className="text-[10px] font-normal text-gray-400">via OpenAlex</span>
-                </h3>
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-                  <MetricsCard title="Open Access" value={`${data.openAccess.oaPercent}%`} subtitle={`${data.openAccess.oa} of ${data.openAccess.total}`} icon="publications" />
-                  {data.openAccess.gold > 0 && <MetricsCard title="Gold OA" value={data.openAccess.gold} icon="publications" />}
-                  {data.openAccess.green > 0 && <MetricsCard title="Green OA" value={data.openAccess.green} icon="publications" />}
-                  {data.openAccess.hybrid > 0 && <MetricsCard title="Hybrid OA" value={data.openAccess.hybrid} icon="publications" />}
-                  {data.openAccess.closed > 0 && <MetricsCard title="Closed Access" value={data.openAccess.closed} icon="publications" />}
-                </div>
-                {data.openAccess.orcid && (
-                  <div className="mt-3">
-                    <a
-                      href={`https://orcid.org/${data.openAccess.orcid}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] hover:underline"
-                    >
-                      ORCID: {data.openAccess.orcid}
-                    </a>
-                  </div>
-                )}
-              </div>
-            )}
           </div>
         )}
 
@@ -311,8 +298,12 @@ export function ProfileView({
           </div>
         )}
 
+        {activeTab === 'openscience' && (
+          <OpenScienceTab data={data} />
+        )}
+
         {activeTab === 'publications' && (
-          <PublicationsList publications={data.publications} />
+          <PublicationsList publications={data.publications} openAccess={data.openAccess} />
         )}
       </main>
 

--- a/src/components/PublicationsList.tsx
+++ b/src/components/PublicationsList.tsx
@@ -1,9 +1,39 @@
 import React, { useState } from 'react';
-import { ArrowUpDown, BookOpen, Presentation as Citation, Calendar, Award, Star, TrendingUp } from 'lucide-react';
-import type { Publication, JournalRanking } from '../types/scholar';
+import { ArrowUpDown, BookOpen, Presentation as Citation, Calendar, Award, Star, TrendingUp, Unlock, Lock } from 'lucide-react';
+import type { Publication, JournalRanking, OpenAccessStats, OaStatus } from '../types/scholar';
+
+const OA_COLORS: Record<OaStatus, { bg: string; text: string; label: string; tooltip: string }> = {
+  gold: { bg: 'bg-amber-100', text: 'text-amber-800', label: 'Gold OA', tooltip: 'Published in an open access journal' },
+  green: { bg: 'bg-emerald-100', text: 'text-emerald-800', label: 'Green OA', tooltip: 'Available via a repository (e.g. institutional or preprint)' },
+  hybrid: { bg: 'bg-sky-100', text: 'text-sky-800', label: 'Hybrid OA', tooltip: 'Open access in a subscription journal' },
+  bronze: { bg: 'bg-orange-100', text: 'text-orange-800', label: 'Bronze OA', tooltip: 'Free to read on publisher site, but no open license' },
+  closed: { bg: 'bg-gray-100', text: 'text-gray-500', label: 'Closed', tooltip: 'Not freely available' },
+};
+
+function OaBadge({ status, oaUrl }: { status: OaStatus; oaUrl?: string }) {
+  const style = OA_COLORS[status];
+  const badge = (
+    <span
+      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${style.bg} ${style.text} cursor-help`}
+      title={style.tooltip}
+    >
+      {status === 'closed' ? <Lock className="h-3 w-3 mr-0.5" /> : <Unlock className="h-3 w-3 mr-0.5" />}
+      {style.label}
+    </span>
+  );
+  if (oaUrl && status !== 'closed') {
+    return (
+      <a href={oaUrl} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()}>
+        {badge}
+      </a>
+    );
+  }
+  return badge;
+}
 
 interface PublicationsListProps {
   publications: Publication[];
+  openAccess?: OpenAccessStats;
 }
 
 type SortField = 'year' | 'citations' | 'title';
@@ -45,7 +75,7 @@ function JournalRankingBadge({ ranking }: { ranking: JournalRanking }) {
   );
 }
 
-export function PublicationsList({ publications }: PublicationsListProps) {
+export function PublicationsList({ publications, openAccess }: PublicationsListProps) {
   const [sortField, setSortField] = useState<SortField>('citations');
   
   const handleSort = (field: SortField) => {
@@ -120,7 +150,10 @@ export function PublicationsList({ publications }: PublicationsListProps) {
       </div>
 
       <div className="space-y-4">
-        {sortedPublications.map((pub, index) => (
+        {sortedPublications.map((pub, index) => {
+          const normalizedTitle = pub.title.toLowerCase().replace(/[^a-z0-9]/g, '');
+          const pubOaStatus = openAccess?.publicationOa?.[normalizedTitle];
+          return (
           <div key={index} className="border-b border-gray-100 last:border-0 pb-4 last:pb-0">
             <a
               href={pub.url}
@@ -144,9 +177,10 @@ export function PublicationsList({ publications }: PublicationsListProps) {
                     <span className="text-gray-400">{pub.venue}</span>
                   )}
                 </div>
-                {pub.journalRanking && (
-                  <div className="mt-2">
-                    <JournalRankingBadge ranking={pub.journalRanking} />
+                {(pub.journalRanking || pubOaStatus) && (
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    {pubOaStatus && <OaBadge status={pubOaStatus.status} oaUrl={pubOaStatus.oaUrl} />}
+                    {pub.journalRanking && <JournalRankingBadge ranking={pub.journalRanking} />}
                   </div>
                 )}
               </div>
@@ -156,7 +190,8 @@ export function PublicationsList({ publications }: PublicationsListProps) {
               </div>
             </a>
           </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -25,8 +25,8 @@ function getTopVenues(publications: Author['publications'], limit: number): { na
       // but preserve commas that are part of journal names
       const baseName = venue
         .replace(/,\s*(?:vol\.?|no\.?|pp\.?|issue|pages?|supplement)\s.*/i, '')
+        .replace(/\s+\d+\s*\([\d()–\-]+\)[\s,.\d–\-]*$/, '')
         .replace(/,\s*\d[\d()–\-\s]*$/, '')
-        .replace(/\s+\d+\s*\([\d–\-]+\)\s*$/, '')
         .replace(/\s+\d+\s*$/, '')
         .trim();
       if (baseName.length > 0) {
@@ -464,8 +464,39 @@ function generateOpenAccessParagraph(data: Author): string | null {
     paragraph += ` This includes ${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]} open access publications.`;
   }
 
-  if (oa.orcid) {
-    paragraph += ` Their ORCID identifier is ${oa.orcid}.`;
+  // Analyze OA trend over time
+  if (oa.publicationOa && data.publications.length > 0) {
+    const yearMap: Record<number, { total: number; oa: number }> = {};
+    for (const pub of data.publications) {
+      if (pub.year <= 0) continue;
+      const normalized = pub.title.toLowerCase().replace(/[^a-z0-9]/g, '');
+      const oaInfo = oa.publicationOa[normalized];
+      if (!yearMap[pub.year]) yearMap[pub.year] = { total: 0, oa: 0 };
+      yearMap[pub.year].total++;
+      if (oaInfo && oaInfo.status !== 'closed') yearMap[pub.year].oa++;
+    }
+
+    const years = Object.entries(yearMap)
+      .map(([y, d]) => ({ year: parseInt(y), pct: d.total > 0 ? d.oa / d.total : 0 }))
+      .filter(d => d.year > 0)
+      .sort((a, b) => a.year - b.year);
+
+    if (years.length >= 4) {
+      const half = Math.floor(years.length / 2);
+      const earlyAvg = years.slice(0, half).reduce((s, d) => s + d.pct, 0) / half;
+      const lateAvg = years.slice(half).reduce((s, d) => s + d.pct, 0) / (years.length - half);
+      const diff = lateAvg - earlyAvg;
+
+      if (diff > 0.15) {
+        paragraph += ` There is a notable trend toward increased open access publishing in recent years.`;
+      } else if (diff > 0.05) {
+        paragraph += ` Open access publishing has been gradually increasing over their career.`;
+      } else if (diff < -0.15) {
+        paragraph += ` Interestingly, the share of open access publications has decreased in recent years.`;
+      } else {
+        paragraph += ` The proportion of open access publications has remained relatively stable over time.`;
+      }
+    }
   }
 
   return paragraph;

--- a/src/services/openalex/index.ts
+++ b/src/services/openalex/index.ts
@@ -1,5 +1,5 @@
 import { ApiError } from '../../utils/api';
-import type { JournalRanking, OpenAccessStats } from '../../types/scholar';
+import type { JournalRanking, OpenAccessStats, OaStatus } from '../../types/scholar';
 import { rateLimiter } from '../scholar/rate-limiter';
 
 export class OpenAlexService {
@@ -61,6 +61,37 @@ export class OpenAlexService {
         }
       }
 
+      // Step 4: Fetch per-publication OA status (paginated, up to 200 works per page)
+      const publicationOa: Record<string, { status: OaStatus; oaUrl?: string }> = {};
+      let page = 1;
+      const maxPages = 10; // Up to 2000 works
+      while (page <= maxPages) {
+        await rateLimiter.acquireToken();
+        const pubsUrl = `${this.API_URL}/works?filter=authorships.author.id:${authorId}&select=title,open_access,publication_year&per_page=200&page=${page}&mailto=${this.EMAIL}`;
+        const pubsResponse = await fetch(pubsUrl, {
+          headers: this.headers,
+          signal: AbortSignal.timeout(15000)
+        });
+        if (!pubsResponse.ok) break;
+        const pubsData = await pubsResponse.json();
+        const results = pubsData.results || [];
+        if (results.length === 0) break;
+
+        for (const work of results) {
+          if (work.title) {
+            const normalizedTitle = work.title.toLowerCase().replace(/[^a-z0-9]/g, '');
+            const status: OaStatus = work.open_access?.oa_status === 'diamond' ? 'gold' : (work.open_access?.oa_status || 'closed');
+            publicationOa[normalizedTitle] = {
+              status,
+              oaUrl: work.open_access?.oa_url || undefined,
+            };
+          }
+        }
+
+        if (results.length < 200) break;
+        page++;
+      }
+
       return {
         total,
         oa,
@@ -71,6 +102,7 @@ export class OpenAlexService {
         closed,
         oaPercent: Math.round((oa / total) * 100),
         orcid,
+        publicationOa,
       };
     } catch (error) {
       console.warn('[OpenAlex] Error fetching OA stats:', error);

--- a/src/types/scholar.ts
+++ b/src/types/scholar.ts
@@ -59,6 +59,8 @@ export interface Metrics {
   topCoAuthorLastPaper: string;
 }
 
+export type OaStatus = 'gold' | 'green' | 'hybrid' | 'bronze' | 'closed';
+
 export interface OpenAccessStats {
   total: number;
   oa: number;
@@ -69,6 +71,8 @@ export interface OpenAccessStats {
   closed: number;
   oaPercent: number;
   orcid?: string;
+  /** Per-publication OA status, keyed by normalized title */
+  publicationOa?: Record<string, { status: OaStatus; oaUrl?: string }>;
 }
 
 export interface Author {


### PR DESCRIPTION
## Summary
- New Open Science tab with OA breakdown chart, trend over time, ORCID link
- Per-publication OA status badges (gold/green/hybrid/bronze/closed) with tooltips and clickable links
- ORCID button next to Share/Embed/PDF buttons
- OA narrative includes trend analysis
- Fix journal name truncation for volume/issue patterns
- Move OA out of Impact Metrics into dedicated tab

## Test plan
- [ ] Open Science tab renders with OA breakdown and trend chart
- [ ] Publications show OA badges that link to open access versions
- [ ] ORCID button appears next to share buttons when available
- [ ] Journal names no longer truncated at volume/issue info