### PR TITLE
Fix OpenAlex author matching for FWCI and co-author map

### DIFF
--- a/src/services/openalex/coauthor-geo.ts
+++ b/src/services/openalex/coauthor-geo.ts
@@ -56,15 +56,23 @@ export async function fetchCoAuthorGeoData(
   // Step 1: Find the main author's OpenAlex ID and current institution
   const authorSearch = await fetchJson<{ results: Array<{
     id: string;
+    display_name: string;
     last_known_institutions?: Array<{
       id: string;
       display_name: string;
       country_code: string;
     }>;
   }> }>(
-    `${API_URL}/authors?search=${encodeURIComponent(authorName)}&per_page=1&select=id,last_known_institutions&mailto=${EMAIL}`
+    `${API_URL}/authors?search=${encodeURIComponent(authorName)}&per_page=10&select=id,display_name,last_known_institutions&mailto=${EMAIL}`
   );
-  const mainAuthorResult = authorSearch?.results?.[0];
+
+  // Prefer results whose display_name matches the search name
+  const nameLower = authorName.toLowerCase().trim();
+  const nameMatches = authorSearch?.results?.filter(r =>
+    r.display_name.toLowerCase().trim() === nameLower
+  );
+  const candidates = nameMatches?.length ? nameMatches : authorSearch?.results;
+  const mainAuthorResult = candidates?.[0];
   const mainAuthorOaId = mainAuthorResult?.id;
   if (!mainAuthorOaId) return { mainAuthor: null, coAuthors: [] };
 

--- a/src/services/openalex/field-metrics.ts
+++ b/src/services/openalex/field-metrics.ts
@@ -50,16 +50,23 @@ export async function fetchFieldNormalizedMetrics(
 ): Promise<FieldNormalizedMetrics | null> {
   try {
     // Step 1: Find author in OpenAlex
-    const authorSearch = await fetchJson<{ results: Array<{ id: string }> }>(
-      `${API_URL}/authors?search=${encodeURIComponent(authorName)}&per_page=5&select=id,last_known_institutions,affiliations&mailto=${EMAIL}`
+    const authorSearch = await fetchJson<{ results: Array<{ id: string; display_name: string }> }>(
+      `${API_URL}/authors?search=${encodeURIComponent(authorName)}&per_page=10&select=id,display_name,last_known_institutions,affiliations&mailto=${EMAIL}`
     );
     if (!authorSearch?.results?.length) return null;
 
-    // Try to match by affiliation
-    let authorId = authorSearch.results[0].id;
-    if (authorSearch.results.length > 1 && authorAffiliation) {
+    // First: filter to results whose display_name actually matches the search name
+    const nameLower = authorName.toLowerCase().trim();
+    const nameMatches = authorSearch.results.filter(r =>
+      r.display_name.toLowerCase().trim() === nameLower
+    );
+    const candidates = nameMatches.length > 0 ? nameMatches : authorSearch.results;
+
+    // Then try to match by affiliation among candidates
+    let authorId = candidates[0].id;
+    if (candidates.length > 1 && authorAffiliation) {
       const affLower = authorAffiliation.toLowerCase();
-      for (const result of authorSearch.results) {
+      for (const result of candidates) {
         const fullResult = await fetchJson<{
           id: string;
           last_known_institutions?: Array<{ display_name?: string }>;


### PR DESCRIPTION
## Summary
- OpenAlex search can return unrelated authors first (e.g. "B.F. Schutz" when searching "Albert Einstein")
- Now filters candidates by exact `display_name` match before falling back to affiliation matching
- Applied to both `field-metrics.ts` and `coauthor-geo.ts`
- Increased search from `per_page=1` to `per_page=10` in coauthor-geo

## Test plan
- [ ] Search Albert Einstein — FWCI should reflect his actual papers, not another physicist's
- [ ] Search common names — verify correct author is picked
- [ ] Verify existing profiles (e.g. own profile) still work correctly