### PR TITLE
Fix world map self-as-coauthor and arc wrapping

### DIFF
--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -113,38 +113,37 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
           return pt ?? null;
         };
 
-        // Draw arcs from main author to each co-author
+        // Draw arcs from main author to each co-author using GeoJSON LineStrings
+        // This handles wrapping correctly — D3 geoPath clips arcs at the projection boundary
         if (geoData.mainAuthor) {
-          const mainPt = project(geoData.mainAuthor.lng, geoData.mainAuthor.lat);
-          if (mainPt) {
             geoData.coAuthors.forEach(coAuthor => {
-              const coPt = project(coAuthor.lng, coAuthor.lat);
-              if (!coPt) return;
+              const arcGeoJson: GeoJSON.Feature<GeoJSON.LineString> = {
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                  type: 'LineString',
+                  coordinates: (() => {
+                    const interp = d3.geoInterpolate(
+                      [geoData.mainAuthor!.lng, geoData.mainAuthor!.lat],
+                      [coAuthor.lng, coAuthor.lat]
+                    );
+                    const pts: [number, number][] = [];
+                    for (let t = 0; t <= 1; t += 0.02) {
+                      pts.push(interp(t) as [number, number]);
+                    }
+                    return pts;
+                  })()
+                }
+              };
 
-              // d3.geoInterpolate great-circle arc as SVG path
-              const interpolate = d3.geoInterpolate(
-                [geoData.mainAuthor!.lng, geoData.mainAuthor!.lat],
-                [coAuthor.lng, coAuthor.lat]
-              );
-              const arcPoints: [number, number][] = [];
-              for (let t = 0; t <= 1; t += 0.02) {
-                const [lng2, lat2] = interpolate(t);
-                const pt = project(lng2, lat2);
-                if (pt) arcPoints.push(pt);
-              }
-
-              if (arcPoints.length > 1) {
-                const lineGen = d3.line<[number, number]>().x(d => d[0]).y(d => d[1]).curve(d3.curveCatmullRom);
-                zoomGroup.append('path')
-                  .datum(arcPoints)
-                  .attr('d', lineGen)
-                  .attr('fill', 'none')
-                  .attr('stroke', '#2d7d7d')
-                  .attr('stroke-width', 1)
-                  .attr('stroke-opacity', 0.25 + Math.min(0.5, coAuthor.sharedPapers / 10));
-              }
+              zoomGroup.append('path')
+                .datum(arcGeoJson)
+                .attr('d', pathGen as unknown as (d: GeoJSON.Feature<GeoJSON.LineString>) => string)
+                .attr('fill', 'none')
+                .attr('stroke', '#2d7d7d')
+                .attr('stroke-width', 1)
+                .attr('stroke-opacity', 0.25 + Math.min(0.5, coAuthor.sharedPapers / 10));
             });
-          }
         }
 
         // Draw co-author dots

--- a/src/services/openalex/coauthor-geo.ts
+++ b/src/services/openalex/coauthor-geo.ts
@@ -52,12 +52,23 @@ export async function fetchCoAuthorGeoData(
   _authorAffiliation: string,
   publications: Publication[]
 ): Promise<{ mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] }> {
-  // Step 1: Find the main author's OpenAlex ID
-  const authorSearch = await fetchJson<{ results: Array<{ id: string }> }>(
-    `${API_URL}/authors?search=${encodeURIComponent(authorName)}&per_page=1&select=id&mailto=${EMAIL}`
+  // Step 1: Find the main author's OpenAlex ID and current institution
+  const authorSearch = await fetchJson<{ results: Array<{
+    id: string;
+    last_known_institutions?: Array<{
+      id: string;
+      display_name: string;
+      country_code: string;
+    }>;
+  }> }>(
+    `${API_URL}/authors?search=${encodeURIComponent(authorName)}&per_page=1&select=id,last_known_institutions&mailto=${EMAIL}`
   );
-  const mainAuthorOaId = authorSearch?.results?.[0]?.id;
+  const mainAuthorResult = authorSearch?.results?.[0];
+  const mainAuthorOaId = mainAuthorResult?.id;
   if (!mainAuthorOaId) return { mainAuthor: null, coAuthors: [] };
+
+  // Use last_known_institutions for the main author's CURRENT affiliation
+  const mainCurrentInst = mainAuthorResult?.last_known_institutions?.[0];
 
   const shortId = mainAuthorOaId.replace('https://openalex.org/', '');
 
@@ -107,8 +118,11 @@ export async function fetchCoAuthorGeoData(
   }
 
   const coAuthorInstitutions = new Map<string, CoAuthorInfo>();
+  const mainNameLower = authorName.toLowerCase().trim();
   for (const authorship of allAuthorships) {
+    // Skip the main author — by ID and by name (handles duplicate OA profiles)
     if (authorship.author.id === mainAuthorOaId) continue;
+    if (authorship.author.display_name.toLowerCase().trim() === mainNameLower) continue;
     const inst = authorship.institutions[0];
     if (!inst?.id || !inst.display_name || !inst.country_code) continue;
 
@@ -173,21 +187,10 @@ export async function fetchCoAuthorGeoData(
   matched.sort((a, b) => b.papers - a.papers);
   const top20 = matched.slice(0, 20);
 
-  // Also find main author's institution from OpenAlex authorships
-  let mainInstitutionId: string | null = null;
-  let mainInstitutionName: string | null = null;
-  let mainCountryCode: string | null = null;
-  for (const authorship of allAuthorships) {
-    if (authorship.author.id === mainAuthorOaId && authorship.institutions.length > 0) {
-      const inst = authorship.institutions[0];
-      if (inst.id && inst.display_name && inst.country_code) {
-        mainInstitutionId = inst.id;
-        mainInstitutionName = inst.display_name;
-        mainCountryCode = inst.country_code;
-        break;
-      }
-    }
-  }
+  // Use the main author's current institution from their profile
+  const mainInstitutionId = mainCurrentInst?.id ?? null;
+  const mainInstitutionName = mainCurrentInst?.display_name ?? null;
+  const mainCountryCode = mainCurrentInst?.country_code ?? null;
 
   // Step 4: Collect unique institution IDs and batch-fetch their geo
   const uniqueInstIds = new Set<string>();


### PR DESCRIPTION
## Summary
- Main author now shows current institution (from `last_known_institutions`) not old paper affiliations
- Filters out self from co-author list by name match (handles duplicate OA profiles)
- Arcs rendered as GeoJSON LineStrings via geoPath — no more wrapping around the globe

## Test plan
- [ ] Jonas Heller profile: main dot should be Maastricht, not UNSW Sydney
- [ ] No "Jonas Heller @ UNSW" co-author dot
- [ ] Arcs should follow great-circle paths without wrapping