### PR TITLE
Enhance world map with continent colors, zoom controls & region views

### DIFF
--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import * as d3 from 'd3';
 import * as topojson from 'topojson-client';
 import type { Topology, GeometryCollection } from 'topojson-specification';
-import { Globe, Info, MapPin, Users, Flag } from 'lucide-react';
+import { Globe, Info, MapPin, Users, Flag, ZoomIn, ZoomOut, RotateCcw } from 'lucide-react';
 import type { Publication, CoAuthorGeoData } from '../types/scholar';
 import { fetchCoAuthorGeoData } from '../services/openalex/coauthor-geo';
 
@@ -26,13 +26,54 @@ interface WorldTopology extends Topology {
   };
 }
 
+// Continent classification based on geographic centroid
+function classifyContinent(feature: GeoJSON.Feature): string {
+  const [lng, lat] = d3.geoCentroid(feature);
+  if (lng >= -30 && lng <= 50 && lat > 35) return 'europe';
+  if (lng >= -25 && lng <= 55 && lat <= 37 && lat >= -40) return 'africa';
+  if (lng < -25 && lat > 15) return 'north-america';
+  if (lng < -25 && lat <= 15) return 'south-america';
+  if (lng > 100 && lat < -8) return 'oceania';
+  return 'asia';
+}
+
+const CONTINENT_FILLS: Record<string, string> = {
+  'europe': '#dbeafe',
+  'asia': '#fef9c4',
+  'africa': '#fce7f3',
+  'north-america': '#d1fae5',
+  'south-america': '#e0e7ff',
+  'oceania': '#ccfbf1',
+};
+
+const CONTINENT_BORDERS: Record<string, string> = {
+  'europe': '#bfdbfe',
+  'asia': '#fde68a',
+  'africa': '#fbcfe8',
+  'north-america': '#a7f3d0',
+  'south-america': '#c7d2fe',
+  'oceania': '#99f6e4',
+};
+
+const REGION_VIEWS = [
+  { id: 'world', label: 'World', center: [0, 20] as [number, number], scale: 1 },
+  { id: 'europe', label: 'Europe', center: [15, 52] as [number, number], scale: 4.5 },
+  { id: 'asia', label: 'Asia', center: [85, 35] as [number, number], scale: 2.2 },
+  { id: 'africa', label: 'Africa', center: [20, 2] as [number, number], scale: 2.8 },
+  { id: 'americas', label: 'Americas', center: [-80, 10] as [number, number], scale: 1.8 },
+  { id: 'oceania', label: 'Oceania', center: [145, -25] as [number, number], scale: 4 },
+];
+
 export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoAuthorMapProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const zoomRef = useRef<d3.ZoomBehavior<SVGSVGElement, unknown> | null>(null);
+  const projectionRef = useRef<d3.GeoProjection | null>(null);
   const [loading, setLoading] = useState(true);
   const [geoData, setGeoData] = useState<{ mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null>(null);
   const [tooltip, setTooltip] = useState<TooltipState>({ visible: false, x: 0, y: 0, data: null });
   const [mapError, setMapError] = useState(false);
+  const [activeRegion, setActiveRegion] = useState('world');
 
   // Fetch geo data on mount
   useEffect(() => {
@@ -46,6 +87,54 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
     });
     return () => { cancelled = true; };
   }, [authorName, authorAffiliation, publications]);
