### PR TITLE
Fix RCR showing wrong data from iCite

### DIFF
--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -419,14 +419,12 @@ export function ProfileView({
                       icon="meanIF"
                     />
                   )}
-                  {data.fieldMetrics.rcrMean !== null && (
-                    <MetricsCard
-                      title="RCR"
-                      value={data.fieldMetrics.rcrMean}
-                      subtitle={`${data.fieldMetrics.rcrPaperCount} PubMed paper${data.fieldMetrics.rcrPaperCount !== 1 ? 's' : ''}`}
-                      icon="rcr"
-                    />
-                  )}
+                  <MetricsCard
+                    title="RCR"
+                    value={data.fieldMetrics.rcrMean !== null ? data.fieldMetrics.rcrMean : 'N/A'}
+                    subtitle={data.fieldMetrics.rcrMean !== null ? `${data.fieldMetrics.rcrPaperCount} PubMed paper${data.fieldMetrics.rcrPaperCount !== 1 ? 's' : ''}` : 'PubMed papers only'}
+                    icon="rcr"
+                  />
                 </div>
               </div>
             )}

--- a/src/services/openalex/field-metrics.ts
+++ b/src/services/openalex/field-metrics.ts
@@ -38,10 +38,6 @@ interface OpenAlexWork {
   };
 }
 
-interface ICiteResult {
-  relative_citation_ratio?: number;
-}
-
 /**
  * Fetches field-normalized metrics for an author from OpenAlex:
  * - FWCI-like: average citation percentile across papers
@@ -114,52 +110,16 @@ export async function fetchFieldNormalizedMetrics(
       ? Number((citednessValues.reduce((a, b) => a + b, 0) / citednessValues.length).toFixed(2))
       : null;
 
-    // Step 5: Fetch RCR from NIH iCite for papers with DOIs
-    const dois = allWorks
-      .map(w => w.doi?.replace('https://doi.org/', ''))
-      .filter((d): d is string => !!d);
-
-    let rcrMean: number | null = null;
-    let rcrPaperCount = 0;
-
-    if (dois.length > 0) {
-      // iCite accepts up to 200 DOIs per request
-      const rcrValues: number[] = [];
-      const batchSize = 200;
-      for (let i = 0; i < dois.length && i < 400; i += batchSize) {
-        const batch = dois.slice(i, i + batchSize);
-        try {
-          const response = await fetch(
-            `https://icite.od.nih.gov/api/pubs?dois=${batch.join(',')}`,
-            { signal: timeoutSignal(15000) }
-          );
-          if (response.ok) {
-            const data = await response.json();
-            const pubs = data.data || data;
-            if (Array.isArray(pubs)) {
-              for (const pub of pubs as ICiteResult[]) {
-                if (pub.relative_citation_ratio != null && pub.relative_citation_ratio > 0) {
-                  rcrValues.push(pub.relative_citation_ratio);
-                }
-              }
-            }
-          }
-        } catch {
-          // iCite is optional — skip on error
-        }
-      }
-      if (rcrValues.length > 0) {
-        rcrMean = Number((rcrValues.reduce((a, b) => a + b, 0) / rcrValues.length).toFixed(2));
-        rcrPaperCount = rcrValues.length;
-      }
-    }
+    // RCR (Relative Citation Ratio) from NIH iCite is not supported yet.
+    // iCite only accepts PMIDs, not DOIs, and there's no reliable batch DOI→PMID
+    // conversion available. RCR will be added when PMID mapping is implemented.
 
     return {
       fwci,
       meanCitedness,
       paperCount: allWorks.length,
-      rcrMean,
-      rcrPaperCount,
+      rcrMean: null,
+      rcrPaperCount: 0,
     };
   } catch (error) {
     console.warn('[OpenAlex] Error fetching field-normalized metrics:', error);


### PR DESCRIPTION
## Summary
- iCite API ignores `?dois=` param and returns random biomedical papers
- RCR was showing a bogus 1.3 for non-PubMed profiles
- Now shows "N/A" with "PubMed papers only" subtitle
- RCR tooltip explains it only covers PubMed-indexed publications

## Test plan
- [ ] Load marketing researcher profile — RCR should show N/A
- [ ] FWCI and Mean Journal Impact still display correctly