### PR TITLE
Add co-author world map tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,23 @@
 {
   "name": "research-portfolio",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "research-portfolio",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.39.3",
+        "@types/topojson-client": "^3.1.5",
         "d3": "^7.8.5",
         "dompurify": "^3.0.8",
         "jspdf": "^4.2.1",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "recharts": "^2.12.2"
+        "recharts": "^2.12.2",
+        "topojson-client": "^3.1.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -2071,7 +2073,6 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2128,6 +2129,25 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/topojson-client": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-client/-/topojson-client-3.1.5.tgz",
+      "integrity": "sha512-C79rySTyPxnQNNguTZNI1Ct4D7IXgvyAs3p9HPecnl6mNrJ5+UhvGNYcZfpROYV2lMHI48kJPxwR+F9C6c7nmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*",
+        "@types/topojson-specification": "*"
+      }
+    },
+    "node_modules/@types/topojson-specification": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/topojson-specification/-/topojson-specification-1.0.5.tgz",
+      "integrity": "sha512-C7KvcQh+C2nr6Y2Ub4YfgvWvWCgP2nOQMtfhlnwsRL4pYmmwzBS7HclGiS87eQfDOU/DLQpX6GEscviaz4yLIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -7172,6 +7192,26 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -14,13 +14,15 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.3",
+    "@types/topojson-client": "^3.1.5",
     "d3": "^7.8.5",
     "dompurify": "^3.0.8",
     "jspdf": "^4.2.1",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "recharts": "^2.12.2"
+    "recharts": "^2.12.2",
+    "topojson-client": "^3.1.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",

