### PR TITLE
Fix journal name truncation for volume-comma pattern

### DIFF
--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -27,6 +27,7 @@ function getTopVenues(publications: Author['publications'], limit: number): { na
         .replace(/,\s*(?:vol\.?|no\.?|pp\.?|issue|pages?|supplement)\s.*/i, '')
         .replace(/\s+\d+\s*\([\d()–\-]+\)[\s,.\d–\-]*$/, '')
         .replace(/,\s*\d[\d()–\-\s]*$/, '')
+        .replace(/\s+\d+\s*,.*$/, '')
         .replace(/\s+\d+\s*$/, '')
         .trim();
       if (baseName.length > 0) {


### PR DESCRIPTION
Handles patterns like 'Computers in Human Behavior 155,' where volume number + comma wasn't being stripped.