### PR TITLE
Align Open Science tab design with profile

### DIFF
--- a/src/components/MetricsCard.tsx
+++ b/src/components/MetricsCard.tsx
@@ -24,7 +24,9 @@ import {
   Activity,
   Hourglass,
   PieChart,
-  Timer
+  Timer,
+  Unlock,
+  Lock
 } from 'lucide-react';
 import { Tooltip } from './Tooltip';
 import { metricInfo } from '../data/metricInfo';
@@ -33,10 +35,11 @@ interface MetricsCardProps {
   title: string;
   value: number | string;
   subtitle?: string;
-  icon: 'citations' | 'hIndex' | 'gIndex' | 'publications' | 'i10Index' | 'scr' | 'hpIndex' | 
-        'sIndex' | 'rcr' | 'pubsPerYear' | 'network' | 'coAuthors' | 'avgAuthors' | 'soloAuthor' | 
+  icon: 'citations' | 'hIndex' | 'gIndex' | 'publications' | 'i10Index' | 'scr' | 'hpIndex' |
+        'sIndex' | 'rcr' | 'pubsPerYear' | 'network' | 'coAuthors' | 'avgAuthors' | 'soloAuthor' |
         'h5Index' | 'acc5' | 'citationsPerYear' | 'topCoAuthor' | 'avgCitationsPerPaper' |
-        'citationGrowth' | 'peak' | 'trend' | 'fwci' | 'halfLife' | 'gini' | 'ageNormalized';
+        'citationGrowth' | 'peak' | 'trend' | 'fwci' | 'halfLife' | 'gini' | 'ageNormalized' |
+        'oaPercent' | 'goldOa' | 'greenOa' | 'hybridOa' | 'bronzeOa' | 'closedAccess';
 }
 
 export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) {
@@ -81,7 +84,15 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
       case 'scr': return <Workflow className="h-3.5 w-3.5" />;
       case 'sIndex': return <Zap className="h-3.5 w-3.5" />;
       case 'hpIndex': return <Award className="h-3.5 w-3.5" />;
-      
+
+      // Open Access metrics
+      case 'oaPercent': return <Unlock className="h-3.5 w-3.5" />;
+      case 'goldOa': return <Unlock className="h-3.5 w-3.5" />;
+      case 'greenOa': return <Unlock className="h-3.5 w-3.5" />;
+      case 'hybridOa': return <Unlock className="h-3.5 w-3.5" />;
+      case 'bronzeOa': return <Unlock className="h-3.5 w-3.5" />;
+      case 'closedAccess': return <Lock className="h-3.5 w-3.5" />;
+
       default: return <Citation className="h-3.5 w-3.5" />;
     }
   };
@@ -114,6 +125,12 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
       case 'halfLife': return 'halfLife';
       case 'gini': return 'gini';
       case 'ageNormalized': return 'ageNormalized';
+      case 'oaPercent': return 'oaPercent';
+      case 'goldOa': return 'goldOa';
+      case 'greenOa': return 'greenOa';
+      case 'hybridOa': return 'hybridOa';
+      case 'bronzeOa': return 'bronzeOa';
+      case 'closedAccess': return 'closedAccess';
       default: return 'citations';
     }
   };

--- a/src/components/OpenScienceTab.tsx
+++ b/src/components/OpenScienceTab.tsx
@@ -1,14 +1,7 @@
 import React, { useMemo } from 'react';
