### PR TITLE
Consolidate OpenAlex into shared cached author lookup

### DIFF
--- a/src/services/openalex/author-lookup.ts
+++ b/src/services/openalex/author-lookup.ts
@@ -1,0 +1,122 @@
+import { timeoutSignal } from '../../utils/api';
+import { RateLimiter } from '../scholar/rate-limiter';
+
+const API_URL = 'https://api.openalex.org';
+const EMAIL = 'scholarfolio@scholarfolio.org';
+export const OA_HEADERS = { 'User-Agent': `ScholarFolio/1.0 (mailto:${EMAIL})` };
+export const OA_EMAIL = EMAIL;
+export const OA_API_URL = API_URL;
+
+/** Shared rate limiter for all OpenAlex calls */
+export const oaRateLimiter = new RateLimiter(5000, 10);
+
+/** Generic JSON fetcher with rate limiting and timeout */
+export async function oaFetchJson<T>(url: string, timeoutMs = 15000): Promise<T | null> {
+  try {
+    await oaRateLimiter.acquireToken();
+    const response = await fetch(url, { headers: OA_HEADERS, signal: timeoutSignal(timeoutMs) });
+    if (!response.ok) return null;
+    return await response.json() as T;
+  } catch {
+    return null;
+  }
+}
+
+export interface OpenAlexAuthor {
+  id: string;
+  displayName: string;
+  orcid?: string;
+  lastKnownInstitutions: Array<{
+    id: string;
+    display_name: string;
+    country_code: string;
+  }>;
+}
+
+// In-memory cache: keyed by "name|affiliation", valid for the page session
+const authorCache = new Map<string, OpenAlexAuthor | null>();
+
+/**
+ * Single consolidated OpenAlex author lookup.
+ * 1. Searches by name (per_page=10)
+ * 2. Filters by display_name match
+ * 3. Refines by affiliation match
+ * 4. Fetches ORCID from full author record
+ * Results are cached per session so all 3 services share one lookup.
+ */
+export async function findOpenAlexAuthor(
+  name: string,
+  affiliation: string
+): Promise<OpenAlexAuthor | null> {
+  const cacheKey = `${name.toLowerCase().trim()}|${affiliation.toLowerCase().trim()}`;
+  if (authorCache.has(cacheKey)) return authorCache.get(cacheKey)!;
+
+  try {
+    const searchData = await oaFetchJson<{ results: Array<{
+      id: string;
+      display_name: string;
+      orcid?: string;
+      last_known_institutions?: Array<{
+        id: string;
+        display_name: string;
+        country_code: string;
+      }>;
+      affiliations?: Array<{ institution?: { display_name?: string } }>;
+    }> }>(
+      `${API_URL}/authors?search=${encodeURIComponent(name)}&per_page=10&select=id,display_name,orcid,last_known_institutions,affiliations&mailto=${EMAIL}`
+    );
+
+    const results = searchData?.results;
+    if (!results?.length) {
+      authorCache.set(cacheKey, null);
+      return null;
+    }
+
+    // Filter to results whose display_name matches the search name
+    const nameLower = name.toLowerCase().trim();
+    const nameMatches = results.filter(r =>
+      r.display_name.toLowerCase().trim() === nameLower
+    );
+    const candidates = nameMatches.length > 0 ? nameMatches : results;
+
+    // Try affiliation match among candidates
+    let best = candidates[0];
+    if (candidates.length > 1 && affiliation) {
+      const affLower = affiliation.toLowerCase();
+      for (const candidate of candidates) {
+        const lastInst = candidate.last_known_institutions?.[0]?.display_name?.toLowerCase() || '';
+        const allInsts = (candidate.affiliations || []).map(
+          (a: { institution?: { display_name?: string } }) => a.institution?.display_name?.toLowerCase() || ''
+        );
+        if ((lastInst && affLower.includes(lastInst)) ||
+            allInsts.some((inst: string) => inst && affLower.includes(inst))) {
+          best = candidate;
+          break;
+        }
+      }
+    }
+
+    // Fetch ORCID from full author record if not in search result
+    let orcid = best.orcid;
+    if (!orcid) {
+      const shortId = best.id.replace('https://openalex.org/', '');
+      const fullAuthor = await oaFetchJson<{ orcid?: string }>(
+        `${API_URL}/authors/${shortId}?select=orcid&mailto=${EMAIL}`
+      );
+      orcid = fullAuthor?.orcid || undefined;
+    }
+
+    const author: OpenAlexAuthor = {
+      id: best.id,
+      displayName: best.display_name,
+      orcid: orcid?.replace('https://orcid.org/', ''),
+      lastKnownInstitutions: best.last_known_institutions || [],
+    };
+
+    authorCache.set(cacheKey, author);
+    return author;
+  } catch {
+    authorCache.set(cacheKey, null);
+    return null;
+  }
+}

