### PR TITLE
Serve claimed profiles from cache to avoid SerpAPI costs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,7 +112,7 @@ function AppContent() {
   const [showSignUpWall, setShowSignUpWall] = useState(false);
   const [page, setPage] = useState<Page>('home');
   const requestInProgressRef = useRef(false);
-  const handleSearchRef = useRef<((url: string, bypassCredits?: boolean) => void) | null>(null);
+  const handleSearchRef = useRef<((url: string, bypassCredits?: boolean, cacheOnly?: boolean) => void) | null>(null);
   const { user, credits, refreshCredits, showWelcome, dismissWelcome } = useAuth();
 
   // Handle shareable profile URL (?user=AUTHOR_ID) or vanity slug path (e.g. /jonas-heller)
@@ -143,7 +143,7 @@ function AppContent() {
         .then(({ data: claim }) => {
           if (claim?.author_id && handleSearchRef.current) {
             const scholarUrl = `https://scholar.google.com/citations?user=${encodeURIComponent(claim.author_id)}`;
-            handleSearchRef.current(scholarUrl, true);
+            handleSearchRef.current(scholarUrl, true, true);
           }
         });
     }
@@ -168,7 +168,7 @@ function AppContent() {
   };
   const ANON_FREE_LIMIT = 3;
 
-  const handleSearch = useCallback(async (url: string, bypassCredits = false) => {
+  const handleSearch = useCallback(async (url: string, bypassCredits = false, cacheOnly = false) => {
     // Prevent multiple concurrent requests using ref to avoid stale closure
     if (requestInProgressRef.current) {
       return;
@@ -201,7 +201,7 @@ function AppContent() {
         return;
       }
 
-      const profileData = await scholarService.fetchProfile(url);
+      const profileData = await scholarService.fetchProfile(url, cacheOnly ? { cacheOnly: true } : undefined);
       if (!profileData) {
         setError('Unable to fetch profile data. Please try again later or contact the site administrator.');
         setShowError(true);

--- a/src/services/scholar/index.ts
+++ b/src/services/scholar/index.ts
@@ -86,13 +86,13 @@ export const scholarService = {
     }
   },
 
-  fetchProfile: async (profileUrl: string): Promise<Author> => {
+  fetchProfile: async (profileUrl: string, options?: { cacheOnly?: boolean }): Promise<Author> => {
     const normalizedUrl = normalizeScholarUrl(profileUrl);
 
     // Try the Supabase edge function first (SerpAPI + server-side scraping)
     let edgeError: unknown = null;
     try {
-      const data = await fetchViaEdgeFunction(normalizedUrl);
+      const data = await fetchViaEdgeFunction(normalizedUrl, options?.cacheOnly);
       return buildAuthorResult(data);
     } catch (err) {
       edgeError = err;
@@ -120,7 +120,7 @@ export const scholarService = {
   }
 };
 
-async function fetchViaEdgeFunction(normalizedUrl: string) {
+async function fetchViaEdgeFunction(normalizedUrl: string, cacheOnly?: boolean) {
   // Get the current session token for authenticated credit tracking
   const { data: { session } } = await supabase.auth.getSession();
   const token = session?.access_token || import.meta.env.VITE_SUPABASE_ANON_KEY || '';
@@ -133,7 +133,7 @@ async function fetchViaEdgeFunction(normalizedUrl: string) {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`
       },
-      body: JSON.stringify({ profileUrl: normalizedUrl })
+      body: JSON.stringify({ profileUrl: normalizedUrl, ...(cacheOnly ? { cacheOnly: true } : {}) })
     }
   );
 

--- a/supabase/functions/scholar/index.ts
+++ b/supabase/functions/scholar/index.ts
@@ -750,7 +750,7 @@ Deno.serve(async (req) => {
       );
     }
 
-    const { profileUrl, action, query } = requestData;
+    const { profileUrl, action, query, cacheOnly } = requestData;
     const clientIp = getRequestIp(req);
 
     // --- Authenticate user via JWT ---
@@ -828,13 +828,18 @@ Deno.serve(async (req) => {
 
     const normalizedUrl = `https://scholar.google.com/citations?user=${authorId}`;
 
-    // Check cache
-    const { data: cached, error: cacheError } = await supabase
+    // Check cache (for claimed profiles / cacheOnly, also serve expired cache)
+    const cacheQuery = supabase
       .from('scholar_cache')
       .select('data')
-      .eq('url', normalizedUrl)
-      .gt('expires_at', new Date().toISOString())
-      .maybeSingle();
+      .eq('url', normalizedUrl);
+
+    // Only filter by expiry for normal requests, not cacheOnly
+    if (!cacheOnly) {
+      cacheQuery.gt('expires_at', new Date().toISOString());
+    }
+
+    const { data: cached, error: cacheError } = await cacheQuery.maybeSingle();
 
     if (cacheError) {
       console.error("Cache lookup error:", cacheError);
@@ -847,6 +852,22 @@ Deno.serve(async (req) => {
       // (exactly 100 publications is suspicious — likely truncated)
       const pubCount = cached.data.publications?.length || 0;
       const likelyTruncated = pubCount === 100;
+
+      // For cacheOnly (claimed profile views), always serve cache if it exists
+      if (cacheOnly && hasCitationGraph) {
+        console.log("Cache-only hit (claimed profile) for:", normalizedUrl);
+        logRequest(req, authorId, 'cache', userId);
+        return new Response(
+          JSON.stringify({ ...cached.data, cacheStatus: 'hit' }),
+          {
+            headers: {
+              ...corsHeaders,
+              'Content-Type': 'application/json',
+              'X-Cache': 'HIT-STALE'
+            }
+          }
+        );
+      }
 
       if (hasCitationGraph && !likelyTruncated) {
         console.log("Cache hit for:", normalizedUrl);


### PR DESCRIPTION
## Summary
- Vanity URL visits send `cacheOnly: true` to the edge function
- Edge function serves expired cache for claimed profiles instead of hitting SerpAPI
- First-time loads and manual searches still fetch fresh data
- Prevents every visitor to a claimed profile from burning a SerpAPI token

## Test plan
- [ ] Visit a claimed vanity URL — profile loads from cache
- [ ] Manual search from search bar still fetches fresh data
- [ ] Edge function deployed with `--no-verify-jwt`