### PR TITLE
Fix world map showing no geographic data

### DIFF
--- a/src/services/openalex/coauthor-geo.ts
+++ b/src/services/openalex/coauthor-geo.ts
@@ -10,17 +10,59 @@ const HEADERS = {
   'User-Agent': `ScholarFolio/1.0 (mailto:${EMAIL})`
 };
 
-interface OpenAlexInstitution {
+interface InstitutionRef {
+  id?: string;
   display_name?: string;
   country_code?: string;
-  geo?: {
-    latitude?: number;
-    longitude?: number;
-  };
 }
 
-interface OpenAlexAuthorResult {
-  last_known_institutions?: OpenAlexInstitution[];
+interface InstitutionGeo {
+  latitude?: number;
+  longitude?: number;
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  await geoRateLimiter.acquireToken();
+  const response = await fetch(url, {
+    headers: HEADERS,
+    signal: AbortSignal.timeout(8000)
+  });
+  if (!response.ok) return null;
+  return response.json();
+}
+
+/** Look up an author's institution ID via OpenAlex */
+async function resolveAuthorInstitution(
+  name: string
+): Promise<InstitutionRef | null> {
+  try {
+    const data = await fetchJson(
+      `${API_URL}/authors?search=${encodeURIComponent(name)}&per_page=1&select=last_known_institutions&mailto=${EMAIL}`
+    ) as { results?: Array<{ last_known_institutions?: InstitutionRef[] }> } | null;
+    if (!data) return null;
+
+    const inst = data.results?.[0]?.last_known_institutions?.[0];
+    if (!inst?.id || !inst.display_name) return null;
+    return inst;
+  } catch {
+    return null;
+  }
+}
+
+/** Fetch geo coordinates for an institution by its OpenAlex ID */
+async function fetchInstitutionGeo(
+  institutionId: string
+): Promise<InstitutionGeo | null> {
+  try {
+    const shortId = institutionId.replace('https://openalex.org/', '');
+    const data = await fetchJson(
+      `${API_URL}/institutions/${shortId}?select=geo&mailto=${EMAIL}`
+    ) as { geo?: InstitutionGeo } | null;
+    if (!data) return null;
+    return data.geo ?? null;
+  } catch {
+    return null;
+  }
 }
 
 async function resolveAuthorGeo(
@@ -28,44 +70,28 @@ async function resolveAuthorGeo(
   sharedPapers: number,
   sharedCitations: number
 ): Promise<CoAuthorGeoData | null> {
-  try {
-    await geoRateLimiter.acquireToken();
-    const url = `${API_URL}/authors?search=${encodeURIComponent(name)}&per_page=1&mailto=${EMAIL}`;
-    const response = await fetch(url, {
-      headers: HEADERS,
-      signal: AbortSignal.timeout(8000)
-    });
-    if (!response.ok) return null;
+  // Step 1: find the author's institution
+  const inst = await resolveAuthorInstitution(name);
+  if (!inst?.id || !inst.display_name || !inst.country_code) return null;
 
-    const data = await response.json();
-    const result: OpenAlexAuthorResult | undefined = data.results?.[0];
-    if (!result) return null;
+  // Step 2: get the institution's geo coordinates
+  const geo = await fetchInstitutionGeo(inst.id);
+  if (geo?.latitude == null || geo?.longitude == null) return null;
 
-    const institution = result.last_known_institutions?.[0];
-    if (!institution) return null;
-
-    const { display_name, country_code, geo } = institution;
-    if (!display_name || !country_code || geo?.latitude == null || geo?.longitude == null) {
-      return null;
-    }
-
-    return {
-      name,
-      institution: display_name,
-      countryCode: country_code,
-      lat: geo.latitude,
-      lng: geo.longitude,
-      sharedPapers,
-      sharedCitations
-    };
-  } catch {
-    return null;
-  }
+  return {
+    name,
+    institution: inst.display_name,
+    countryCode: inst.country_code,
+    lat: geo.latitude,
+    lng: geo.longitude,
+    sharedPapers,
+    sharedCitations
+  };
 }
 
 export async function fetchCoAuthorGeoData(
   authorName: string,
-  authorAffiliation: string,
+  _authorAffiliation: string,
   publications: Publication[]
 ): Promise<{ mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] }> {
   // Identify the main author as the most frequent name across publications
@@ -96,12 +122,9 @@ export async function fetchCoAuthorGeoData(
     .sort((a, b) => b[1].papers - a[1].papers)
     .slice(0, 20);
 
-  // Resolve all co-authors and main author in parallel (non-blocking per item)
+  // Resolve all in parallel (each does 2 API calls: author → institution)
   const [mainAuthor, ...coAuthorResults] = await Promise.all([
-    resolveAuthorGeo(authorName, 0, 0).then(result => {
-      // Override name/affiliation hint not available from API — just use what we got
-      return result;
-    }),
+    resolveAuthorGeo(authorName, 0, 0),
     ...top20.map(([name, data]) =>
       resolveAuthorGeo(name, data.papers, data.citations)
     )


### PR DESCRIPTION
## Summary
- OpenAlex `/authors` endpoint returns institution name/country but no lat/lng
- Geo coordinates live on the `/institutions/:id` endpoint
- Rewrote geo service to do two-step lookup: author → institution ID → institution geo
- Tested manually: Maastricht University returns lat 50.84, lng 5.69

## Test plan
- [ ] Open any profile, click World Map — dots should appear now
- [ ] Hover dots to verify institution names and coordinates are correct