--- a/src/services/openalex/coauthor-geo.ts
+++ b/src/services/openalex/coauthor-geo.ts
@@ -1,28 +1,5 @@
 import type { Publication, CoAuthorGeoData } from '../../types/scholar';
-import { RateLimiter } from '../scholar/rate-limiter';
-import { timeoutSignal } from '../../utils/api';
-
-const API_URL = 'https://api.openalex.org';
-const EMAIL = 'scholarfolio@scholarfolio.org';
-
-const geoRateLimiter = new RateLimiter(5000, 10);
-const HEADERS = {
-  'User-Agent': `ScholarFolio/1.0 (mailto:${EMAIL})`
-};
-
-async function fetchJson<T>(url: string): Promise<T | null> {
-  try {
-    await geoRateLimiter.acquireToken();
-    const response = await fetch(url, {
-      headers: HEADERS,
-      signal: timeoutSignal(10000)
-    });
-    if (!response.ok) return null;
-    return await response.json() as T;
-  } catch {
-    return null;
-  }
-}
+import { findOpenAlexAuthor, oaFetchJson, OA_API_URL, OA_EMAIL } from './author-lookup';
 
 interface WorkAuthorship {
   author: { id: string; display_name: string };
@@ -43,50 +20,30 @@ interface InstitutionResult {
 
 /**
  * Fetches co-author geo data using a works-based approach:
- * 1. Find main author's OpenAlex ID
- * 2. Fetch all their works → extract co-author IDs + institution IDs (already disambiguated)
+ * 1. Find main author's OpenAlex ID (shared cached lookup)
+ * 2. Fetch all their works -> extract co-author IDs + institution IDs
  * 3. Match co-authors to publication names from ScholarFolio data
  * 4. Batch-fetch institution geo for unique institution IDs
  */
 export async function fetchCoAuthorGeoData(
   authorName: string,
-  _authorAffiliation: string,
+  authorAffiliation: string,
   publications: Publication[]
 ): Promise<{ mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] }> {
-  // Step 1: Find the main author's OpenAlex ID and current institution
-  const authorSearch = await fetchJson<{ results: Array<{
-    id: string;
-    display_name: string;
-    last_known_institutions?: Array<{
-      id: string;
-      display_name: string;
-      country_code: string;
-    }>;
-  }> }>(
-    `${API_URL}/authors?search=${encodeURIComponent(authorName)}&per_page=10&select=id,display_name,last_known_institutions&mailto=${EMAIL}`
-  );
+  // Use shared author lookup (cached across services)
+  const author = await findOpenAlexAuthor(authorName, authorAffiliation);
+  if (!author) return { mainAuthor: null, coAuthors: [] };
 
-  // Prefer results whose display_name matches the search name
-  const nameLower = authorName.toLowerCase().trim();
-  const nameMatches = authorSearch?.results?.filter(r =>
-    r.display_name.toLowerCase().trim() === nameLower
-  );
-  const candidates = nameMatches?.length ? nameMatches : authorSearch?.results;
-  const mainAuthorResult = candidates?.[0];
-  const mainAuthorOaId = mainAuthorResult?.id;
-  if (!mainAuthorOaId) return { mainAuthor: null, coAuthors: [] };
-
-  // Use last_known_institutions for the main author's CURRENT affiliation
-  const mainCurrentInst = mainAuthorResult?.last_known_institutions?.[0];
-
+  const mainAuthorOaId = author.id;
+  const mainCurrentInst = author.lastKnownInstitutions[0];
   const shortId = mainAuthorOaId.replace('https://openalex.org/', '');
 
   // Step 2: Fetch works with authorships (paginated, up to 200 per page)
   const allAuthorships: WorkAuthorship[] = [];
   let page = 1;
   while (page <= 5) {
-    const worksData = await fetchJson<{ results: WorkResult[] }>(
-      `${API_URL}/works?filter=authorships.author.id:${shortId}&per_page=200&page=${page}&select=authorships&mailto=${EMAIL}`
+    const worksData = await oaFetchJson<{ results: WorkResult[] }>(
+      `${OA_API_URL}/works?filter=authorships.author.id:${shortId}&per_page=200&page=${page}&select=authorships&mailto=${OA_EMAIL}`
     );
     if (!worksData?.results?.length) break;
     for (const work of worksData.results) {
@@ -97,7 +54,6 @@ export async function fetchCoAuthorGeoData(
   }
 
   // Step 3: Build co-author map with their most recent institution
-  // Match OpenAlex names to ScholarFolio publication names
   const normalize = (name: string) => name.toLowerCase().trim();
   const getLastName = (name: string) => {
     const parts = name.split(/\s+/);
@@ -132,7 +88,6 @@ export async function fetchCoAuthorGeoData(
   }
 
   // From OpenAlex authorships, collect unique co-authors with their institution
-  // Use author ID to deduplicate, pick most frequent institution
   interface CoAuthorInfo {
     oaId: string;
     displayName: string;
@@ -145,7 +100,6 @@ export async function fetchCoAuthorGeoData(
   const coAuthorInstitutions = new Map<string, CoAuthorInfo>();
   const mainNameLower = authorName.toLowerCase().trim();
   for (const authorship of allAuthorships) {
-    // Skip the main author — by ID and by name (handles duplicate OA profiles)
     if (authorship.author.id === mainAuthorOaId) continue;
     if (authorship.author.display_name.toLowerCase().trim() === mainNameLower) continue;
     const inst = authorship.institutions[0];
@@ -176,11 +130,9 @@ export async function fetchCoAuthorGeoData(
   const matched: MatchedCoAuthor[] = [];
   const usedOaIds = new Set<string>();
 
-  // Helper: extract all name tokens for fuzzy matching
   const getNameTokens = (name: string) => new Set(normalize(name).split(/\s+/).filter(t => t.length > 1));
 
   for (const [sfName, stats] of coAuthorStats) {
-    // Try exact match first, then last-name match, then token overlap
     let bestMatch: CoAuthorInfo | null = null;
     for (const info of coAuthorInstitutions.values()) {
       if (usedOaIds.has(info.oaId)) continue;
@@ -199,7 +151,6 @@ export async function fetchCoAuthorGeoData(
         }
       }
     }
-    // Fallback: token overlap (handles reordered compound names like "Easthope Awai" vs "Awai Easthope")
     if (!bestMatch) {
       const sfTokens = getNameTokens(sfName);
       let bestOverlap = 0;
@@ -219,11 +170,10 @@ export async function fetchCoAuthorGeoData(
     }
   }
 
-  // Sort by shared papers and take top 20
+  // Sort by shared papers and take top 50
   matched.sort((a, b) => b.papers - a.papers);
   const top50 = matched.slice(0, 50);
 
-  // Use the main author's current institution from their profile
   const mainInstitutionId = mainCurrentInst?.id ?? null;
   const mainInstitutionName = mainCurrentInst?.display_name ?? null;
   const mainCountryCode = mainCurrentInst?.country_code ?? null;
@@ -238,8 +188,8 @@ export async function fetchCoAuthorGeoData(
   const geoCache = new Map<string, { lat: number; lng: number }>();
   const geoPromises = [...uniqueInstIds].map(async instId => {
     const sid = instId.replace('https://openalex.org/', '');
-    const data = await fetchJson<InstitutionResult>(
-      `${API_URL}/institutions/${sid}?select=geo&mailto=${EMAIL}`
+    const data = await oaFetchJson<InstitutionResult>(
+      `${OA_API_URL}/institutions/${sid}?select=geo&mailto=${OA_EMAIL}`
     );
     if (data?.geo?.latitude != null && data?.geo?.longitude != null) {
       geoCache.set(instId, { lat: data.geo.latitude, lng: data.geo.longitude });
@@ -248,11 +198,11 @@ export async function fetchCoAuthorGeoData(
   await Promise.all(geoPromises);
 
   // Build results
-  let mainAuthor: CoAuthorGeoData | null = null;
+  let mainAuthorGeo: CoAuthorGeoData | null = null;
   if (mainInstitutionId && mainInstitutionName && mainCountryCode) {
     const geo = geoCache.get(mainInstitutionId);
     if (geo) {
-      mainAuthor = {
+      mainAuthorGeo = {
         name: authorName,
         institution: mainInstitutionName,
         countryCode: mainCountryCode,
@@ -279,5 +229,5 @@ export async function fetchCoAuthorGeoData(
     });
   }
 
-  return { mainAuthor, coAuthors };
+  return { mainAuthor: mainAuthorGeo, coAuthors };
 }

--- a/src/services/openalex/field-metrics.ts
+++ b/src/services/openalex/field-metrics.ts
@@ -1,30 +1,7 @@
-import { timeoutSignal } from '../../utils/api';
-import { RateLimiter } from '../scholar/rate-limiter';
+import { findOpenAlexAuthor, oaFetchJson, OA_API_URL, OA_EMAIL } from './author-lookup';
+import type { FieldNormalizedMetrics } from '../../types/scholar';
 
-const API_URL = 'https://api.openalex.org';
-const EMAIL = 'scholarfolio@scholarfolio.org';
-const HEADERS = { 'User-Agent': `ScholarFolio/1.0 (mailto:${EMAIL})` };
-
-const metricsRateLimiter = new RateLimiter(5000, 10);
-
-async function fetchJson<T>(url: string): Promise<T | null> {
-  try {
-    await metricsRateLimiter.acquireToken();
-    const response = await fetch(url, { headers: HEADERS, signal: timeoutSignal(15000) });
-    if (!response.ok) return null;
-    return await response.json() as T;
-  } catch {
-    return null;
-  }
-}
-
-export interface FieldNormalizedMetrics {
-  fwci: number | null;
-  meanCitedness: number | null;
-  paperCount: number;
-  rcrMean: number | null;
-  rcrPaperCount: number;
-}
+export type { FieldNormalizedMetrics };
 
 interface OpenAlexWork {
   doi?: string;
@@ -42,51 +19,23 @@ interface OpenAlexWork {
  * Fetches field-normalized metrics for an author from OpenAlex:
  * - FWCI-like: average citation percentile across papers
  * - Mean journal citedness (proxy for mean IF)
- * Then enriches with RCR from NIH iCite for papers with DOIs.
  */
 export async function fetchFieldNormalizedMetrics(
   authorName: string,
   authorAffiliation: string
 ): Promise<FieldNormalizedMetrics | null> {
   try {
-    // Step 1: Find author in OpenAlex
-    const authorSearch = await fetchJson<{ results: Array<{ id: string; display_name: string }> }>(
-      `${API_URL}/authors?search=${encodeURIComponent(authorName)}&per_page=10&select=id,display_name,last_known_institutions,affiliations&mailto=${EMAIL}`
-    );
-    if (!authorSearch?.results?.length) return null;
+    const author = await findOpenAlexAuthor(authorName, authorAffiliation);
+    if (!author) return null;
 
-    // First: filter to results whose display_name actually matches the search name
-    const nameLower = authorName.toLowerCase().trim();
-    const nameMatches = authorSearch.results.filter(r =>
-      r.display_name.toLowerCase().trim() === nameLower
-    );
-    const candidates = nameMatches.length > 0 ? nameMatches : authorSearch.results;
+    const shortId = author.id.replace('https://openalex.org/', '');
 
-    // Then try to match by affiliation among candidates
-    let authorId = candidates[0].id;
-    if (candidates.length > 1 && authorAffiliation) {
-      const affLower = authorAffiliation.toLowerCase();
-      for (const result of candidates) {
-        const fullResult = await fetchJson<{
-          id: string;
-          last_known_institutions?: Array<{ display_name?: string }>;
-        }>(`${API_URL}/authors/${result.id.replace('https://openalex.org/', '')}?select=id,last_known_institutions&mailto=${EMAIL}`);
-        const inst = fullResult?.last_known_institutions?.[0]?.display_name?.toLowerCase() || '';
-        if (inst && affLower.includes(inst)) {
-          authorId = result.id;
-          break;
-        }
-      }
-    }
-
-    const shortId = authorId.replace('https://openalex.org/', '');
-
-    // Step 2: Fetch works with citation percentiles and source stats
+    // Fetch works with citation percentiles and source stats
     const allWorks: OpenAlexWork[] = [];
     let page = 1;
     while (page <= 5) {
-      const data = await fetchJson<{ results: OpenAlexWork[] }>(
-        `${API_URL}/works?filter=authorships.author.id:${shortId}&per_page=200&page=${page}&select=doi,cited_by_count,cited_by_percentile_year,primary_location&mailto=${EMAIL}`
+      const data = await oaFetchJson<{ results: OpenAlexWork[] }>(
+        `${OA_API_URL}/works?filter=authorships.author.id:${shortId}&per_page=200&page=${page}&select=doi,cited_by_count,cited_by_percentile_year,primary_location&mailto=${OA_EMAIL}`
       );
       if (!data?.results?.length) break;
       allWorks.push(...data.results);
@@ -96,7 +45,8 @@ export async function fetchFieldNormalizedMetrics(
 
     if (allWorks.length === 0) return null;
 
-    // Step 3: Calculate FWCI-like metric (average citation percentile)
+    // FWCI-like metric (average citation percentile / 50)
+    // 50th percentile = 1.0 (world average), >1.0 = above average
     const percentiles: number[] = [];
     for (const work of allWorks) {
       const pct = work.cited_by_percentile_year?.min;
@@ -105,9 +55,8 @@ export async function fetchFieldNormalizedMetrics(
     const fwci = percentiles.length > 0
       ? Number((percentiles.reduce((a, b) => a + b, 0) / percentiles.length / 50).toFixed(2))
       : null;
-    // Dividing by 50 normalizes: 50th percentile = 1.0 (world average), >1.0 = above average
 
-    // Step 4: Calculate mean journal citedness (proxy for mean IF)
+    // Mean journal citedness (proxy for mean IF)
     const citednessValues: number[] = [];
     for (const work of allWorks) {
       const citedness = work.primary_location?.source?.summary_stats?.['2yr_mean_citedness'];
@@ -116,10 +65,6 @@ export async function fetchFieldNormalizedMetrics(
     const meanCitedness = citednessValues.length > 0
       ? Number((citednessValues.reduce((a, b) => a + b, 0) / citednessValues.length).toFixed(2))
       : null;
-
-    // RCR (Relative Citation Ratio) from NIH iCite is not supported yet.
-    // iCite only accepts PMIDs, not DOIs, and there's no reliable batch DOI→PMID
-    // conversion available. RCR will be added when PMID mapping is implemented.
 
     return {
       fwci,

--- a/src/services/openalex/index.ts
+++ b/src/services/openalex/index.ts
@@ -1,30 +1,24 @@
-import { ApiError, timeoutSignal } from '../../utils/api';
+import { timeoutSignal } from '../../utils/api';
 import type { JournalRanking, OpenAccessStats, OaStatus } from '../../types/scholar';
-import { rateLimiter } from '../scholar/rate-limiter';
+import { findOpenAlexAuthor, oaFetchJson, oaRateLimiter, OA_HEADERS, OA_API_URL, OA_EMAIL } from './author-lookup';
 
 export class OpenAlexService {
-  private readonly API_URL = 'https://api.openalex.org';
-  private readonly EMAIL = 'scholarfolio@scholarfolio.org';
-
-  private readonly headers = {
-    'User-Agent': `ScholarFolio/1.0 (mailto:${this.EMAIL})`
-  };
-
   /**
    * Search OpenAlex for an author by name + affiliation, return OA stats.
    * Non-blocking — returns null on any failure.
    */
   public async fetchOpenAccessStats(name: string, affiliation: string): Promise<OpenAccessStats | null> {
     try {
-      // Step 1: Find the author in OpenAlex
-      const authorId = await this.findAuthorId(name, affiliation);
-      if (!authorId) return null;
+      // Use shared author lookup (cached across services)
+      const author = await findOpenAlexAuthor(name, affiliation);
+      if (!author) return null;
+      const authorId = author.id;
 
-      // Step 2: Get works grouped by OA status
-      await rateLimiter.acquireToken();
-      const worksUrl = `${this.API_URL}/works?filter=authorships.author.id:${authorId}&group_by=open_access.oa_status&per_page=10&mailto=${this.EMAIL}`;
+      // Get works grouped by OA status
+      await oaRateLimiter.acquireToken();
+      const worksUrl = `${OA_API_URL}/works?filter=authorships.author.id:${authorId}&group_by=open_access.oa_status&per_page=10&mailto=${OA_EMAIL}`;
       const worksResponse = await fetch(worksUrl, {
-        headers: this.headers,
+        headers: OA_HEADERS,
         signal: timeoutSignal(10000)
       });
 
@@ -47,29 +41,18 @@ export class OpenAlexService {
       const closed = groups['closed'] || 0;
       const oa = gold + green + hybrid + bronze;
 
-      // Step 3: Get ORCID from author record
-      await rateLimiter.acquireToken();
-      const authorResponse = await fetch(`${this.API_URL}/authors/${authorId}?mailto=${this.EMAIL}`, {
-        headers: this.headers,
-        signal: timeoutSignal(10000)
-      });
-      let orcid: string | undefined;
-      if (authorResponse.ok) {
-        const authorData = await authorResponse.json();
-        if (authorData.orcid) {
-          orcid = authorData.orcid.replace('https://orcid.org/', '');
-        }
-      }
+      // ORCID is already fetched by shared author lookup
+      const orcid = author.orcid;
 
-      // Step 4: Fetch per-publication OA status (paginated, up to 200 works per page)
+      // Fetch per-publication OA status (paginated, up to 200 works per page)
       const publicationOa: Record<string, { status: OaStatus; oaUrl?: string }> = {};
       let page = 1;
-      const maxPages = 10; // Up to 2000 works
+      const maxPages = 10;
       while (page <= maxPages) {
-        await rateLimiter.acquireToken();
-        const pubsUrl = `${this.API_URL}/works?filter=authorships.author.id:${authorId}&select=title,open_access,publication_year&per_page=200&page=${page}&mailto=${this.EMAIL}`;
+        await oaRateLimiter.acquireToken();
+        const pubsUrl = `${OA_API_URL}/works?filter=authorships.author.id:${authorId}&select=title,open_access,publication_year&per_page=200&page=${page}&mailto=${OA_EMAIL}`;
         const pubsResponse = await fetch(pubsUrl, {
-          headers: this.headers,
+          headers: OA_HEADERS,
           signal: timeoutSignal(15000)
         });
         if (!pubsResponse.ok) break;
@@ -110,53 +93,12 @@ export class OpenAlexService {
     }
   }
 
-  private async findAuthorId(name: string, affiliation: string): Promise<string | null> {
-    await rateLimiter.acquireToken();
-
-    // Search by name, optionally filtered by institution
-    let searchUrl = `${this.API_URL}/authors?search=${encodeURIComponent(name)}&per_page=5&mailto=${this.EMAIL}`;
-
-    const response = await fetch(searchUrl, {
-      headers: this.headers,
-      signal: timeoutSignal(10000)
-    });
-
-    if (!response.ok) return null;
-    const data = await response.json();
-    const results = data.results || [];
-
-    if (results.length === 0) return null;
-    if (results.length === 1) return results[0].id;
-
-    // Multiple results — try to match by affiliation
-    const affiliationLower = affiliation.toLowerCase();
-    for (const author of results) {
-      const lastInstitution = author.last_known_institutions?.[0]?.display_name?.toLowerCase() || '';
-      const allInstitutions = (author.affiliations || []).map((a: any) => a.institution?.display_name?.toLowerCase() || '');
-      if (lastInstitution && affiliationLower.includes(lastInstitution)) return author.id;
-      if (allInstitutions.some((inst: string) => inst && affiliationLower.includes(inst))) return author.id;
-    }
-
-    // No affiliation match — return top result (OpenAlex ranks by relevance)
-    return results[0].id;
-  }
-
   public async getJournalMetrics(issn: string): Promise<JournalRanking | null> {
-    await rateLimiter.acquireToken();
-
     try {
-      const response = await fetch(
-        `${this.API_URL}/venues?filter=issn:${issn}`,
-        { headers: this.headers }
+      const data = await oaFetchJson<{ results?: Array<{ x_concepts?: Array<{ score?: number }>; impact_factor?: number }> }>(
+        `${OA_API_URL}/venues?filter=issn:${issn}`
       );
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const data = await response.json();
-      const venue = data.results?.[0];
-      
+      const venue = data?.results?.[0];
       if (!venue) return null;
 
       return {
@@ -171,21 +113,11 @@ export class OpenAlexService {
   }
 
   public async searchJournal(name: string): Promise<JournalRanking | null> {
-    await rateLimiter.acquireToken();
-
     try {
-      const response = await fetch(
-        `${this.API_URL}/venues?search=${encodeURIComponent(name)}&per-page=1`,
-        { headers: this.headers }
+      const data = await oaFetchJson<{ results?: Array<{ x_concepts?: Array<{ score?: number }>; impact_factor?: number }> }>(
+        `${OA_API_URL}/venues?search=${encodeURIComponent(name)}&per-page=1`
       );
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const data = await response.json();
-      const venue = data.results?.[0];
-      
+      const venue = data?.results?.[0];
       if (!venue) return null;
 
       return {


### PR DESCRIPTION
## Summary
- Create `author-lookup.ts` — single cached `findOpenAlexAuthor()` used by all 3 OpenAlex services
- Eliminates 3 separate author searches per profile load → 1 cached lookup
- Shared rate limiter (`oaRateLimiter`) replaces 3 independent rate limiters
- Fixes name-matching bug in OA stats service (was missing `display_name` filter, same Einstein bug)
- ORCID fetched once in shared lookup, not separately in OA stats
- Removes duplicate `FieldNormalizedMetrics` interface

**Before:** 3 author searches + 3 rate limiters + inconsistent name matching
**After:** 1 cached author search + 1 rate limiter + consistent name matching

## Test plan
- [ ] Load any profile — verify OA stats, field metrics, and world map all still work
- [ ] Load Albert Einstein — verify correct author is matched across all services
- [ ] Load a second profile — verify cache doesn't leak between different authors
- [ ] Check ORCID still appears on profiles that have one