### PR TITLE
Add unresolved report badge on admin button

### DIFF
--- a/src/components/AuthHeaderControls.tsx
+++ b/src/components/AuthHeaderControls.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Coins, Shield } from 'lucide-react';
 import { AuthButton } from './AuthButton';
 import { useAuth } from '../contexts/AuthContext';
+import { supabase } from '../lib/supabase';
 
 const ADMIN_EMAIL = 'jonasheller89@gmail.com';
 
@@ -15,6 +16,16 @@ interface AuthHeaderControlsProps {
 export function AuthHeaderControls({ onBuyCredits, onAdmin, anonSearchesUsed = 0, anonFreeLimit = 3 }: AuthHeaderControlsProps) {
   const { user, credits } = useAuth();
   const isAdmin = user?.email === ADMIN_EMAIL;
+  const [unresolvedCount, setUnresolvedCount] = useState(0);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    supabase
+      .from('profile_reports')
+      .select('id', { count: 'exact', head: true })
+      .eq('resolved', false)
+      .then(({ count }) => { if (count != null) setUnresolvedCount(count); });
+  }, [isAdmin]);
 
   return (
     <div className="flex items-center gap-2">
@@ -42,10 +53,15 @@ export function AuthHeaderControls({ onBuyCredits, onAdmin, anonSearchesUsed = 0
       {isAdmin && onAdmin && (
         <button
           onClick={onAdmin}
-          className="p-1 text-gray-400 hover:text-indigo-600 transition-colors"
+          className="relative p-1 text-gray-400 hover:text-indigo-600 transition-colors"
           title="Admin Dashboard"
         >
           <Shield className="h-4 w-4" />
+          {unresolvedCount > 0 && (
+            <span className="absolute -top-1 -right-1 min-w-[14px] h-[14px] flex items-center justify-center bg-red-500 text-white text-[9px] font-bold rounded-full px-0.5">
+              {unresolvedCount}
+            </span>
+          )}
         </button>
       )}
       <AuthButton />


### PR DESCRIPTION
## Summary
- Red badge with unresolved report count on the admin shield icon
- Only fetched and shown for admin user
- Disappears when all reports are resolved

## Test plan
- [ ] Submit a report on a profile
- [ ] Log in as admin — red badge appears on shield icon
- [ ] Resolve the report in admin — badge count decreases