-import { Unlock, Lock, ExternalLink, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { Unlock, ExternalLink } from 'lucide-react';
+import { MetricsCard } from './MetricsCard';
 import type { Author, OaStatus } from '../types/scholar';
-
-const OA_COLORS: Record<OaStatus, { bg: string; fill: string; text: string; label: string; tooltip: string }> = {
-  gold: { bg: 'bg-amber-100', fill: 'bg-amber-400', text: 'text-amber-800', label: 'Gold', tooltip: 'Published in a fully open access journal' },
-  green: { bg: 'bg-emerald-100', fill: 'bg-emerald-400', text: 'text-emerald-800', label: 'Green', tooltip: 'Available via a repository (e.g. institutional or preprint server)' },
-  hybrid: { bg: 'bg-sky-100', fill: 'bg-sky-400', text: 'text-sky-800', label: 'Hybrid', tooltip: 'Open access article in a subscription journal' },
-  bronze: { bg: 'bg-orange-100', fill: 'bg-orange-400', text: 'text-orange-800', label: 'Bronze', tooltip: 'Free to read on publisher site, but without an open license' },
-  closed: { bg: 'bg-gray-100', fill: 'bg-gray-300', text: 'text-gray-600', label: 'Closed', tooltip: 'Not freely available' },
-};
 
 interface OpenScienceTabProps {
   data: Author;
@@ -37,31 +30,45 @@ function OaTrend({ publications, publicationOa }: { publications: Author['public
   const maxTotal = Math.max(...yearlyOa.map(d => d.total));
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
-      <h3 className="text-sm font-semibold text-gray-900 mb-4">Open Access Over Time</h3>
-      <div className="space-y-1.5">
-        {yearlyOa.map(({ year, total, oa, pct }) => (
-          <div key={year} className="flex items-center gap-3 text-sm">
-            <span className="text-gray-500 w-12 text-xs shrink-0">{year}</span>
-            <div className="flex-1 bg-gray-100 rounded-full h-5 overflow-hidden relative" title={`${oa} of ${total} publications are open access (${pct}%)`}>
+    <div>
+      <h3 className="text-sm font-semibold text-gray-900 mb-3">Open Access Over Time</h3>
+      <div className="bg-white rounded-xl border border-gray-100 shadow-card p-6">
+        <div className="space-y-1.5">
+          {yearlyOa.map(({ year, total, oa, pct }) => (
+            <div key={year} className="flex items-center gap-3 text-sm">
+              <span className="text-gray-500 w-12 text-xs shrink-0">{year}</span>
               <div
-                className="absolute inset-y-0 left-0 bg-gray-300 rounded-full transition-all duration-300"
-                style={{ width: `${(total / maxTotal) * 100}%` }}
-              />
-              <div
-                className="absolute inset-y-0 left-0 bg-[#2d7d7d] rounded-full transition-all duration-300"
-                style={{ width: `${(oa / maxTotal) * 100}%` }}
-              />
+                className="flex-1 bg-gray-100 rounded-full h-5 overflow-hidden relative cursor-help"
+                title={`${oa} of ${total} publications are open access (${pct}%)`}
+              >
+                <div
+                  className="absolute inset-y-0 left-0 bg-gray-200 rounded-full transition-all duration-300"
+                  style={{ width: `${(total / maxTotal) * 100}%` }}
+                />
+                <div
+                  className="absolute inset-y-0 left-0 bg-gradient-to-r from-[#2d7d7d] to-[#3a9a9a] rounded-full transition-all duration-300"
+                  style={{ width: `${(oa / maxTotal) * 100}%` }}
+                />
+              </div>
+              <span
+                className="text-xs text-gray-500 w-16 text-right shrink-0 cursor-help"
+                title={`${oa} of ${total} open access`}
+              >
+                {pct}% OA
+              </span>
             </div>
-            <span className="text-xs text-gray-500 w-16 text-right shrink-0" title={`${oa}/${total} OA`}>
-              {pct}% OA
-            </span>
-          </div>
-        ))}
-      </div>
-      <div className="flex items-center gap-4 mt-3 text-[10px] text-gray-400">
-        <span className="flex items-center gap-1"><span className="w-3 h-2 rounded bg-[#2d7d7d] inline-block" /> Open Access</span>
-        <span className="flex items-center gap-1"><span className="w-3 h-2 rounded bg-gray-300 inline-block" /> Closed</span>
+          ))}
+        </div>
+        <div className="flex items-center gap-4 mt-3 text-[10px] text-gray-400">
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-2 rounded bg-gradient-to-r from-[#2d7d7d] to-[#3a9a9a] inline-block" />
+            Open Access
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-2 rounded bg-gray-200 inline-block" />
+            Total publications
+          </span>
+        </div>
       </div>
     </div>
   );
@@ -72,56 +79,97 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
 
   if (!oa) {
     return (
-      <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-8 text-center">
+      <div className="bg-white rounded-xl border border-gray-100 shadow-card p-8 text-center">
         <Unlock className="h-8 w-8 text-gray-300 mx-auto mb-3" />
-        <p className="text-sm text-gray-500">Loading Open Access data from OpenAlex...</p>
+        <p className="text-sm text-gray-500">Loading Open Access data...</p>
         <p className="text-xs text-gray-400 mt-1">This may take a few seconds</p>
       </div>
     );
   }
 
-  const statuses: OaStatus[] = ['gold', 'green', 'hybrid', 'bronze', 'closed'];
-
   return (
     <div className="space-y-6">
-      {/* Summary cards */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-5">
-          <div className="flex items-center gap-2 text-[#2d7d7d] mb-2"><Unlock className="h-4 w-4" /></div>
-          <div className="text-2xl font-bold text-gray-900">{oa.oaPercent}%</div>
-          <div className="text-xs text-gray-500 mt-0.5">Open Access</div>
+      {/* Summary metrics — using MetricsCard for consistency */}
+      <div>
+        <h3 className="text-sm font-semibold text-gray-900 mb-3">Open Access Metrics</h3>
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+          <MetricsCard title="Open Access" value={`${oa.oaPercent}%`} subtitle={`${oa.oa} of ${oa.total} publications`} icon="oaPercent" />
+          {oa.gold > 0 && <MetricsCard title="Gold OA" value={oa.gold} subtitle="Fully OA journals" icon="goldOa" />}
+          {oa.green > 0 && <MetricsCard title="Green OA" value={oa.green} subtitle="Repository deposits" icon="greenOa" />}
+          {oa.hybrid > 0 && <MetricsCard title="Hybrid OA" value={oa.hybrid} subtitle="OA in subscription journals" icon="hybridOa" />}
+          {oa.bronze > 0 && <MetricsCard title="Bronze OA" value={oa.bronze} subtitle="Free to read, no license" icon="bronzeOa" />}
+          {oa.closed > 0 && <MetricsCard title="Closed Access" value={oa.closed} subtitle="Behind paywall" icon="closedAccess" />}
         </div>
-        {statuses.filter(s => oa[s] > 0).map(status => (
-          <div key={status} className="bg-white rounded-2xl border border-gray-100 shadow-card p-5" title={OA_COLORS[status].tooltip}>
-            <div className={`flex items-center gap-2 mb-2 ${OA_COLORS[status].text}`}>
-              {status === 'closed' ? <Lock className="h-4 w-4" /> : <Unlock className="h-4 w-4" />}
-            </div>
-            <div className="text-2xl font-bold text-gray-900">{oa[status]}</div>
-            <div className="text-xs text-gray-500 mt-0.5 cursor-help" title={OA_COLORS[status].tooltip}>{OA_COLORS[status].label} OA</div>
-          </div>
-        ))}
       </div>
 
       {/* Visual breakdown bar */}
-      <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
-        <h3 className="text-sm font-semibold text-gray-900 mb-4">Access Breakdown</h3>
-        <div className="h-8 rounded-full overflow-hidden flex">
-          {statuses.filter(s => oa[s] > 0).map(status => (
-            <div
-              key={status}
-              className={`${OA_COLORS[status].fill} transition-all duration-500 cursor-help`}
-              style={{ width: `${(oa[status] / oa.total) * 100}%` }}
-              title={`${OA_COLORS[status].label}: ${oa[status]} publications (${Math.round((oa[status] / oa.total) * 100)}%)`}
-            />
-          ))}
-        </div>
-        <div className="flex flex-wrap gap-3 mt-3">
-          {statuses.filter(s => oa[s] > 0).map(status => (
-            <span key={status} className="flex items-center gap-1.5 text-xs text-gray-600 cursor-help" title={OA_COLORS[status].tooltip}>
-              <span className={`w-3 h-3 rounded ${OA_COLORS[status].fill}`} />
-              {OA_COLORS[status].label} ({oa[status]})
-            </span>
-          ))}
+      <div>
+        <h3 className="text-sm font-semibold text-gray-900 mb-3">Access Breakdown</h3>
+        <div className="bg-white rounded-xl border border-gray-100 shadow-card p-6">
+          <div className="h-6 rounded-full overflow-hidden flex bg-gray-100">
+            {oa.gold > 0 && (
+              <div
+                className="h-full bg-[#2d7d7d] transition-all duration-500 cursor-help"
+                style={{ width: `${(oa.gold / oa.total) * 100}%` }}
+                title={`Gold: ${oa.gold} publications (${Math.round((oa.gold / oa.total) * 100)}%) — Published in fully open access journals`}
+              />
+            )}
+            {oa.green > 0 && (
+              <div
+                className="h-full bg-[#4db6ac] transition-all duration-500 cursor-help"
+                style={{ width: `${(oa.green / oa.total) * 100}%` }}
+                title={`Green: ${oa.green} publications (${Math.round((oa.green / oa.total) * 100)}%) — Available via repositories`}
+              />
+            )}
+            {oa.hybrid > 0 && (
+              <div
+                className="h-full bg-[#80cbc4] transition-all duration-500 cursor-help"
+                style={{ width: `${(oa.hybrid / oa.total) * 100}%` }}
+                title={`Hybrid: ${oa.hybrid} publications (${Math.round((oa.hybrid / oa.total) * 100)}%) — OA in subscription journals`}
+              />
+            )}
+            {oa.bronze > 0 && (
+              <div
+                className="h-full bg-[#b2dfdb] transition-all duration-500 cursor-help"
+                style={{ width: `${(oa.bronze / oa.total) * 100}%` }}
+                title={`Bronze: ${oa.bronze} publications (${Math.round((oa.bronze / oa.total) * 100)}%) — Free to read, no open license`}
+              />
+            )}
+            {oa.closed > 0 && (
+              <div
+                className="h-full bg-gray-300 transition-all duration-500 cursor-help"
+                style={{ width: `${(oa.closed / oa.total) * 100}%` }}
+                title={`Closed: ${oa.closed} publications (${Math.round((oa.closed / oa.total) * 100)}%) — Behind paywall`}
+              />
+            )}
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 mt-3">
+            {oa.gold > 0 && (
+              <span className="flex items-center gap-1.5 text-xs text-gray-600 cursor-help" title="Published in fully open access journals">
+                <span className="w-3 h-3 rounded bg-[#2d7d7d]" /> Gold ({oa.gold})
+              </span>
+            )}
+            {oa.green > 0 && (
+              <span className="flex items-center gap-1.5 text-xs text-gray-600 cursor-help" title="Available via repositories">
+                <span className="w-3 h-3 rounded bg-[#4db6ac]" /> Green ({oa.green})
+              </span>
+            )}
+            {oa.hybrid > 0 && (
+              <span className="flex items-center gap-1.5 text-xs text-gray-600 cursor-help" title="OA in subscription journals">
+                <span className="w-3 h-3 rounded bg-[#80cbc4]" /> Hybrid ({oa.hybrid})
+              </span>
+            )}
+            {oa.bronze > 0 && (
+              <span className="flex items-center gap-1.5 text-xs text-gray-600 cursor-help" title="Free to read, no open license">
+                <span className="w-3 h-3 rounded bg-[#b2dfdb]" /> Bronze ({oa.bronze})
+              </span>
+            )}
+            {oa.closed > 0 && (
+              <span className="flex items-center gap-1.5 text-xs text-gray-600 cursor-help" title="Behind paywall">
+                <span className="w-3 h-3 rounded bg-gray-300" /> Closed ({oa.closed})
+              </span>
+            )}
+          </div>
         </div>
       </div>
 
@@ -130,24 +178,29 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
 
       {/* ORCID */}
       {oa.orcid && (
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6">
+        <div>
           <h3 className="text-sm font-semibold text-gray-900 mb-3">ORCID</h3>
-          <a
-            href={`https://orcid.org/${oa.orcid}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 text-sm text-[#2d7d7d] hover:underline"
-          >
-            <img src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" alt="ORCID" className="h-4 w-4" />
-            {oa.orcid}
-            <ExternalLink className="h-3 w-3" />
-          </a>
+          <div className="bg-white rounded-xl border border-gray-100 shadow-card p-4">
+            <a
+              href={`https://orcid.org/${oa.orcid}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-sm text-[#2d7d7d] hover:text-[#1a5c5c] transition-colors"
+            >
+              <img src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" alt="ORCID" className="h-4 w-4" />
+              {oa.orcid}
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          </div>
         </div>
       )}
 
       {/* Attribution */}
       <p className="text-[10px] text-gray-400 text-center">
-        Open Access data sourced from <a href="https://openalex.org" target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-500">OpenAlex</a>
+        Data sourced from{' '}
+        <a href="https://openalex.org" target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-500">
+          OpenAlex
+        </a>
       </p>
     </div>
   );

--- a/src/data/metricInfo.ts
+++ b/src/data/metricInfo.ts
@@ -124,5 +124,41 @@ export const metricInfo = {
     pros: "Shows research productivity consistency and output level throughout career.",
     cons: "Doesn't reflect publication quality or account for varying career stage demands.",
     link: "https://en.wikipedia.org/wiki/Academic_publishing"
+  },
+  oaPercent: {
+    description: "Percentage of publications that are freely accessible (gold, green, hybrid, or bronze open access) according to OpenAlex.",
+    pros: "Indicates commitment to open science and research accessibility. Higher OA rates increase visibility and citation potential.",
+    cons: "OpenAlex coverage may not be complete. Bronze OA (free to read but no open license) is included in the OA count.",
+    link: "https://en.wikipedia.org/wiki/Open_access"
+  },
+  goldOa: {
+    description: "Publications in fully open access journals where the publisher makes all articles freely available (e.g. PLOS ONE, Nature Communications).",
+    pros: "Highest level of guaranteed permanent access. Articles are immediately and permanently free.",
+    cons: "Often requires article processing charges (APCs) paid by the author or their institution.",
+    link: "https://en.wikipedia.org/wiki/Open_access#Gold_OA"
+  },
+  greenOa: {
+    description: "Publications deposited in a repository (institutional or preprint server like SSRN, arXiv) that may differ from the published version.",
+    pros: "No cost to the author. Repositories provide long-term preservation and often broader discoverability.",
+    cons: "May be a preprint or accepted manuscript rather than the final published version. Some embargo periods apply.",
+    link: "https://en.wikipedia.org/wiki/Open_access#Green_OA"
+  },
+  hybridOa: {
+    description: "Open access articles published in subscription journals, typically made OA through an APC or a transformative agreement.",
+    pros: "Combines the prestige of established journals with open access. Increasingly supported by institutional agreements.",
+    cons: "Can result in 'double dipping' where publishers charge both subscriptions and APCs.",
+    link: "https://en.wikipedia.org/wiki/Hybrid_open-access_journal"
+  },
+  bronzeOa: {
+    description: "Publications free to read on the publisher's website but without a formal open license. Access may be temporary.",
+    pros: "Provides free readability without any cost to the author.",
+    cons: "No guarantee of permanent access. Cannot be legally redistributed or archived. Publisher may revoke access.",
+    link: "https://en.wikipedia.org/wiki/Open_access#Bronze_OA"
+  },
+  closedAccess: {
+    description: "Publications behind a paywall, accessible only through subscriptions or individual purchase.",
+    pros: "Traditional publishing model with established peer review processes.",
+    cons: "Limits research accessibility and may reduce citation potential and societal impact.",
+    link: "https://en.wikipedia.org/wiki/Paywall#Academic_publishing"
   }
 };


### PR DESCRIPTION
## Summary
- Open Science metrics now use MetricsCard (same gradient icons, hover effects, tooltips as Impact Metrics)
- Added detailed tooltip descriptions for all OA metric types (gold, green, hybrid, bronze, closed)
- Breakdown bar uses teal gradient color scheme matching the rest of the profile
- Bar chart for OA trend uses same gradient as citation trends
- Section headers, card styling, spacing all match other tabs
- ORCID button in profile header next to Share/Embed/PDF

## Test plan
- [ ] Open Science tab metrics cards have tooltips on hover
- [ ] Color scheme consistent with Impact Metrics and Citation Trends
- [ ] OA trend chart visually matches citation trends bar style
- [ ] All tooltips explain OA types clearly