+
+  const zoomToRegion = useCallback((regionId: string) => {
+    const svg = svgRef.current;
+    const projection = projectionRef.current;
+    const zoom = zoomRef.current;
+    const container = containerRef.current;
+    if (!svg || !projection || !zoom || !container) return;
+
+    setActiveRegion(regionId);
+
+    if (regionId === 'world') {
+      d3.select(svg).transition().duration(750)
+        .call(zoom.transform, d3.zoomIdentity);
+      return;
+    }
+
+    const region = REGION_VIEWS.find(r => r.id === regionId);
+    if (!region) return;
+
+    const width = container.clientWidth;
+    const height = Math.max(360, Math.round(width * 0.5));
+    const pt = projection(region.center);
+    if (!pt) return;
+
+    const transform = d3.zoomIdentity
+      .translate(width / 2, height / 2)
+      .scale(region.scale)
+      .translate(-pt[0], -pt[1]);
+
+    d3.select(svg).transition().duration(750)
+      .call(zoom.transform, transform);
+  }, []);
+
+  const handleZoomIn = useCallback(() => {
+    if (!svgRef.current || !zoomRef.current) return;
+    d3.select(svgRef.current).transition().duration(300)
+      .call(zoomRef.current.scaleBy, 1.5);
+  }, []);
+
+  const handleZoomOut = useCallback(() => {
+    if (!svgRef.current || !zoomRef.current) return;
+    d3.select(svgRef.current).transition().duration(300)
+      .call(zoomRef.current.scaleBy, 1 / 1.5);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    zoomToRegion('world');
+  }, [zoomToRegion]);
 
   const drawMap = useCallback(() => {
     if (!svgRef.current || !containerRef.current || !geoData) return;
@@ -61,6 +150,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
     const projection = d3.geoNaturalEarth1()
       .scale(width / 6.5)
       .translate([width / 2, height / 2]);
+    projectionRef.current = projection;
 
     const pathGen = d3.geoPath().projection(projection);
 
@@ -73,12 +163,12 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
       .on('zoom', event => {
         zoomGroup.attr('transform', event.transform);
         currentScale = event.transform.k;
-        // Scale dots inversely so they stay the same visual size when zoomed
         zoomGroup.selectAll<SVGCircleElement, unknown>('.geo-dot')
           .attr('r', function() { return +(this.getAttribute('data-base-r') ?? '4') / currentScale; })
           .attr('stroke-width', 1 / currentScale);
       });
 
+    zoomRef.current = zoom;
     svg.call(zoom);
 
     // Load world TopoJSON
@@ -89,28 +179,29 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
       })
       .then((world: WorldTopology) => {
         const countries = topojson.feature(world, world.objects.countries);
-        const land = topojson.feature(world, world.objects.land);
 
-        // Draw land fill
-        zoomGroup.append('path')
-          .datum(land)
-          .attr('d', pathGen as unknown as string)
-          .attr('fill', '#f9fafb');
-
-        // Draw country borders
-        zoomGroup.append('path')
-          .datum(countries)
-          .attr('d', pathGen as unknown as string)
-          .attr('fill', 'none')
-          .attr('stroke', '#e5e7eb')
-          .attr('stroke-width', 0.5);
-
-        // Outer sphere
+        // Outer sphere (ocean)
         zoomGroup.insert('path', ':first-child')
           .datum({ type: 'Sphere' } as d3.GeoPermissibleObjects)
           .attr('d', pathGen as unknown as string)
           .attr('fill', '#eaf4f4')
           .attr('stroke', '#d1fae5')
+          .attr('stroke-width', 0.5);
+
+        // Draw individual countries with continent coloring
+        zoomGroup.selectAll('.country')
+          .data((countries as unknown as GeoJSON.FeatureCollection).features)
+          .join('path')
+          .attr('class', 'country')
+          .attr('d', (d: GeoJSON.Feature) => pathGen(d) ?? '')
+          .attr('fill', (d: GeoJSON.Feature) => {
+            const continent = classifyContinent(d);
+            return CONTINENT_FILLS[continent] || '#f9fafb';
+          })
+          .attr('stroke', (d: GeoJSON.Feature) => {
+            const continent = classifyContinent(d);
+            return CONTINENT_BORDERS[continent] || '#e5e7eb';
+          })
           .attr('stroke-width', 0.5);
 
         // Helper: project coordinates
@@ -119,39 +210,38 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
           return pt ?? null;
         };
 
-        // Draw arcs from main author to each co-author using GeoJSON LineStrings
-        // This handles wrapping correctly — D3 geoPath clips arcs at the projection boundary
+        // Draw arcs from main author to each co-author
         if (geoData.mainAuthor) {
-            geoData.coAuthors.forEach(coAuthor => {
-              const arcGeoJson: GeoJSON.Feature<GeoJSON.LineString> = {
-                type: 'Feature',
-                properties: {},
-                geometry: {
-                  type: 'LineString',
-                  coordinates: (() => {
-                    const interp = d3.geoInterpolate(
-                      [geoData.mainAuthor!.lng, geoData.mainAuthor!.lat],
-                      [coAuthor.lng, coAuthor.lat]
-                    );
-                    const pts: [number, number][] = [];
-                    for (let t = 0; t <= 1; t += 0.02) {
-                      pts.push(interp(t) as [number, number]);
-                    }
-                    return pts;
-                  })()
-                }
-              };
+          geoData.coAuthors.forEach(coAuthor => {
+            const arcGeoJson: GeoJSON.Feature<GeoJSON.LineString> = {
+              type: 'Feature',
+              properties: {},
+              geometry: {
+                type: 'LineString',
+                coordinates: (() => {
+                  const interp = d3.geoInterpolate(
+                    [geoData.mainAuthor!.lng, geoData.mainAuthor!.lat],
+                    [coAuthor.lng, coAuthor.lat]
+                  );
+                  const pts: [number, number][] = [];
+                  for (let t = 0; t <= 1; t += 0.02) {
+                    pts.push(interp(t) as [number, number]);
+                  }
+                  return pts;
+                })()
+              }
+            };
 
-              zoomGroup.append('path')
-                .attr('class', 'geo-arc')
-                .datum(arcGeoJson)
-                .attr('d', pathGen as unknown as (d: GeoJSON.Feature<GeoJSON.LineString>) => string)
-                .attr('fill', 'none')
-                .attr('stroke', '#2d7d7d')
-                .attr('stroke-width', 1)
-                .attr('stroke-opacity', 0.15 + Math.min(0.35, coAuthor.sharedPapers / 20))
-                .style('vector-effect', 'non-scaling-stroke');
-            });
+            zoomGroup.append('path')
+              .attr('class', 'geo-arc')
+              .datum(arcGeoJson)
+              .attr('d', pathGen as unknown as (d: GeoJSON.Feature<GeoJSON.LineString>) => string)
+              .attr('fill', 'none')
+              .attr('stroke', '#2d7d7d')
+              .attr('stroke-width', 1)
+              .attr('stroke-opacity', 0.15 + Math.min(0.35, coAuthor.sharedPapers / 20))
+              .style('vector-effect', 'non-scaling-stroke');
+          });
         }
 
         // Draw co-author dots
@@ -271,6 +361,25 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
         </h3>
       </div>
 
+      {/* Region buttons */}
+      {!loading && !isEmpty && !mapError && (
+        <div className="flex flex-wrap gap-1.5 mb-3">
+          {REGION_VIEWS.map(region => (
+            <button
+              key={region.id}
+              onClick={() => zoomToRegion(region.id)}
+              className={`px-3 py-1 text-xs font-medium rounded-full transition-colors ${
+                activeRegion === region.id
+                  ? 'bg-[#2d7d7d] text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {region.label}
+            </button>
+          ))}
+        </div>
+      )}
+
       {/* Map area */}
       <div ref={containerRef} className="relative w-full rounded-lg overflow-hidden bg-[#eaf4f4]/30 border border-gray-100">
         {loading && (
@@ -278,7 +387,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
             <div className="flex flex-col items-center gap-3">
               <div className="w-8 h-8 border-2 border-[#2d7d7d] border-t-transparent rounded-full animate-spin" />
               <p className="text-sm text-gray-500">Locating co-authors via OpenAlex...</p>
-              <p className="text-xs text-gray-400">This may take 10–15 seconds — we're looking up institutions for your top co-authors.</p>
+              <p className="text-xs text-gray-400">This may take 10-15 seconds — we're looking up institutions for your top co-authors.</p>
             </div>
           </div>
         )}
@@ -311,6 +420,31 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
           <div className="relative">
             <svg ref={svgRef} className="w-full block" />
 
+            {/* Zoom controls */}
+            <div className="absolute top-2 left-2 flex flex-col gap-1">
+              <button
+                onClick={handleZoomIn}
+                className="w-7 h-7 flex items-center justify-center bg-white/90 hover:bg-white rounded shadow-sm border border-gray-200 text-gray-600 hover:text-gray-900 transition-colors"
+                title="Zoom in"
+              >
+                <ZoomIn className="h-3.5 w-3.5" />
+              </button>
+              <button
+                onClick={handleZoomOut}
+                className="w-7 h-7 flex items-center justify-center bg-white/90 hover:bg-white rounded shadow-sm border border-gray-200 text-gray-600 hover:text-gray-900 transition-colors"
+                title="Zoom out"
+              >
+                <ZoomOut className="h-3.5 w-3.5" />
+              </button>
+              <button
+                onClick={handleReset}
+                className="w-7 h-7 flex items-center justify-center bg-white/90 hover:bg-white rounded shadow-sm border border-gray-200 text-gray-600 hover:text-gray-900 transition-colors"
+                title="Reset view"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+              </button>
+            </div>
+
             {/* Tooltip */}
             {tooltip.visible && tooltip.data && (
               <div
@@ -330,7 +464,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
             )}
 
             {/* Map legend */}
-            <div className="absolute top-2 right-2 flex flex-col gap-1.5 text-xs text-gray-500">
+            <div className="absolute top-2 right-2 flex flex-col gap-1.5 text-xs text-gray-500 bg-white/80 backdrop-blur-sm rounded-lg p-2 shadow-sm border border-gray-100">
               <div className="flex items-center gap-1.5">
                 <div className="w-3 h-3 rounded-full bg-[#0d9488] border-2 border-white shadow-sm" />
                 <span>Main Author</span>
@@ -338,6 +472,28 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
               <div className="flex items-center gap-1.5">
                 <div className="w-3 h-3 rounded-full bg-[#2d7d7d] opacity-70 border border-white shadow-sm" />
                 <span>Co-author</span>
+              </div>
+              <div className="border-t border-gray-100 pt-1.5 mt-0.5 space-y-1">
+                <div className="flex items-center gap-1.5">
+                  <div className="w-3 h-2 rounded-sm" style={{ backgroundColor: CONTINENT_FILLS['europe'] }} />
+                  <span>Europe</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <div className="w-3 h-2 rounded-sm" style={{ backgroundColor: CONTINENT_FILLS['asia'] }} />
+                  <span>Asia</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <div className="w-3 h-2 rounded-sm" style={{ backgroundColor: CONTINENT_FILLS['north-america'] }} />
+                  <span>Americas</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <div className="w-3 h-2 rounded-sm" style={{ backgroundColor: CONTINENT_FILLS['africa'] }} />
+                  <span>Africa</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <div className="w-3 h-2 rounded-sm" style={{ backgroundColor: CONTINENT_FILLS['oceania'] }} />
+                  <span>Oceania</span>
+                </div>
               </div>
             </div>
           </div>
@@ -382,6 +538,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
               <li>• Dot size scales with number of shared papers</li>
               <li>• Arcs show collaboration routes across the globe</li>
               <li>• Hover a dot for details · Scroll to zoom · Drag to pan</li>
+              <li>• Use region buttons or zoom controls to explore specific areas</li>
               <li>• Locations sourced from OpenAlex — top 20 co-authors by shared papers</li>
             </ul>
           </div>

--- a/src/services/openalex/coauthor-geo.ts
+++ b/src/services/openalex/coauthor-geo.ts
@@ -89,18 +89,34 @@ export async function fetchCoAuthorGeoData(
 
   // Step 3: Build co-author map with their most recent institution
   // Match OpenAlex names to ScholarFolio publication names
+  const normalize = (name: string) => name.toLowerCase().trim();
+  const getLastName = (name: string) => {
+    const parts = name.split(/\s+/);
+    return normalize(parts[parts.length - 1]);
+  };
+
   const mainAuthorFreq = new Map<string, number>();
   for (const pub of publications) {
-    for (const a of pub.authors) {
+    for (const a of (pub.authors || []).filter(n => n && n.trim())) {
       mainAuthorFreq.set(a, (mainAuthorFreq.get(a) || 0) + 1);
     }
   }
   const mainAuthorKey = [...mainAuthorFreq.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? authorName;
 
+  // Build a set of name variants that likely refer to the main author
+  const mainLastName = getLastName(mainAuthorKey);
+  const mainNameVariants = new Set<string>();
+  mainNameVariants.add(mainAuthorKey);
+  for (const [name] of mainAuthorFreq) {
+    if (getLastName(name) === mainLastName && name !== mainAuthorKey) {
+      mainNameVariants.add(name);
+    }
+  }
+
   // Count shared papers/citations from ScholarFolio data
   const coAuthorStats = new Map<string, { papers: number; citations: number }>();
   for (const pub of publications) {
-    for (const a of pub.authors.filter(a => a !== mainAuthorKey)) {
+    for (const a of (pub.authors || []).filter(a => a && a.trim() && !mainNameVariants.has(a))) {
       const existing = coAuthorStats.get(a) ?? { papers: 0, citations: 0 };
       coAuthorStats.set(a, { papers: existing.papers + 1, citations: existing.citations + pub.citations });
     }
@@ -141,12 +157,6 @@ export async function fetchCoAuthorGeoData(
   }
 
   // Match OpenAlex display names to ScholarFolio co-author names (fuzzy last-name match)
-  const normalize = (name: string) => name.toLowerCase().trim();
-  const getLastName = (name: string) => {
-    const parts = name.split(/\s+/);
-    return normalize(parts[parts.length - 1]);
-  };
-
   interface MatchedCoAuthor {
     sfName: string;
     oaInfo: CoAuthorInfo;
@@ -157,8 +167,11 @@ export async function fetchCoAuthorGeoData(
   const matched: MatchedCoAuthor[] = [];
   const usedOaIds = new Set<string>();
 
+  // Helper: extract all name tokens for fuzzy matching
+  const getNameTokens = (name: string) => new Set(normalize(name).split(/\s+/).filter(t => t.length > 1));
+
   for (const [sfName, stats] of coAuthorStats) {
-    // Try exact match first, then last-name match
+    // Try exact match first, then last-name match, then token overlap
     let bestMatch: CoAuthorInfo | null = null;
     for (const info of coAuthorInstitutions.values()) {
       if (usedOaIds.has(info.oaId)) continue;
@@ -174,6 +187,20 @@ export async function fetchCoAuthorGeoData(
         if (getLastName(info.displayName) === sfLast) {
           bestMatch = info;
           break;
+        }
+      }
+    }
+    // Fallback: token overlap (handles reordered compound names like "Easthope Awai" vs "Awai Easthope")
+    if (!bestMatch) {
+      const sfTokens = getNameTokens(sfName);
+      let bestOverlap = 0;
+      for (const info of coAuthorInstitutions.values()) {
+        if (usedOaIds.has(info.oaId)) continue;
+        const oaTokens = getNameTokens(info.displayName);
+        const overlap = [...sfTokens].filter(t => oaTokens.has(t)).length;
+        if (overlap >= 2 && overlap > bestOverlap) {
+          bestOverlap = overlap;
+          bestMatch = info;
         }
       }
     }


### PR DESCRIPTION
## Summary
- Color countries by continent (soft pastel fills for Europe, Asia, Africa, Americas, Oceania) with matching border colors and a legend overlay
- Add zoom in/out/reset buttons (top-left of map) and region preset buttons (World, Europe, Asia, Africa, Americas, Oceania) for quick navigation with smooth animated transitions
- Fix co-author name matching robustness: filter empty author strings from publications, exclude all main-author name variants (not just most frequent), add token-overlap fallback for compound surnames (e.g. "Easthope Awai" vs "Awai Easthope")

## Test plan
- [ ] Load own profile → world map shows continent-colored countries, co-author dots, arcs
- [ ] Load Chris Easthope Awai profile (user=61DvKEIAAAAJ) → verify map populates with co-authors
- [ ] Click region buttons → map smoothly zooms to each region
- [ ] Click zoom +/- buttons → map zooms in/out
- [ ] Click reset button → map returns to world view
- [ ] Hover co-author dots → tooltip appears with details
- [ ] Verify legend shows both dot types and continent colors
- [ ] Test on mobile viewport → buttons and map remain usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)