### PR TITLE
Add P-Index (thought leadership metric)

### DIFF
--- a/src/components/MetricsCard.tsx
+++ b/src/components/MetricsCard.tsx
@@ -39,7 +39,8 @@ interface MetricsCardProps {
         'sIndex' | 'rcr' | 'pubsPerYear' | 'network' | 'coAuthors' | 'avgAuthors' | 'soloAuthor' |
         'h5Index' | 'acc5' | 'citationsPerYear' | 'topCoAuthor' | 'avgCitationsPerPaper' |
         'citationGrowth' | 'peak' | 'trend' | 'fwci' | 'halfLife' | 'gini' | 'ageNormalized' |
-        'oaPercent' | 'goldOa' | 'greenOa' | 'hybridOa' | 'bronzeOa' | 'closedAccess' | 'meanIF';
+        'oaPercent' | 'goldOa' | 'greenOa' | 'hybridOa' | 'bronzeOa' | 'closedAccess' | 'meanIF' |
+        'pindex' | 'owpi';
 }
 
 function useCountUp(target: number | string, duration = 600) {
@@ -134,6 +135,10 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
       case 'sIndex': return <Zap className="h-3.5 w-3.5" />;
       case 'hpIndex': return <Award className="h-3.5 w-3.5" />;
 
+      // P-Index metrics
+      case 'pindex': return <Award className="h-3.5 w-3.5" />;
+      case 'owpi': return <Scale className="h-3.5 w-3.5" />;
+
       // Open Access metrics
       case 'oaPercent': return <Unlock className="h-3.5 w-3.5" />;
       case 'goldOa': return <Unlock className="h-3.5 w-3.5" />;
@@ -181,6 +186,8 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
       case 'hybridOa': return 'hybridOa';
       case 'bronzeOa': return 'bronzeOa';
       case 'closedAccess': return 'closedAccess';
+      case 'pindex': return 'pindex';
+      case 'owpi': return 'owpi';
       default: return 'citations';
     }
   };
@@ -200,6 +207,9 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
       // Collaboration metrics → teal (brand)
       case 'network': case 'coAuthors': case 'avgAuthors': case 'soloAuthor': case 'topCoAuthor':
         return 'from-cat-collab-from to-cat-collab-to';
+      // P-Index → violet
+      case 'pindex': case 'owpi':
+        return 'from-violet-500 to-purple-600';
       // Field-normalized → indigo
       case 'fwci': case 'rcr': case 'meanIF':
         return 'from-cat-field-from to-cat-field-to';

