### PR TITLE
Fix world map loading forever

### DIFF
--- a/src/services/openalex/coauthor-geo.ts
+++ b/src/services/openalex/coauthor-geo.ts
@@ -1,8 +1,11 @@
 import type { Publication, CoAuthorGeoData } from '../../types/scholar';
-import { rateLimiter } from '../scholar/rate-limiter';
+import { RateLimiter } from '../scholar/rate-limiter';
 
 const API_URL = 'https://api.openalex.org';
 const EMAIL = 'scholarfolio@scholarfolio.org';
+
+// Dedicated limiter: OpenAlex polite pool allows ~10 req/sec with mailto
+const geoRateLimiter = new RateLimiter(5000, 10);
 const HEADERS = {
   'User-Agent': `ScholarFolio/1.0 (mailto:${EMAIL})`
 };
@@ -26,7 +29,7 @@ async function resolveAuthorGeo(
   sharedCitations: number
 ): Promise<CoAuthorGeoData | null> {
   try {
-    await rateLimiter.acquireToken();
+    await geoRateLimiter.acquireToken();
     const url = `${API_URL}/authors?search=${encodeURIComponent(name)}&per_page=1&mailto=${EMAIL}`;
     const response = await fetch(url, {
       headers: HEADERS,


### PR DESCRIPTION
## Summary
- Geo service was using the shared `rateLimiter` (10 req/60s), causing 21 OpenAlex lookups to take 2+ minutes
- Switched to a dedicated `RateLimiter` instance (10 req/5s) matching OpenAlex's polite pool rate limits

## Test plan
- [ ] Open a profile, click World Map tab — should load in ~5-10 seconds instead of hanging