### PR TITLE
Prefetch world map data on profile load

### DIFF
--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -11,6 +11,7 @@ interface CoAuthorMapProps {
   publications: Publication[];
   authorName: string;
   authorAffiliation: string;
+  prefetchedData?: { mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null;
 }
 
 interface TooltipState {
@@ -65,7 +66,7 @@ const REGION_VIEWS = [
   { id: 'oceania', label: 'Oceania', center: [145, -25] as [number, number], scale: 4 },
 ];
 
-export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoAuthorMapProps) {
+export function CoAuthorMap({ publications, authorName, authorAffiliation, prefetchedData }: CoAuthorMapProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const zoomRef = useRef<d3.ZoomBehavior<SVGSVGElement, unknown> | null>(null);
@@ -76,8 +77,13 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
   const [mapError, setMapError] = useState(false);
   const [activeRegion, setActiveRegion] = useState('world');
 
-  // Fetch geo data on mount
+  // Use prefetched data if available, otherwise fetch on mount
   useEffect(() => {
+    if (prefetchedData) {
+      setGeoData(prefetchedData);
+      setLoading(false);
+      return;
+    }
     let cancelled = false;
     setLoading(true);
     fetchCoAuthorGeoData(authorName, authorAffiliation, publications).then(result => {
@@ -87,7 +93,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation }: CoA
       }
     });
     return () => { cancelled = true; };
-  }, [authorName, authorAffiliation, publications]);
+  }, [authorName, authorAffiliation, publications, prefetchedData]);
 
   const zoomToRegion = useCallback((regionId: string) => {
     const svg = svgRef.current;

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -15,7 +15,8 @@ import { ResearcherNarrative } from './ResearcherNarrative';
 import { Logo } from './Logo';
 import { useAuth } from '../contexts/AuthContext';
 import { supabase } from '../lib/supabase';
-import type { Author } from '../types/scholar';
+import type { Author, CoAuthorGeoData } from '../types/scholar';
+import { fetchCoAuthorGeoData } from '../services/openalex/coauthor-geo';
 import { extractLastName } from '../utils/names';
 import packageJson from '../../package.json';
 
@@ -79,6 +80,17 @@ export function ProfileView({
   }, [updateIndicator]);
   const [claimedSlug, setClaimedSlug] = useState<string | null>(null);
   const [claimedByCurrentUser, setClaimedByCurrentUser] = useState(false);
+  const [prefetchedGeo, setPrefetchedGeo] = useState<{ mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null>(null);
+
+  // Prefetch co-author geo data as soon as profile loads (don't wait for tab click)
+  useEffect(() => {
+    if (!data) { setPrefetchedGeo(null); return; }
+    let cancelled = false;
+    fetchCoAuthorGeoData(data.name, data.affiliation, data.publications).then(result => {
+      if (!cancelled) setPrefetchedGeo(result);
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [data?.name, data?.affiliation, data?.publications]);
 
   // Extract scholar ID from URL params or profileUrl
   const scholarId = new URLSearchParams(window.location.search).get('user')
@@ -465,6 +477,7 @@ export function ProfileView({
             publications={data.publications}
             authorName={data.name}
             authorAffiliation={data.affiliation}
+            prefetchedData={prefetchedGeo}
           />
         )}
 


### PR DESCRIPTION
## Summary
- Start geo data fetch immediately when a profile loads (in ProfileView)
- Pass prefetched result to CoAuthorMap via prop
- World Map tab now renders instantly instead of showing a loading spinner
- Falls back to self-fetch if prefetched data isn't available yet

## Test plan
- [ ] Load a profile — world map tab should show data immediately without spinner
- [ ] Verify other tabs still work normally