### PR TITLE
Semantic color accents, footer on all pages, 6-box landing grid

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,7 +54,7 @@ function SocialLinks() {
   );
 }
 
-function Footer({ onNavigate }: { onNavigate: (page: Page) => void }) {
+function Footer({ onNavigate, onSupport }: { onNavigate: (page: Page) => void; onSupport?: () => void }) {
   return (
     <footer className="bg-[#1e293b] text-white py-10 px-6">
       <div className="max-w-5xl mx-auto text-center">
@@ -96,6 +96,14 @@ function Footer({ onNavigate }: { onNavigate: (page: Page) => void }) {
           >
             LinkedIn <ExternalLink className="h-3 w-3" />
           </a>
+          {onSupport && (
+            <button
+              onClick={onSupport}
+              className="text-sm text-[#3d9494] hover:text-white transition-colors"
+            >
+              Support ScholarFolio
+            </button>
+          )}
         </div>
         <p className="text-xs text-white/40">
           &copy; 2025 Jonas Heller. Open source. Made with intent.
@@ -382,7 +390,7 @@ function AppContent() {
       <div className="flex-1">
         {renderPage()}
       </div>
-      {!(data && !error) && <Footer onNavigate={handleNavigate} />}
+      <Footer onNavigate={handleNavigate} onSupport={() => setShowCreditPacks(true)} />
       {showError && error && (
         <ErrorModal message={error} onClose={handleReset} />
       )}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { CheckCircle, Search, Network, BarChart, BookOpen, ArrowRight, Menu, X, ExternalLink, User, Link, BadgeCheck } from 'lucide-react';
+import { CheckCircle, Search, Network, BarChart, BookOpen, ArrowRight, Menu, X, ExternalLink, User, Link, BadgeCheck, Globe, Gauge, TrendingUp, Unlock } from 'lucide-react';
 import { SearchBar } from './SearchBar';
 import { ScholarSearchModal } from './ScholarSearchModal';
 import { Logo } from './Logo';
@@ -178,33 +178,61 @@ export function LandingPage({ onSearch, loading, error, onNavigate, authControls
             </p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {[
               {
                 icon: Link,
                 title: "Your Profile, Your URL",
-                description: "Claim a vanity URL like scholarfolio.org/your-name. Add it to your CV, email signature, or LinkedIn — a verified, always-up-to-date research page."
+                description: "Claim a vanity URL like scholarfolio.org/your-name. Add it to your CV, email signature, or LinkedIn.",
+                color: '#2d7d7d',
+                bg: '#eaf4f4',
               },
               {
                 icon: BarChart,
-                title: "Research Reach",
-                description: "How far your work has travelled — citations, growth trends, and the conversations your research has opened."
+                title: "Impact Metrics",
+                description: "h-index, g-index, i10, citation growth, Gini coefficient, and age-normalized rates — all computed automatically.",
+                color: '#b08d57',
+                bg: '#faf6ef',
               },
               {
-                icon: Network,
-                title: "Collaboration Network",
-                description: "Co-authorship visualization, collaboration patterns, and research network mapping."
-              }
+                icon: Gauge,
+                title: "Field-Normalized Impact",
+                description: "FWCI and Mean Journal Impact via OpenAlex. Compare your citation performance to the world average in your field.",
+                color: '#6b5b8a',
+                bg: '#f3f0f8',
+              },
+              {
+                icon: TrendingUp,
+                title: "Citation Trends",
+                description: "Year-by-year citation charts, cumulative growth, publication output, and momentum analysis.",
+                color: '#4a6fa5',
+                bg: '#eef3fa',
+              },
+              {
+                icon: Globe,
+                title: "Co-Author World Map",
+                description: "See where your collaborators are — an interactive map of co-author institutions across the globe.",
+                color: '#2d7d7d',
+                bg: '#eaf4f4',
+              },
+              {
+                icon: Unlock,
+                title: "Open Access Profile",
+                description: "Gold, green, hybrid, and bronze OA breakdown. See how accessible your research is to the world.",
+                color: '#4a8c6f',
+                bg: '#eef7f2',
+              },
             ].map((feature, index) => (
               <div
                 key={index}
-                className="scroll-reveal group relative bg-white rounded-2xl p-6 border border-gray-100 border-l-[3px] border-l-[#2d7d7d] shadow-card hover-lift"
+                className="scroll-reveal group relative bg-white rounded-2xl p-5 border border-gray-100 shadow-card hover-lift"
+                style={{ borderLeftWidth: '3px', borderLeftColor: feature.color }}
               >
-                <div className="inline-flex items-center justify-center w-10 h-10 rounded-xl bg-[#eaf4f4] mb-3">
-                  <feature.icon className="h-5 w-5 text-[#2d7d7d]" />
+                <div className="inline-flex items-center justify-center w-9 h-9 rounded-lg mb-2.5" style={{ backgroundColor: feature.bg }}>
+                  <feature.icon className="h-4 w-4" style={{ color: feature.color }} />
                 </div>
-                <h3 className="text-base font-semibold text-[#1e293b] mb-2">{feature.title}</h3>
-                <p className="text-sm text-[#64748b] leading-relaxed">{feature.description}</p>
+                <h3 className="text-sm font-semibold text-[#1e293b] mb-1.5">{feature.title}</h3>
+                <p className="text-xs text-[#64748b] leading-relaxed">{feature.description}</p>
               </div>
             ))}
           </div>

--- a/src/components/MetricsCard.tsx
+++ b/src/components/MetricsCard.tsx
@@ -187,10 +187,34 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
 
   const tooltipInfo = metricInfo[getMetricKey()];
 
+  const getIconGradient = () => {
+    switch (icon) {
+      // Impact / citation metrics → amber
+      case 'citations': case 'hIndex': case 'gIndex': case 'i10Index': case 'h5Index':
+      case 'avgCitationsPerPaper': case 'citationsPerYear': case 'peak': case 'acc5':
+      case 'ageNormalized': case 'halfLife': case 'gini':
+        return 'from-cat-impact-from to-cat-impact-to';
+      // Trend metrics → blue
+      case 'citationGrowth': case 'trend': case 'publications': case 'pubsPerYear':
+        return 'from-cat-trend-from to-cat-trend-to';
+      // Collaboration metrics → teal (brand)
+      case 'network': case 'coAuthors': case 'avgAuthors': case 'soloAuthor': case 'topCoAuthor':
+        return 'from-cat-collab-from to-cat-collab-to';
+      // Field-normalized → indigo
+      case 'fwci': case 'rcr': case 'meanIF':
+        return 'from-cat-field-from to-cat-field-to';
+      // Open access → green
+      case 'oaPercent': case 'goldOa': case 'greenOa': case 'hybridOa': case 'bronzeOa': case 'closedAccess':
+        return 'from-cat-oa-from to-cat-oa-to';
+      default:
+        return 'from-primary-start to-primary-end';
+    }
+  };
+
   const cardContent = (
     <div ref={countRef} className={`bg-white dark:bg-slate-800 p-3 rounded-xl border border-gray-100 dark:border-slate-700 shadow-card w-full transition-all duration-200 hover:shadow-card-hover hover:border-gray-200 dark:hover:border-slate-600 hover:scale-[1.02] ${tooltipInfo ? 'cursor-help' : ''}`}>
       <div className="flex items-start gap-2.5">
-        <div className="p-1.5 bg-gradient-to-br from-primary-start to-primary-end rounded-lg text-white mt-0.5 flex-shrink-0">
+        <div className={`p-1.5 bg-gradient-to-br ${getIconGradient()} rounded-lg text-white mt-0.5 flex-shrink-0`}>
           {getIcon()}
         </div>
         <div className="min-w-0 flex-1">

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -361,7 +361,7 @@ export function ProfileView({
         {activeTab === 'metrics' && (
           <div className="space-y-6">
             <div>
-              <h3 className="text-sm font-semibold text-gray-900 mb-3">Impact Metrics</h3>
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-cat-impact-from"></span>Impact Metrics</h3>
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
                 <MetricsCard title="Total Citations" value={data.totalCitations.toLocaleString()} icon="citations" />
                 <MetricsCard title="h-index" value={data.metrics.hIndex} icon="hIndex" />
@@ -401,7 +401,7 @@ export function ProfileView({
 
             {data.fieldMetrics && (data.fieldMetrics.fwci !== null || data.fieldMetrics.meanCitedness !== null || data.fieldMetrics.rcrMean !== null) && (
               <div>
-                <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Field-Normalized Metrics</h3>
+                <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-cat-field-from"></span>Field-Normalized Metrics</h3>
                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
                   {data.fieldMetrics.fwci !== null && (
                     <MetricsCard
@@ -430,7 +430,7 @@ export function ProfileView({
             )}
 
             <div>
-              <h3 className="text-sm font-semibold text-gray-900 mb-3">Collaboration Metrics</h3>
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-cat-collab-from"></span>Collaboration Metrics</h3>
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
                 <MetricsCard title="Co-authors" value={data.metrics.totalCoAuthors} icon="coAuthors" />
                 <MetricsCard title="Avg Authors/Paper" value={data.metrics.averageAuthors} icon="avgAuthors" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,6 +38,14 @@ export default {
           100: '#f1f5f9',
           200: '#e2e8f0',
         },
+        // Semantic category colors (muted, academic tone)
+        cat: {
+          impact: { from: '#b08d57', to: '#8b6f47' },       // warm amber/gold
+          collab: { from: '#2d7d7d', to: '#1f5c5c' },       // teal (brand)
+          trend: { from: '#4a6fa5', to: '#3a5a8a' },         // slate blue
+          field: { from: '#6b5b8a', to: '#554870' },         // muted indigo
+          oa: { from: '#4a8c6f', to: '#3a7059' },            // sage green
+        },
       },
       backgroundImage: {
         'gradient-primary': 'linear-gradient(135deg, #2d7d7d, #1f5c5c)',


### PR DESCRIPTION
## Summary
- Metric card icons use category-specific colors (amber/blue/teal/indigo/green)
- Section headers have matching color dot indicators
- Footer now visible on profile pages with "Support ScholarFolio" link
- Landing page expanded from 3 to 6 feature boxes in 2x3 responsive grid

## Test plan
- [ ] Check metric cards have distinct icon colors per category
- [ ] Verify footer shows on profile view pages
- [ ] Landing page shows 6 feature boxes in grid
- [ ] Dark mode still works