--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -1,0 +1,380 @@
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import * as d3 from 'd3';
+import * as topojson from 'topojson-client';
+import type { Topology, GeometryCollection } from 'topojson-specification';
+import { Globe, Info, MapPin, Users, Flag } from 'lucide-react';
+import type { Publication, CoAuthorGeoData } from '../types/scholar';
+import { fetchCoAuthorGeoData } from '../services/openalex/coauthor-geo';
+
+interface CoAuthorMapProps {
+  publications: Publication[];
+  authorName: string;
+  authorAffiliation: string;
+}
+
+interface TooltipState {
+  visible: boolean;
+  x: number;
+  y: number;
+  data: CoAuthorGeoData | null;
+}
+
+interface WorldTopology extends Topology {
+  objects: {
+    countries: GeometryCollection;
+    land: GeometryCollection;
+  };
+}
+
+export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoAuthorMapProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [loading, setLoading] = useState(true);
+  const [geoData, setGeoData] = useState<{ mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null>(null);
+  const [tooltip, setTooltip] = useState<TooltipState>({ visible: false, x: 0, y: 0, data: null });
+  const [mapError, setMapError] = useState(false);
+
+  // Fetch geo data on mount
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchCoAuthorGeoData(authorName, authorAffiliation, publications).then(result => {
+      if (!cancelled) {
+        setGeoData(result);
+        setLoading(false);
+      }
+    });
+    return () => { cancelled = true; };
+  }, [authorName, authorAffiliation, publications]);
+
+  const drawMap = useCallback(() => {
+    if (!svgRef.current || !containerRef.current || !geoData) return;
+
+    const container = containerRef.current;
+    const width = container.clientWidth;
+    const height = Math.max(360, Math.round(width * 0.5));
+
+    const svg = d3.select(svgRef.current);
+    svg.selectAll('*').remove();
+    svg.attr('viewBox', `0 0 ${width} ${height}`).attr('width', width).attr('height', height);
+
+    const projection = d3.geoNaturalEarth1()
+      .scale(width / 6.5)
+      .translate([width / 2, height / 2]);
+
+    const pathGen = d3.geoPath().projection(projection);
+
+    // Zoom behaviour
+    const zoomGroup = svg.append('g');
+
+    const zoom = d3.zoom<SVGSVGElement, unknown>()
+      .scaleExtent([0.5, 8])
+      .on('zoom', event => {
+        zoomGroup.attr('transform', event.transform);
+      });
+
+    svg.call(zoom);
+
+    // Load world TopoJSON
+    fetch('https://unpkg.com/world-atlas@2/countries-110m.json')
+      .then(r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((world: WorldTopology) => {
+        const countries = topojson.feature(world, world.objects.countries);
+        const land = topojson.feature(world, world.objects.land);
+
+        // Draw land fill
+        zoomGroup.append('path')
+          .datum(land)
+          .attr('d', pathGen as unknown as string)
+          .attr('fill', '#f9fafb');
+
+        // Draw country borders
+        zoomGroup.append('path')
+          .datum(countries)
+          .attr('d', pathGen as unknown as string)
+          .attr('fill', 'none')
+          .attr('stroke', '#e5e7eb')
+          .attr('stroke-width', 0.5);
+
+        // Outer sphere
+        zoomGroup.insert('path', ':first-child')
+          .datum({ type: 'Sphere' } as d3.GeoPermissibleObjects)
+          .attr('d', pathGen as unknown as string)
+          .attr('fill', '#eaf4f4')
+          .attr('stroke', '#d1fae5')
+          .attr('stroke-width', 0.5);
+
+        // Helper: project coordinates
+        const project = (lng: number, lat: number): [number, number] | null => {
+          const pt = projection([lng, lat]);
+          return pt ?? null;
+        };
+
+        // Draw arcs from main author to each co-author
+        if (geoData.mainAuthor) {
+          const mainPt = project(geoData.mainAuthor.lng, geoData.mainAuthor.lat);
+          if (mainPt) {
+            geoData.coAuthors.forEach(coAuthor => {
+              const coPt = project(coAuthor.lng, coAuthor.lat);
+              if (!coPt) return;
+
+              // d3.geoInterpolate great-circle arc as SVG path
+              const interpolate = d3.geoInterpolate(
+                [geoData.mainAuthor!.lng, geoData.mainAuthor!.lat],
+                [coAuthor.lng, coAuthor.lat]
+              );
+              const arcPoints: [number, number][] = [];
+              for (let t = 0; t <= 1; t += 0.02) {
+                const [lng2, lat2] = interpolate(t);
+                const pt = project(lng2, lat2);
+                if (pt) arcPoints.push(pt);
+              }
+
+              if (arcPoints.length > 1) {
+                const lineGen = d3.line<[number, number]>().x(d => d[0]).y(d => d[1]).curve(d3.curveCatmullRom);
+                zoomGroup.append('path')
+                  .datum(arcPoints)
+                  .attr('d', lineGen)
+                  .attr('fill', 'none')
+                  .attr('stroke', '#2d7d7d')
+                  .attr('stroke-width', 1)
+                  .attr('stroke-opacity', 0.25 + Math.min(0.5, coAuthor.sharedPapers / 10));
+              }
+            });
+          }
+        }
+
+        // Draw co-author dots
+        geoData.coAuthors.forEach(coAuthor => {
+          const pt = project(coAuthor.lng, coAuthor.lat);
+          if (!pt) return;
+
+          const r = Math.sqrt(coAuthor.sharedPapers) * 4 + 4;
+
+          zoomGroup.append('circle')
+            .attr('cx', pt[0])
+            .attr('cy', pt[1])
+            .attr('r', r)
+            .attr('fill', '#2d7d7d')
+            .attr('fill-opacity', 0.7)
+            .attr('stroke', 'white')
+            .attr('stroke-width', 1)
+            .style('cursor', 'pointer')
+            .on('mouseenter', (event: MouseEvent) => {
+              const rect = svgRef.current!.getBoundingClientRect();
+              setTooltip({
+                visible: true,
+                x: event.clientX - rect.left + 12,
+                y: event.clientY - rect.top - 8,
+                data: coAuthor
+              });
+            })
+            .on('mousemove', (event: MouseEvent) => {
+              const rect = svgRef.current!.getBoundingClientRect();
+              setTooltip(prev => ({
+                ...prev,
+                x: event.clientX - rect.left + 12,
+                y: event.clientY - rect.top - 8
+              }));
+            })
+            .on('mouseleave', () => {
+              setTooltip(prev => ({ ...prev, visible: false }));
+            });
+        });
+
+        // Draw main author dot (on top)
+        if (geoData.mainAuthor) {
+          const mainPt = project(geoData.mainAuthor.lng, geoData.mainAuthor.lat);
+          if (mainPt) {
+            zoomGroup.append('circle')
+              .attr('cx', mainPt[0])
+              .attr('cy', mainPt[1])
+              .attr('r', 8)
+              .attr('fill', '#0d9488')
+              .attr('stroke', 'white')
+              .attr('stroke-width', 2)
+              .style('cursor', 'pointer')
+              .on('mouseenter', (event: MouseEvent) => {
+                const rect = svgRef.current!.getBoundingClientRect();
+                setTooltip({
+                  visible: true,
+                  x: event.clientX - rect.left + 12,
+                  y: event.clientY - rect.top - 8,
+                  data: geoData.mainAuthor
+                });
+              })
+              .on('mousemove', (event: MouseEvent) => {
+                const rect = svgRef.current!.getBoundingClientRect();
+                setTooltip(prev => ({
+                  ...prev,
+                  x: event.clientX - rect.left + 12,
+                  y: event.clientY - rect.top - 8
+                }));
+              })
+              .on('mouseleave', () => {
+                setTooltip(prev => ({ ...prev, visible: false }));
+              });
+          }
+        }
+      })
+      .catch(err => {
+        console.warn('[CoAuthorMap] Failed to load world map data:', err);
+        setMapError(true);
+      });
+  }, [geoData]);
+
+  // Redraw on data change or container resize
+  useEffect(() => {
+    if (!geoData || !containerRef.current) return;
+
+    drawMap();
+
+    const observer = new ResizeObserver(() => drawMap());
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [geoData, drawMap]);
+
+  // Summary stats
+  const totalCountries = new Set(geoData?.coAuthors.map(a => a.countryCode)).size;
+  const totalMapped = geoData?.coAuthors.length ?? 0;
+  const topCountry = (() => {
+    if (!geoData?.coAuthors.length) return null;
+    const countMap = new Map<string, number>();
+    geoData.coAuthors.forEach(a => countMap.set(a.countryCode, (countMap.get(a.countryCode) ?? 0) + 1));
+    const top = [...countMap.entries()].sort((a, b) => b[1] - a[1])[0];
+    return top ? top[0] : null;
+  })();
+
+  const isEmpty = !loading && geoData && geoData.coAuthors.length === 0 && !geoData.mainAuthor;
+
+  return (
+    <div className="bg-white/80 backdrop-blur-xl rounded-xl border border-primary-start/10 p-6 hover:shadow-lg transition-all">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold gradient-text flex items-center">
+          <Globe className="h-5 w-5 mr-2 gradient-icon" />
+          Co-Author World Map
+        </h3>
+      </div>
+
+      {/* Map area */}
+      <div ref={containerRef} className="relative w-full rounded-lg overflow-hidden bg-[#eaf4f4]/30 border border-gray-100">
+        {loading && (
+          <div className="flex items-center justify-center h-64">
+            <div className="flex flex-col items-center gap-3">
+              <div className="w-8 h-8 border-2 border-[#2d7d7d] border-t-transparent rounded-full animate-spin" />
+              <p className="text-sm text-gray-500">Locating co-authors...</p>
+            </div>
+          </div>
+        )}
+
+        {isEmpty && (
+          <div className="flex items-center justify-center h-64">
+            <div className="flex flex-col items-center gap-3 text-gray-400">
+              <MapPin className="h-10 w-10 opacity-40" />
+              <p className="text-sm">No geographic data available for co-authors</p>
+            </div>
+          </div>
+        )}
+
+        {mapError && (
+          <div className="flex items-center justify-center h-64">
+            <div className="flex flex-col items-center gap-3 text-gray-400">
+              <Globe className="h-10 w-10 opacity-40" />
+              <p className="text-sm">Failed to load world map data</p>
+              <button
+                onClick={() => { setMapError(false); drawMap(); }}
+                className="text-xs text-[#2d7d7d] hover:text-[#1a5c5c] underline"
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        )}
+
+        {!loading && !isEmpty && !mapError && (
+          <div className="relative">
+            <svg ref={svgRef} className="w-full block" />
+
+            {/* Tooltip */}
+            {tooltip.visible && tooltip.data && (
+              <div
+                className="pointer-events-none absolute z-20 bg-white rounded-lg shadow-lg border border-gray-100 p-3 text-xs max-w-[200px]"
+                style={{ left: tooltip.x, top: tooltip.y }}
+              >
+                <p className="font-semibold text-gray-900 mb-1">{tooltip.data.name}</p>
+                <p className="text-gray-500 mb-1">{tooltip.data.institution}</p>
+                <p className="text-gray-400">{tooltip.data.countryCode}</p>
+                {tooltip.data.sharedPapers > 0 && (
+                  <div className="mt-2 pt-2 border-t border-gray-100 space-y-0.5">
+                    <p className="text-[#2d7d7d] font-medium">{tooltip.data.sharedPapers} shared {tooltip.data.sharedPapers === 1 ? 'paper' : 'papers'}</p>
+                    <p className="text-gray-400">{tooltip.data.sharedCitations.toLocaleString()} shared citations</p>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Map legend */}
+            <div className="absolute top-2 right-2 flex flex-col gap-1.5 text-xs text-gray-500">
+              <div className="flex items-center gap-1.5">
+                <div className="w-3 h-3 rounded-full bg-[#0d9488] border-2 border-white shadow-sm" />
+                <span>Main Author</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <div className="w-3 h-3 rounded-full bg-[#2d7d7d] opacity-70 border border-white shadow-sm" />
+                <span>Co-author</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Summary stats */}
+      {!loading && !isEmpty && !mapError && (
+        <div className="mt-4 grid grid-cols-3 gap-3">
+          <div className="bg-[#eaf4f4]/50 rounded-lg p-3 text-center">
+            <div className="flex items-center justify-center mb-1">
+              <Flag className="h-4 w-4 text-[#2d7d7d]" />
+            </div>
+            <p className="text-xl font-bold text-[#2d7d7d]">{totalCountries}</p>
+            <p className="text-xs text-gray-500">Countries</p>
+          </div>
+          <div className="bg-[#eaf4f4]/50 rounded-lg p-3 text-center">
+            <div className="flex items-center justify-center mb-1">
+              <Users className="h-4 w-4 text-[#2d7d7d]" />
+            </div>
+            <p className="text-xl font-bold text-[#2d7d7d]">{totalMapped}</p>
+            <p className="text-xs text-gray-500">Co-authors mapped</p>
+          </div>
+          <div className="bg-[#eaf4f4]/50 rounded-lg p-3 text-center">
+            <div className="flex items-center justify-center mb-1">
+              <MapPin className="h-4 w-4 text-[#2d7d7d]" />
+            </div>
+            <p className="text-xl font-bold text-[#2d7d7d]">{topCountry ?? '—'}</p>
+            <p className="text-xs text-gray-500">Top country</p>
+          </div>
+        </div>
+      )}
+
+      {/* Info box */}
+      <div className="mt-4 text-xs text-gray-500 bg-[#eaf4f4]/50 rounded-lg p-3">
+        <div className="flex items-start space-x-2">
+          <Info className="h-4 w-4 text-[#2d7d7d] flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="font-medium text-[#1e293b] mb-1">World Map Guide</p>
+            <ul className="space-y-1 text-[#64748b]">
+              <li>• Teal dot marks your location; darker dots are co-authors</li>
+              <li>• Dot size scales with number of shared papers</li>
+              <li>• Arcs show collaboration routes across the globe</li>
+              <li>• Hover a dot for details · Scroll to zoom · Drag to pan</li>
+              <li>• Locations sourced from OpenAlex — top 20 co-authors by shared papers</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock, ExternalLink, Heart, BadgeCheck, Link } from 'lucide-react';
+import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock, ExternalLink, Heart, BadgeCheck, Link, Globe } from 'lucide-react';
 import { EmbedModal } from './EmbedModal';
 import { ClaimProfileModal } from './ClaimProfileModal';
 import { exportProfilePdf } from '../utils/pdfExport';
@@ -9,6 +9,7 @@ import { PublicationsList } from './PublicationsList';
 import { CitationsChart } from './CitationsChart';
 import { MetricsCard } from './MetricsCard';
 import { CitationNetwork } from './CitationNetwork';
+import { CoAuthorMap } from './CoAuthorMap';
 import { OpenScienceTab } from './OpenScienceTab';
 import { ResearcherNarrative } from './ResearcherNarrative';
 import { Logo } from './Logo';
@@ -34,6 +35,7 @@ const tabs = [
   { id: 'metrics', label: 'Impact Metrics', icon: ChartBar },
   { id: 'trends', label: 'Citation Trends', icon: LineChart },
   { id: 'network', label: 'Co-author Network', icon: Network },
+  { id: 'worldmap', label: 'World Map', icon: Globe },
   { id: 'openscience', label: 'Open Science', icon: Unlock },
   { id: 'publications', label: 'Publications', icon: BookOpen },
 ] as const;
@@ -426,6 +428,14 @@ export function ProfileView({
           <div className="w-full">
             <CitationNetwork publications={data.publications} fullScreen={true} />
           </div>
+        )}
+
+        {activeTab === 'worldmap' && (
+          <CoAuthorMap
+            publications={data.publications}
+            authorName={data.name}
+            authorAffiliation={data.affiliation}
+          />
         )}
 
         {activeTab === 'openscience' && (

--- a/src/services/openalex/coauthor-geo.ts
+++ b/src/services/openalex/coauthor-geo.ts
@@ -1,0 +1,110 @@
+import type { Publication, CoAuthorGeoData } from '../../types/scholar';
+import { rateLimiter } from '../scholar/rate-limiter';
+
+const API_URL = 'https://api.openalex.org';
+const EMAIL = 'scholarfolio@scholarfolio.org';
+const HEADERS = {
+  'User-Agent': `ScholarFolio/1.0 (mailto:${EMAIL})`
+};
+
+interface OpenAlexInstitution {
+  display_name?: string;
+  country_code?: string;
+  geo?: {
+    latitude?: number;
+    longitude?: number;
+  };
+}
+
+interface OpenAlexAuthorResult {
+  last_known_institutions?: OpenAlexInstitution[];
+}
+
+async function resolveAuthorGeo(
+  name: string,
+  sharedPapers: number,
+  sharedCitations: number
+): Promise<CoAuthorGeoData | null> {
+  try {
+    await rateLimiter.acquireToken();
+    const url = `${API_URL}/authors?search=${encodeURIComponent(name)}&per_page=1&mailto=${EMAIL}`;
+    const response = await fetch(url, {
+      headers: HEADERS,
+      signal: AbortSignal.timeout(8000)
+    });
+    if (!response.ok) return null;
+
+    const data = await response.json();
+    const result: OpenAlexAuthorResult | undefined = data.results?.[0];
+    if (!result) return null;
+
+    const institution = result.last_known_institutions?.[0];
+    if (!institution) return null;
+
+    const { display_name, country_code, geo } = institution;
+    if (!display_name || !country_code || geo?.latitude == null || geo?.longitude == null) {
+      return null;
+    }
+
+    return {
+      name,
+      institution: display_name,
+      countryCode: country_code,
+      lat: geo.latitude,
+      lng: geo.longitude,
+      sharedPapers,
+      sharedCitations
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchCoAuthorGeoData(
+  authorName: string,
+  authorAffiliation: string,
+  publications: Publication[]
+): Promise<{ mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] }> {
+  // Identify the main author as the most frequent name across publications
+  const freq = new Map<string, number>();
+  for (const pub of publications) {
+    for (const author of pub.authors) {
+      freq.set(author, (freq.get(author) || 0) + 1);
+    }
+  }
+  const sorted = [...freq.entries()].sort((a, b) => b[1] - a[1]);
+  const mainAuthorKey = sorted[0]?.[0] ?? authorName;
+
+  // Count co-author shared papers and citations, excluding main author
+  const coAuthorMap = new Map<string, { papers: number; citations: number }>();
+  for (const pub of publications) {
+    const coAuthors = pub.authors.filter(a => a !== mainAuthorKey);
+    for (const coAuthor of coAuthors) {
+      const existing = coAuthorMap.get(coAuthor) ?? { papers: 0, citations: 0 };
+      coAuthorMap.set(coAuthor, {
+        papers: existing.papers + 1,
+        citations: existing.citations + pub.citations
+      });
+    }
+  }
+
+  // Sort by shared paper count, take top 20
+  const top20 = [...coAuthorMap.entries()]
+    .sort((a, b) => b[1].papers - a[1].papers)
+    .slice(0, 20);
+
+  // Resolve all co-authors and main author in parallel (non-blocking per item)
+  const [mainAuthor, ...coAuthorResults] = await Promise.all([
+    resolveAuthorGeo(authorName, 0, 0).then(result => {
+      // Override name/affiliation hint not available from API — just use what we got
+      return result;
+    }),
+    ...top20.map(([name, data]) =>
+      resolveAuthorGeo(name, data.papers, data.citations)
+    )
+  ]);
+
+  const coAuthors = coAuthorResults.filter((r): r is CoAuthorGeoData => r !== null);
+
+  return { mainAuthor, coAuthors };
+}

--- a/src/types/scholar.ts
+++ b/src/types/scholar.ts
@@ -88,6 +88,16 @@ export interface Author {
   cacheStatus?: 'hit' | 'miss';
 }
 
+export interface CoAuthorGeoData {
+  name: string;
+  institution: string;
+  countryCode: string;
+  lat: number;
+  lng: number;
+  sharedPapers: number;
+  sharedCitations: number;
+}
+
 // Utility types
 export type SortField = 'year' | 'citations' | 'title';
 export type SortDirection = 'asc' | 'desc';


### PR DESCRIPTION
## Summary
- New **World Map** tab on profile pages showing co-author locations on an interactive D3 globe
- Resolves co-author institutions and coordinates via OpenAlex API (top 20 by shared papers)
- Dots sized by shared papers, great-circle arcs to main author, zoom/pan, hover tooltips
- Summary stats: total countries, co-authors mapped, top country
- Error handling for CDN/API failures with retry option

## New files
- `src/services/openalex/coauthor-geo.ts` — OpenAlex geo lookup service
- `src/components/CoAuthorMap.tsx` — D3 world map component

## Test plan
- [ ] Load any researcher profile, click "World Map" tab
- [ ] Verify dots appear for co-authors with correct tooltips
- [ ] Test zoom/pan on the map
- [ ] Test with a researcher who has few/no co-authors (empty state)
- [ ] Verify other tabs still work correctly