--- a/src/components/PIndexSection.tsx
+++ b/src/components/PIndexSection.tsx
@@ -1,0 +1,317 @@
+import React, { useState, useCallback } from 'react';
+import { Search, Loader2, CheckCircle, AlertTriangle, ChevronDown, ChevronUp, Info } from 'lucide-react';
+import { oaFetchJson, OA_API_URL, OA_EMAIL } from '../services/openalex/author-lookup';
+import { computePIndex, type PIndexResult } from '../services/openalex/pindex';
+import { MetricsCard } from './MetricsCard';
+
+interface OpenAlexSearchResult {
+  id: string;
+  display_name: string;
+  works_count: number;
+  cited_by_count: number;
+  last_known_institutions?: Array<{ display_name?: string }>;
+}
+
+interface PIndexSectionProps {
+  authorName: string;
+  affiliation: string;
+}
+
+export function PIndexSection({ authorName, affiliation }: PIndexSectionProps) {
+  const [step, setStep] = useState<'idle' | 'searching' | 'select' | 'computing' | 'done' | 'error'>('idle');
+  const [searchResults, setSearchResults] = useState<OpenAlexSearchResult[]>([]);
+  const [selectedAuthor, setSelectedAuthor] = useState<OpenAlexSearchResult | null>(null);
+  const [result, setResult] = useState<PIndexResult | null>(null);
+  const [progress, setProgress] = useState({ pct: 0, status: '' });
+  const [errorMsg, setErrorMsg] = useState('');
+  const [showDetails, setShowDetails] = useState(false);
+
+  // Search fields — pre-filled from the profile
+  const nameParts = authorName.split(' ');
+  const [firstName, setFirstName] = useState(nameParts.slice(0, -1).join(' '));
+  const [lastName, setLastName] = useState(nameParts[nameParts.length - 1] || '');
+  const [institution, setInstitution] = useState(
+    affiliation.replace(/,.*$/, '').replace(/^(Assistant|Associate|Full)?\s*Professor.*?,\s*/i, '').trim()
+  );
+
+  const handleSearch = useCallback(async () => {
+    if (!firstName.trim() || !lastName.trim()) return;
+    setStep('searching');
+    setErrorMsg('');
+
+    const query = `${firstName} ${lastName}`;
+    const data = await oaFetchJson<{ results: OpenAlexSearchResult[] }>(
+      `${OA_API_URL}/authors?search=${encodeURIComponent(query)}&per_page=10&select=id,display_name,works_count,cited_by_count,last_known_institutions&mailto=${OA_EMAIL}`
+    );
+
+    if (!data?.results?.length) {
+      setErrorMsg('No authors found in OpenAlex. Try adjusting the name.');
+      setStep('error');
+      return;
+    }
+
+    setSearchResults(data.results);
+    setStep('select');
+  }, [firstName, lastName]);
+
+  const handleSelect = useCallback(async (author: OpenAlexSearchResult) => {
+    setSelectedAuthor(author);
+    setStep('computing');
+    setProgress({ pct: 0, status: 'Starting…' });
+
+    try {
+      const pIndex = await computePIndex(author.id, (pct, status) => {
+        setProgress({ pct, status });
+      });
+
+      if (pIndex) {
+        setResult(pIndex);
+        setStep('done');
+      } else {
+        setErrorMsg('Could not compute p-index. No publications with journal data found.');
+        setStep('error');
+      }
+    } catch {
+      setErrorMsg('Calculation failed. Please try again later.');
+      setStep('error');
+    }
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setStep('idle');
+    setResult(null);
+    setSelectedAuthor(null);
+    setSearchResults([]);
+    setErrorMsg('');
+    setProgress({ pct: 0, status: '' });
+  }, []);
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2">
+        <span className="w-1.5 h-1.5 rounded-full bg-violet-500"></span>
+        P-Index
+        <span className="text-[10px] font-normal text-gray-400 dark:text-gray-500">(Pham, Wu &amp; Wang, 2024)</span>
+      </h3>
+
+      {/* Info banner */}
+      {step === 'idle' && (
+        <div className="bg-violet-50 dark:bg-violet-950/30 border border-violet-200 dark:border-violet-800 rounded-xl p-4 mb-3">
+          <div className="flex gap-3">
+            <Info className="h-4 w-4 text-violet-500 mt-0.5 flex-shrink-0" />
+            <div className="text-xs text-violet-700 dark:text-violet-300 space-y-2">
+              <p>
+                The <strong>p-index</strong> measures where your papers rank in citation percentile
+                <em> within their own journal and publication year</em>. It indicates thought leadership
+                independent of field or career stage.
+              </p>
+              <p className="text-violet-500 dark:text-violet-400">
+                This uses OpenAlex data, which may differ from Google Scholar or Web of Science.
+                Calculation takes 10–30 seconds as it analyzes citation distributions for each journal-year.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-4 space-y-2">
+            <p className="text-[11px] font-medium text-violet-600 dark:text-violet-400">Confirm your details to calculate:</p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              <input
+                type="text"
+                value={firstName}
+                onChange={e => setFirstName(e.target.value)}
+                placeholder="First name"
+                className="px-3 py-1.5 text-xs rounded-lg border border-violet-200 dark:border-violet-700 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-400"
+              />
+              <input
+                type="text"
+                value={lastName}
+                onChange={e => setLastName(e.target.value)}
+                placeholder="Last name"
+                className="px-3 py-1.5 text-xs rounded-lg border border-violet-200 dark:border-violet-700 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-400"
+              />
+              <input
+                type="text"
+                value={institution}
+                onChange={e => setInstitution(e.target.value)}
+                placeholder="Institution (optional)"
+                className="px-3 py-1.5 text-xs rounded-lg border border-violet-200 dark:border-violet-700 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-400"
+              />
+            </div>
+            <button
+              onClick={handleSearch}
+              disabled={!firstName.trim() || !lastName.trim()}
+              className="mt-1 flex items-center gap-1.5 px-4 py-1.5 text-xs font-medium text-white bg-violet-600 hover:bg-violet-700 disabled:bg-gray-300 disabled:cursor-not-allowed rounded-lg transition-colors"
+            >
+              <Search className="h-3 w-3" />
+              Find Author in OpenAlex
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Searching spinner */}
+      {step === 'searching' && (
+        <div className="flex items-center gap-2 text-xs text-gray-500 py-4">
+          <Loader2 className="h-4 w-4 animate-spin text-violet-500" />
+          Searching OpenAlex…
+        </div>
+      )}
+
+      {/* Author selection */}
+      {step === 'select' && (
+        <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 mb-3">
+          <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-3">
+            Select your profile from OpenAlex:
+          </p>
+          <div className="space-y-1.5 max-h-64 overflow-y-auto">
+            {searchResults.map(author => {
+              const inst = author.last_known_institutions?.[0]?.display_name || 'Unknown institution';
+              return (
+                <button
+                  key={author.id}
+                  onClick={() => handleSelect(author)}
+                  className="w-full text-left px-3 py-2 rounded-lg hover:bg-violet-50 dark:hover:bg-violet-950/30 border border-transparent hover:border-violet-200 dark:hover:border-violet-800 transition-colors"
+                >
+                  <p className="text-xs font-medium text-gray-900 dark:text-gray-100">{author.display_name}</p>
+                  <p className="text-[10px] text-gray-500 dark:text-gray-400">
+                    {inst} · {author.works_count} works · {author.cited_by_count.toLocaleString()} citations
+                  </p>
+                </button>
+              );
+            })}
+          </div>
+          <button
+            onClick={handleReset}
+            className="mt-3 text-[10px] text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            ← Back to search
+          </button>
+        </div>
+      )}
+
+      {/* Computing with progress */}
+      {step === 'computing' && (
+        <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl p-4 mb-3">
+          <div className="flex items-center gap-2 mb-3">
+            <Loader2 className="h-4 w-4 animate-spin text-violet-500" />
+            <span className="text-xs text-gray-700 dark:text-gray-300">
+              Computing p-index for <strong>{selectedAuthor?.display_name}</strong>…
+            </span>
+          </div>
+          <div className="w-full bg-gray-100 dark:bg-slate-700 rounded-full h-1.5 mb-1.5">
+            <div
+              className="bg-violet-500 h-1.5 rounded-full transition-all duration-300"
+              style={{ width: `${progress.pct}%` }}
+            />
+          </div>
+          <p className="text-[10px] text-gray-400">{progress.status}</p>
+        </div>
+      )}
+
+      {/* Error state */}
+      {step === 'error' && (
+        <div className="bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 rounded-xl p-4 mb-3">
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-red-500" />
+            <span className="text-xs text-red-700 dark:text-red-300">{errorMsg}</span>
+          </div>
+          <button
+            onClick={handleReset}
+            className="mt-2 text-[10px] text-red-500 hover:text-red-700 dark:hover:text-red-400"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {/* Results */}
+      {step === 'done' && result && (
+        <>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 mb-3">
+            <MetricsCard
+              title="P-Index (PI)"
+              value={result.rawPIndex ?? 0}
+              subtitle={
+                result.rawPIndex !== null
+                  ? result.rawPIndex >= 75 ? 'Excellent' : result.rawPIndex >= 60 ? 'Strong' : result.rawPIndex >= 50 ? 'Above average' : 'Average'
+                  : undefined
+              }
+              icon="pindex"
+            />
+            <MetricsCard
+              title="P-Index (OWPI)"
+              value={result.owpiPIndex ?? 0}
+              subtitle="Authorship-weighted"
+              icon="owpi"
+            />
+          </div>
+
+          {/* Source note */}
+          <p className="text-[10px] text-gray-400 dark:text-gray-500 mb-2">
+            Based on {result.worksWithPercentile} of {result.worksAnalyzed} publications from OpenAlex.
+            Values may differ from Web of Science due to different coverage and indexing.
+            {selectedAuthor && (
+              <button onClick={handleReset} className="ml-2 text-violet-500 hover:text-violet-700 underline">
+                Recalculate
+              </button>
+            )}
+          </p>
+
+          {/* Expandable top publications */}
+          {result.topPublications.length > 0 && (
+            <button
+              onClick={() => setShowDetails(!showDetails)}
+              className="flex items-center gap-1 text-[11px] text-violet-600 dark:text-violet-400 hover:text-violet-800 dark:hover:text-violet-300 mb-2"
+            >
+              {showDetails ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+              {showDetails ? 'Hide' : 'Show'} top publications by percentile
+            </button>
+          )}
+
+          {showDetails && (
+            <div className="bg-white dark:bg-slate-800 border border-gray-100 dark:border-slate-700 rounded-xl p-3 overflow-x-auto">
+              <table className="w-full text-[11px]">
+                <thead>
+                  <tr className="text-gray-400 dark:text-gray-500 border-b border-gray-100 dark:border-slate-700">
+                    <th className="text-left py-1.5 pr-3 font-medium">Pctl</th>
+                    <th className="text-left py-1.5 pr-3 font-medium">Cit</th>
+                    <th className="text-left py-1.5 pr-3 font-medium">Pos</th>
+                    <th className="text-left py-1.5 pr-3 font-medium">Journal</th>
+                    <th className="text-left py-1.5 font-medium">Title</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.topPublications.map((pub, i) => (
+                    <tr key={i} className="border-b border-gray-50 dark:border-slate-700/50 last:border-0">
+                      <td className="py-1.5 pr-3 font-mono font-medium text-violet-600 dark:text-violet-400">
+                        {pub.percentileRank.toFixed(1)}%
+                      </td>
+                      <td className="py-1.5 pr-3 text-gray-600 dark:text-gray-400">{pub.citations}</td>
+                      <td className="py-1.5 pr-3 text-gray-500 dark:text-gray-500">
+                        {pub.authorPosition}/{pub.totalAuthors}
+                      </td>
+                      <td className="py-1.5 pr-3 text-gray-500 dark:text-gray-500 max-w-[150px] truncate">
+                        {pub.journal}
+                      </td>
+                      <td className="py-1.5 text-gray-700 dark:text-gray-300 max-w-[250px] truncate">
+                        {pub.title}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Idle state — show confirmed check if we already computed */}
+      {step === 'done' && selectedAuthor && (
+        <div className="flex items-center gap-1.5 text-[10px] text-green-600 dark:text-green-400 mt-2">
+          <CheckCircle className="h-3 w-3" />
+          OpenAlex profile: {selectedAuthor.display_name}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -12,6 +12,7 @@ import { CitationNetwork } from './CitationNetwork';
 import { CoAuthorMap } from './CoAuthorMap';
 import { OpenScienceTab } from './OpenScienceTab';
 import { ResearcherNarrative } from './ResearcherNarrative';
+import { PIndexSection } from './PIndexSection';
 import { Logo } from './Logo';
 import { useAuth } from '../contexts/AuthContext';
 import { supabase } from '../lib/supabase';
@@ -439,6 +440,10 @@ export function ProfileView({
                   />
                 </div>
               </div>
+            )}
+
+            {data && (
+              <PIndexSection authorName={data.name} affiliation={data.affiliation} />
             )}
 
             <div>

--- a/src/data/metricInfo.ts
+++ b/src/data/metricInfo.ts
@@ -173,6 +173,18 @@ export const metricInfo = {
     cons: "Journal-level metric applied to individual researchers. Publishing in high-IF journals doesn't guarantee individual paper impact.",
     link: "https://en.wikipedia.org/wiki/Impact_factor"
   },
+  pindex: {
+    description: "The p-index measures the average citation percentile rank of a researcher's papers relative to other papers published in the same journal in the same year. A score of 70 means the researcher's papers are, on average, in the 70th percentile within their journals.\n\nBased on: Pham, Wu & Wang (2024), 'Benchmarking Scholarship in Consumer Research: The p-Index of Thought Leadership,' Journal of Consumer Research, 51(1), 191–203.",
+    pros: "Field-normalized and career-stage independent. Comparable across disciplines. Not inflated by publishing in high-citation fields. Resistant to manipulation.",
+    cons: "Computed from OpenAlex data, which may differ from Web of Science. Coverage varies by discipline. Conference papers and book chapters may have fewer reference papers in the distribution.",
+    link: "https://www.p-index.net/"
+  },
+  owpi: {
+    description: "Ownership-Weighted P-Index — a variant of the p-index that gives more weight to publications where the researcher is a lead or sole author, using the Abbas (2011) positional weighting formula.\n\nFirst author gets more credit than middle authors. For a paper with k authors, the weight of the j-th author is: w = 2(k−j+1) / k(k+1).",
+    pros: "Rewards intellectual leadership and first-authorship. Differentiates between leading research and contributing to large teams.",
+    cons: "Assumes author order reflects contribution, which varies by field (e.g., alphabetical ordering in economics). May disadvantage researchers in large collaborative teams.",
+    link: "https://www.p-index.net/"
+  },
   closedAccess: {
     description: "Publications behind a paywall, accessible only through subscriptions or individual purchase.",
     pros: "Traditional publishing model with established peer review processes.",

--- a/src/services/openalex/pindex.ts
+++ b/src/services/openalex/pindex.ts
@@ -1,0 +1,265 @@
+/**
+ * P-Index Calculator using OpenAlex data
+ *
+ * Implements the p-index from Pham, Wu & Wang (2024, JCR):
+ * "The average citation percentile rank of a researcher's published articles
+ *  relative to other articles published the same year by the same journals."
+ *
+ * Uses OpenAlex group_by=cited_by_count for efficient journal-year distributions
+ * (1 API call per journal-year instead of paginating thousands of papers).
+ *
+ * Authorship weighting uses Abbas (2011, Scientometrics):
+ *   w_j = 2(k - j + 1) / (k(k + 1))
+ */
+
+import { oaFetchJson, OA_API_URL, OA_EMAIL } from './author-lookup';
+
+// --- Types ---
+
+export interface PIndexResult {
+  rawPIndex: number | null;
+  owpiPIndex: number | null;
+  worksAnalyzed: number;
+  worksWithPercentile: number;
+  topPublications: Array<{
+    title: string;
+    journal: string;
+    year: number;
+    citations: number;
+    percentileRank: number;
+    authorPosition: number;
+    totalAuthors: number;
+  }>;
+}
+
+interface CitationDistribution {
+  totalPapers: number;
+  freq: Map<number, number>;
+  maxCitationInGroups: number;
+}
+
+interface OAWork {
+  id: string;
+  title?: string;
+  publication_year?: number;
+  cited_by_count?: number;
+  authorships?: Array<{
+    author_position?: string;
+    author?: { id?: string };
+  }>;
+  primary_location?: {
+    source?: {
+      id?: string;
+      display_name?: string;
+    };
+  };
+}
+
+// --- Helpers ---
+
+/**
+ * Abbas (2011) positional weight.
+ * w_j = 2(k - j + 1) / (k(k + 1))
+ */
+function abbasWeight(position: number, totalAuthors: number): number {
+  const k = totalAuthors;
+  const j = position;
+  if (k <= 0 || k === 1) return 1;
+  return (2 * (k - j + 1)) / (k * (k + 1));
+}
+
+/**
+ * Compute percentile rank from a frequency distribution.
+ * (B + 0.5 * E) / N * 100
+ */
+function percentileFromDistribution(
+  citationCount: number,
+  dist: CitationDistribution
+): number {
+  let below = 0;
+  let equal = 0;
+
+  for (const [cit, count] of dist.freq) {
+    if (cit < citationCount) below += count;
+    else if (cit === citationCount) equal += count;
+  }
+
+  const coveredPapers = Array.from(dist.freq.values()).reduce((a, b) => a + b, 0);
+  const uncovered = dist.totalPapers - coveredPapers;
+  if (uncovered > 0 && citationCount > dist.maxCitationInGroups) {
+    below += coveredPapers;
+    equal = Math.max(1, uncovered);
+  }
+
+  return ((below + 0.5 * equal) / dist.totalPapers) * 100;
+}
+
+// --- Core ---
+
+const distCache = new Map<string, CitationDistribution>();
+
+async function fetchJournalYearDistribution(
+  sourceId: string,
+  year: number
+): Promise<CitationDistribution | null> {
+  const key = `${sourceId}__${year}`;
+  if (distCache.has(key)) return distCache.get(key)!;
+
+  const shortSourceId = sourceId.replace('https://openalex.org/', '');
+  const data = await oaFetchJson<{
+    meta: { count: number };
+    group_by: Array<{ key: string; count: number }>;
+  }>(
+    `${OA_API_URL}/works?filter=primary_location.source.id:${shortSourceId},publication_year:${year}&group_by=cited_by_count&per_page=200&mailto=${OA_EMAIL}`
+  );
+
+  if (!data?.group_by?.length) return null;
+
+  const freq = new Map<number, number>();
+  let maxCit = 0;
+  for (const g of data.group_by) {
+    const cit = parseInt(g.key, 10);
+    if (!isNaN(cit)) {
+      freq.set(cit, g.count);
+      if (cit > maxCit) maxCit = cit;
+    }
+  }
+
+  const dist: CitationDistribution = {
+    totalPapers: data.meta.count,
+    freq,
+    maxCitationInGroups: maxCit,
+  };
+  distCache.set(key, dist);
+  return dist;
+}
+
+function findAuthorPosition(
+  work: OAWork,
+  targetAuthorId: string
+): { position: number; total: number } {
+  const authorships = work.authorships || [];
+  const total = authorships.length || 1;
+  for (let i = 0; i < authorships.length; i++) {
+    if (authorships[i].author?.id === targetAuthorId) {
+      return { position: i + 1, total };
+    }
+  }
+  return { position: 1, total };
+}
+
+/**
+ * Compute the p-index for an OpenAlex author.
+ * @param authorId Full OpenAlex author ID (e.g. "https://openalex.org/A5077827457")
+ * @param onProgress Optional callback with progress updates (0-100)
+ */
+export async function computePIndex(
+  authorId: string,
+  onProgress?: (pct: number, status: string) => void
+): Promise<PIndexResult | null> {
+  const shortId = authorId.replace('https://openalex.org/', '');
+  onProgress?.(5, 'Fetching publications…');
+
+  // Fetch all works
+  const allWorks: OAWork[] = [];
+  let page = 1;
+  while (page <= 10) {
+    const data = await oaFetchJson<{ results: OAWork[] }>(
+      `${OA_API_URL}/works?filter=authorships.author.id:${shortId}&per_page=200&page=${page}&select=id,title,publication_year,cited_by_count,authorships,primary_location&mailto=${OA_EMAIL}`,
+      30000
+    );
+    if (!data?.results?.length) break;
+    allWorks.push(...data.results);
+    if (data.results.length < 200) break;
+    page++;
+  }
+
+  if (allWorks.length === 0) return null;
+  onProgress?.(15, `Found ${allWorks.length} publications`);
+
+  // Collect unique journal-year combos
+  const journalYears = new Set<string>();
+  for (const w of allWorks) {
+    if (w.primary_location?.source?.id && w.publication_year) {
+      journalYears.add(`${w.primary_location.source.id}__${w.publication_year}`);
+    }
+  }
+
+  // Fetch distributions
+  const total = journalYears.size;
+  let fetched = 0;
+  for (const jy of journalYears) {
+    const [sourceId, yearStr] = jy.split('__');
+    await fetchJournalYearDistribution(sourceId, Number(yearStr));
+    fetched++;
+    const pct = 15 + Math.round((fetched / total) * 75);
+    if (fetched % 5 === 0 || fetched === total) {
+      onProgress?.(pct, `Analyzing journals… ${fetched}/${total}`);
+    }
+  }
+
+  // Compute percentile ranks
+  const ranked: Array<{
+    title: string;
+    journal: string;
+    year: number;
+    citations: number;
+    percentileRank: number;
+    authorPosition: number;
+    totalAuthors: number;
+    weight: number;
+  }> = [];
+
+  for (const work of allWorks) {
+    const sourceId = work.primary_location?.source?.id;
+    const year = work.publication_year || 0;
+    const citations = work.cited_by_count ?? 0;
+
+    if (!sourceId || !year) continue;
+
+    const key = `${sourceId}__${year}`;
+    const dist = distCache.get(key);
+    if (!dist) continue;
+
+    const pctRank = percentileFromDistribution(citations, dist);
+    const { position, total: totalAuthors } = findAuthorPosition(work, authorId);
+    const weight = abbasWeight(position, totalAuthors);
+
+    ranked.push({
+      title: work.title || 'Untitled',
+      journal: work.primary_location?.source?.display_name || 'Unknown',
+      year,
+      citations,
+      percentileRank: Number(pctRank.toFixed(2)),
+      authorPosition: position,
+      totalAuthors,
+      weight,
+    });
+  }
+
+  if (ranked.length === 0) return null;
+
+  // Raw p-index
+  const rawPIndex = Number(
+    (ranked.reduce((s, p) => s + p.percentileRank, 0) / ranked.length).toFixed(2)
+  );
+
+  // OWPI
+  const totalWeight = ranked.reduce((s, p) => s + p.weight, 0);
+  const owpiPIndex = Number(
+    (ranked.reduce((s, p) => s + p.percentileRank * p.weight, 0) / totalWeight).toFixed(2)
+  );
+
+  // Top publications sorted by percentile
+  ranked.sort((a, b) => b.percentileRank - a.percentileRank);
+
+  onProgress?.(100, 'Done');
+
+  return {
+    rawPIndex,
+    owpiPIndex,
+    worksAnalyzed: allWorks.length,
+    worksWithPercentile: ranked.length,
+    topPublications: ranked.slice(0, 10).map(({ weight: _, ...rest }) => rest),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds p-index calculation (Pham, Wu & Wang 2024, JCR) using OpenAlex data
- Users confirm first name, last name, and institution, then select their OpenAlex profile from search results
- Computes within-journal-year percentile ranks with Abbas (2011) authorship weighting
- Displays raw PI and OWPI (authorship-weighted) with expandable top-publications table
- Includes notes that calculation takes 10-30s and that OpenAlex data may differ from Google Scholar/WoS

## Test plan
- [ ] Load a profile and verify the P-Index section appears in the Impact Metrics tab
- [ ] Enter name/institution and search — verify OpenAlex results appear
- [ ] Select an author — verify progress bar shows and p-index computes
- [ ] Verify PI and OWPI cards display with correct tooltips
- [ ] Verify "Show top publications" expands with percentile data
- [ ] Test with authors that have no OpenAlex profile — verify error handling
- [ ] Verify dark mode styling