### PR TITLE
Add field-normalized metrics (FWCI, mean IF, RCR) and fix admin bugs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { supabase } from './lib/supabase';
 import type { Author } from './types/scholar';
 import { scholarService } from './services/scholar';
 import { openAlexService } from './services/openalex';
+import { fetchFieldNormalizedMetrics } from './services/openalex/field-metrics';
 
 const SOCIAL_LINKS = {
   linkedin: 'https://www.linkedin.com/in/hellerjonas/',
@@ -268,6 +269,15 @@ function AppContent() {
           }
         })
         .catch(() => {}); // Silently ignore — OA stats are supplementary
+
+      // Fetch field-normalized metrics from OpenAlex + iCite (non-blocking)
+      fetchFieldNormalizedMetrics(sanitizedData.name, sanitizedData.affiliation)
+        .then(fieldMetrics => {
+          if (fieldMetrics) {
+            setData(prev => prev ? { ...prev, fieldMetrics } : prev);
+          }
+        })
+        .catch(() => {}); // Silently ignore — field metrics are supplementary
 
       // Update browser URL with shareable link (preserve vanity URL if loaded via slug)
       const pathSlug = window.location.pathname.replace(/^\//, '').replace(/\/$/, '');

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -247,9 +247,9 @@ export function AdminDashboard({ onBack }: AdminDashboardProps) {
               <h3 className="text-sm font-semibold text-gray-900 mb-6">Conversion Funnel</h3>
               <FunnelChart
                 steps={[
-                  { label: 'Total Searches', value: stats.searchesAllTime, color: '#e0f2f1' },
-                  { label: 'Unique Searchers', value: stats.totalUsers + stats.anonSearches, color: '#b2dfdb' },
-                  { label: 'Signed Up', value: stats.totalUsers, color: '#4db6ac' },
+                  { label: 'Total Searches', value: stats.searches, color: '#e0f2f1' },
+                  { label: 'Unique Searchers', value: stats.newUsers + stats.anonSearches, color: '#b2dfdb' },
+                  { label: 'Signed Up', value: stats.newUsers, color: '#4db6ac' },
                   { label: 'Purchased Credits', value: stats.purchasingUsers, color: '#2d7d7d' },
                 ]}
               />

--- a/src/components/MetricsCard.tsx
+++ b/src/components/MetricsCard.tsx
@@ -39,7 +39,7 @@ interface MetricsCardProps {
         'sIndex' | 'rcr' | 'pubsPerYear' | 'network' | 'coAuthors' | 'avgAuthors' | 'soloAuthor' |
         'h5Index' | 'acc5' | 'citationsPerYear' | 'topCoAuthor' | 'avgCitationsPerPaper' |
         'citationGrowth' | 'peak' | 'trend' | 'fwci' | 'halfLife' | 'gini' | 'ageNormalized' |
-        'oaPercent' | 'goldOa' | 'greenOa' | 'hybridOa' | 'bronzeOa' | 'closedAccess';
+        'oaPercent' | 'goldOa' | 'greenOa' | 'hybridOa' | 'bronzeOa' | 'closedAccess' | 'meanIF';
 }
 
 function useCountUp(target: number | string, duration = 600) {
@@ -110,6 +110,7 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
       // Field metrics
       case 'rcr': return <Scale className="h-3.5 w-3.5" />;
       case 'fwci': return <Gauge className="h-3.5 w-3.5" />;
+      case 'meanIF': return <TrendingUp className="h-3.5 w-3.5" />;
       
       // Publication metrics
       case 'publications': return <BookOpen className="h-3.5 w-3.5" />;
@@ -160,6 +161,7 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
       case 'sIndex': return 'sIndex';
       case 'rcr': return 'rcr';
       case 'fwci': return 'fwci';
+      case 'meanIF': return 'meanIF';
       case 'pubsPerYear': return 'pubsPerYear';
       case 'network': return 'collaborationScore';
       case 'coAuthors': return 'coAuthors';

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -399,6 +399,38 @@ export function ProfileView({
               </div>
             </div>
 
+            {data.fieldMetrics && (data.fieldMetrics.fwci !== null || data.fieldMetrics.meanCitedness !== null || data.fieldMetrics.rcrMean !== null) && (
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Field-Normalized Metrics</h3>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+                  {data.fieldMetrics.fwci !== null && (
+                    <MetricsCard
+                      title="FWCI"
+                      value={data.fieldMetrics.fwci}
+                      subtitle={data.fieldMetrics.fwci >= 1.5 ? 'Well above average' : data.fieldMetrics.fwci >= 1.0 ? 'Above world average' : 'Below world average'}
+                      icon="fwci"
+                    />
+                  )}
+                  {data.fieldMetrics.meanCitedness !== null && (
+                    <MetricsCard
+                      title="Mean Journal Impact"
+                      value={data.fieldMetrics.meanCitedness}
+                      subtitle="Avg venue citedness"
+                      icon="meanIF"
+                    />
+                  )}
+                  {data.fieldMetrics.rcrMean !== null && (
+                    <MetricsCard
+                      title="RCR"
+                      value={data.fieldMetrics.rcrMean}
+                      subtitle={`${data.fieldMetrics.rcrPaperCount} PubMed paper${data.fieldMetrics.rcrPaperCount !== 1 ? 's' : ''}`}
+                      icon="rcr"
+                    />
+                  )}
+                </div>
+              </div>
+            )}
+
             <div>
               <h3 className="text-sm font-semibold text-gray-900 mb-3">Collaboration Metrics</h3>
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">

--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -519,13 +519,18 @@ export function ResearcherNarrative({ data }: ResearcherNarrativeProps) {
   const handleReport = async () => {
     if (!reportMsg.trim()) return;
     setReportStatus('sending');
-    await supabase.from('profile_reports').insert({
+    const { error } = await supabase.from('profile_reports').insert({
       author_id: scholarId,
       author_name: data.name,
       reporter_email: reportEmail || null,
       message: reportMsg.trim(),
       page_url: window.location.href,
     });
+    if (error) {
+      console.error('[Report] Insert failed:', error);
+      setReportStatus('idle');
+      return;
+    }
     setReportStatus('sent');
     setTimeout(() => {
       setShowReport(false);

--- a/src/data/metricInfo.ts
+++ b/src/data/metricInfo.ts
@@ -155,6 +155,24 @@ export const metricInfo = {
     cons: "No guarantee of permanent access. Cannot be legally redistributed or archived. Publisher may revoke access.",
     link: "https://en.wikipedia.org/wiki/Open_access#Bronze_OA"
   },
+  fwci: {
+    description: "Field-Weighted Citation Impact — a normalized measure of citation impact relative to the world average for the same field and publication year. Calculated from OpenAlex citation percentiles.\n\nA value of 1.0 means the researcher's papers are cited at the world average for their fields. Values above 1.0 indicate above-average impact.",
+    pros: "Accounts for field-specific citation norms, making it meaningful to compare researchers across disciplines. Based on per-paper percentiles, not raw counts.",
+    cons: "Depends on OpenAlex field classification accuracy. May differ from Elsevier's proprietary FWCI calculation in Scopus/SciVal.",
+    link: "https://en.wikipedia.org/wiki/Field-weighted_citation_impact"
+  },
+  rcr: {
+    description: "Relative Citation Ratio — developed by NIH, measures how a paper's citation rate compares to the average for its field and age. An RCR of 1.0 means average; 2.0 means twice the expected citations.\n\nData sourced from NIH's iCite database. Only available for papers indexed in PubMed.",
+    pros: "Rigorous field normalization using co-citation networks rather than journal categories. Peer-reviewed methodology. Free and transparent.",
+    cons: "Only covers PubMed-indexed publications (primarily biomedical/health sciences). Not available for humanities, social sciences, or recent papers.",
+    link: "https://icite.od.nih.gov/help"
+  },
+  meanIF: {
+    description: "Mean Journal Impact — the average 2-year citation rate of the journals where this researcher publishes, based on OpenAlex source statistics.\n\nThis is analogous to the Journal Impact Factor but uses OpenAlex's open data rather than Clarivate's proprietary JCR.",
+    pros: "Indicates the quality tier of journals the researcher targets. Higher values suggest publications in more impactful venues.",
+    cons: "Journal-level metric applied to individual researchers. Publishing in high-IF journals doesn't guarantee individual paper impact.",
+    link: "https://en.wikipedia.org/wiki/Impact_factor"
+  },
   closedAccess: {
     description: "Publications behind a paywall, accessible only through subscriptions or individual purchase.",
     pros: "Traditional publishing model with established peer review processes.",

--- a/src/services/openalex/field-metrics.ts
+++ b/src/services/openalex/field-metrics.ts
@@ -1,0 +1,168 @@
+import { timeoutSignal } from '../../utils/api';
+import { RateLimiter } from '../scholar/rate-limiter';
+
+const API_URL = 'https://api.openalex.org';
+const EMAIL = 'scholarfolio@scholarfolio.org';
+const HEADERS = { 'User-Agent': `ScholarFolio/1.0 (mailto:${EMAIL})` };
+
+const metricsRateLimiter = new RateLimiter(5000, 10);
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  try {
+    await metricsRateLimiter.acquireToken();
+    const response = await fetch(url, { headers: HEADERS, signal: timeoutSignal(15000) });
+    if (!response.ok) return null;
+    return await response.json() as T;
+  } catch {
+    return null;
+  }
+}
+
+export interface FieldNormalizedMetrics {
+  fwci: number | null;
+  meanCitedness: number | null;
+  paperCount: number;
+  rcrMean: number | null;
+  rcrPaperCount: number;
+}
+
+interface OpenAlexWork {
+  doi?: string;
+  cited_by_count?: number;
+  cited_by_percentile_year?: { min?: number; max?: number };
+  primary_location?: {
+    source?: {
+      display_name?: string;
+      summary_stats?: { '2yr_mean_citedness'?: number };
+    };
+  };
+}
+
+interface ICiteResult {
+  relative_citation_ratio?: number;
+}
+
+/**
+ * Fetches field-normalized metrics for an author from OpenAlex:
+ * - FWCI-like: average citation percentile across papers
+ * - Mean journal citedness (proxy for mean IF)
+ * Then enriches with RCR from NIH iCite for papers with DOIs.
+ */
+export async function fetchFieldNormalizedMetrics(
+  authorName: string,
+  authorAffiliation: string
+): Promise<FieldNormalizedMetrics | null> {
+  try {
+    // Step 1: Find author in OpenAlex
+    const authorSearch = await fetchJson<{ results: Array<{ id: string }> }>(
+      `${API_URL}/authors?search=${encodeURIComponent(authorName)}&per_page=5&select=id,last_known_institutions,affiliations&mailto=${EMAIL}`
+    );
+    if (!authorSearch?.results?.length) return null;
+
+    // Try to match by affiliation
+    let authorId = authorSearch.results[0].id;
+    if (authorSearch.results.length > 1 && authorAffiliation) {
+      const affLower = authorAffiliation.toLowerCase();
+      for (const result of authorSearch.results) {
+        const fullResult = await fetchJson<{
+          id: string;
+          last_known_institutions?: Array<{ display_name?: string }>;
+        }>(`${API_URL}/authors/${result.id.replace('https://openalex.org/', '')}?select=id,last_known_institutions&mailto=${EMAIL}`);
+        const inst = fullResult?.last_known_institutions?.[0]?.display_name?.toLowerCase() || '';
+        if (inst && affLower.includes(inst)) {
+          authorId = result.id;
+          break;
+        }
+      }
+    }
+
+    const shortId = authorId.replace('https://openalex.org/', '');
+
+    // Step 2: Fetch works with citation percentiles and source stats
+    const allWorks: OpenAlexWork[] = [];
+    let page = 1;
+    while (page <= 5) {
+      const data = await fetchJson<{ results: OpenAlexWork[] }>(
+        `${API_URL}/works?filter=authorships.author.id:${shortId}&per_page=200&page=${page}&select=doi,cited_by_count,cited_by_percentile_year,primary_location&mailto=${EMAIL}`
+      );
+      if (!data?.results?.length) break;
+      allWorks.push(...data.results);
+      if (data.results.length < 200) break;
+      page++;
+    }
+
+    if (allWorks.length === 0) return null;
+
+    // Step 3: Calculate FWCI-like metric (average citation percentile)
+    const percentiles: number[] = [];
+    for (const work of allWorks) {
+      const pct = work.cited_by_percentile_year?.min;
+      if (pct != null) percentiles.push(pct);
+    }
+    const fwci = percentiles.length > 0
+      ? Number((percentiles.reduce((a, b) => a + b, 0) / percentiles.length / 50).toFixed(2))
+      : null;
+    // Dividing by 50 normalizes: 50th percentile = 1.0 (world average), >1.0 = above average
+
+    // Step 4: Calculate mean journal citedness (proxy for mean IF)
+    const citednessValues: number[] = [];
+    for (const work of allWorks) {
+      const citedness = work.primary_location?.source?.summary_stats?.['2yr_mean_citedness'];
+      if (citedness != null && citedness > 0) citednessValues.push(citedness);
+    }
+    const meanCitedness = citednessValues.length > 0
+      ? Number((citednessValues.reduce((a, b) => a + b, 0) / citednessValues.length).toFixed(2))
+      : null;
+
+    // Step 5: Fetch RCR from NIH iCite for papers with DOIs
+    const dois = allWorks
+      .map(w => w.doi?.replace('https://doi.org/', ''))
+      .filter((d): d is string => !!d);
+
+    let rcrMean: number | null = null;
+    let rcrPaperCount = 0;
+
+    if (dois.length > 0) {
+      // iCite accepts up to 200 DOIs per request
+      const rcrValues: number[] = [];
+      const batchSize = 200;
+      for (let i = 0; i < dois.length && i < 400; i += batchSize) {
+        const batch = dois.slice(i, i + batchSize);
+        try {
+          const response = await fetch(
+            `https://icite.od.nih.gov/api/pubs?dois=${batch.join(',')}`,
+            { signal: timeoutSignal(15000) }
+          );
+          if (response.ok) {
+            const data = await response.json();
+            const pubs = data.data || data;
+            if (Array.isArray(pubs)) {
+              for (const pub of pubs as ICiteResult[]) {
+                if (pub.relative_citation_ratio != null && pub.relative_citation_ratio > 0) {
+                  rcrValues.push(pub.relative_citation_ratio);
+                }
+              }
+            }
+          }
+        } catch {
+          // iCite is optional — skip on error
+        }
+      }
+      if (rcrValues.length > 0) {
+        rcrMean = Number((rcrValues.reduce((a, b) => a + b, 0) / rcrValues.length).toFixed(2));
+        rcrPaperCount = rcrValues.length;
+      }
+    }
+
+    return {
+      fwci,
+      meanCitedness,
+      paperCount: allWorks.length,
+      rcrMean,
+      rcrPaperCount,
+    };
+  } catch (error) {
+    console.warn('[OpenAlex] Error fetching field-normalized metrics:', error);
+    return null;
+  }
+}

--- a/src/types/scholar.ts
+++ b/src/types/scholar.ts
@@ -75,6 +75,14 @@ export interface OpenAccessStats {
   publicationOa?: Record<string, { status: OaStatus; oaUrl?: string }>;
 }
 
+export interface FieldNormalizedMetrics {
+  fwci: number | null;
+  meanCitedness: number | null;
+  paperCount: number;
+  rcrMean: number | null;
+  rcrPaperCount: number;
+}
+
 export interface Author {
   name: string;
   affiliation: string;
@@ -85,6 +93,7 @@ export interface Author {
   publications: Publication[];
   metrics: Metrics;
   openAccess?: OpenAccessStats;
+  fieldMetrics?: FieldNormalizedMetrics;
   cacheStatus?: 'hit' | 'miss';
 }
 


### PR DESCRIPTION
## Summary
- Add FWCI (Field-Weighted Citation Impact) via OpenAlex citation percentiles — 1.0 = world average
- Add Mean Journal Impact via OpenAlex source 2yr_mean_citedness (proxy for mean IF)
- Add RCR (Relative Citation Ratio) via NIH iCite API for PubMed-indexed papers
- New "Field-Normalized Metrics" section in Impact Metrics tab (loads async, non-blocking)
- Fix conversion funnel using all-time values instead of period-filtered
- Fix error report insert silently failing without feedback

## Test plan
- [ ] Load a profile and verify FWCI / Mean IF appear in Impact Metrics tab
- [ ] Load a biomedical profile and verify RCR appears
- [ ] Check admin dashboard funnel changes with period filter
- [ ] Verify error reports still display in admin panel