### PR TITLE
Fix email sign-up flow (no confirmation needed)

### DIFF
--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -33,7 +33,8 @@ export function AuthButton() {
         if (error) {
           setError(error);
         } else {
-          setConfirmSent(true);
+          setShowModal(false);
+          resetForm();
         }
       } else {
         const { error } = await signIn(email, password);

--- a/src/components/SignUpWall.tsx
+++ b/src/components/SignUpWall.tsx
@@ -33,7 +33,7 @@ export function SignUpWall({ onClose }: SignUpWallProps) {
         if (error) {
           setError(error);
         } else {
-          setConfirmSent(true);
+          onClose();
         }
       } else {
         const { error } = await signIn(email, password);


### PR DESCRIPTION
Closes modal immediately after email sign-up since Supabase email confirmation is disabled.