### PR TITLE
Fix tooltips overflowing page boundaries

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -14,9 +14,10 @@ interface TooltipProps {
 
 export function Tooltip({ content, children, position = 'bottom' }: TooltipProps) {
   const [isVisible, setIsVisible] = useState(false);
-  const [resolvedPosition, setResolvedPosition] = useState(position);
   const hideTimeoutRef = useRef<number>();
   const containerRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [coords, setCoords] = useState({ top: 0, left: 0, placement: position as 'top' | 'bottom' });
 
   useEffect(() => {
     return () => {
@@ -24,21 +25,46 @@ export function Tooltip({ content, children, position = 'bottom' }: TooltipProps
     };
   }, []);
 
-  // Dynamically flip position when tooltip would overflow viewport
+  // Position tooltip using fixed coordinates relative to viewport
   useEffect(() => {
     if (!isVisible || !containerRef.current) return;
 
-    const rect = containerRef.current.getBoundingClientRect();
-    const viewportHeight = window.innerHeight;
-    const tooltipHeight = 220;
+    const updatePosition = () => {
+      if (!containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const tooltipEl = tooltipRef.current;
+      const tooltipHeight = tooltipEl ? tooltipEl.offsetHeight : 200;
+      const viewportHeight = window.innerHeight;
+      const gap = 8;
 
-    if (position === 'bottom' && rect.bottom + tooltipHeight > viewportHeight) {
-      setResolvedPosition('top');
-    } else if (position === 'top' && rect.top - tooltipHeight < 0) {
-      setResolvedPosition('bottom');
-    } else {
-      setResolvedPosition(position);
-    }
+      // Decide placement
+      let placement = position;
+      const spaceBelow = viewportHeight - rect.bottom - gap;
+      const spaceAbove = rect.top - gap;
+
+      if (placement === 'bottom' && spaceBelow < tooltipHeight && spaceAbove > spaceBelow) {
+        placement = 'top';
+      } else if (placement === 'top' && spaceAbove < tooltipHeight && spaceBelow > spaceAbove) {
+        placement = 'bottom';
+      }
+
+      const top = placement === 'bottom'
+        ? rect.bottom + gap
+        : rect.top - gap;
+
+      // Center horizontally, clamped to viewport
+      const centerX = rect.left + rect.width / 2;
+      const tooltipWidth = 288; // w-72 = 18rem = 288px
+      let left = centerX - tooltipWidth / 2;
+      left = Math.max(8, Math.min(left, window.innerWidth - tooltipWidth - 8));
+
+      setCoords({ top, left, placement });
+    };
+
+    updatePosition();
+
+    // Recalc after tooltip renders (so we have actual height)
+    requestAnimationFrame(updatePosition);
   }, [isVisible, position]);
 
   const handleMouseEnter = useCallback(() => {
@@ -61,48 +87,42 @@ export function Tooltip({ content, children, position = 'bottom' }: TooltipProps
     >
       {isVisible && (
         <div
-          className={`absolute z-50 w-72 p-4 ${
-            resolvedPosition === 'top'
-              ? 'bottom-full mb-2'
-              : 'top-full mt-2'
-          } -translate-x-1/2 left-1/2 bg-white/95 backdrop-blur-lg rounded-xl shadow-lg border border-gray-100/50`}
+          ref={tooltipRef}
+          className="fixed z-50 w-72 p-4 bg-white/95 dark:bg-slate-800/95 backdrop-blur-lg rounded-xl shadow-lg border border-gray-100/50 dark:border-slate-700/50 max-h-[min(400px,70vh)] overflow-y-auto"
+          style={{
+            top: coords.placement === 'bottom' ? `${coords.top}px` : undefined,
+            bottom: coords.placement === 'top' ? `${window.innerHeight - coords.top}px` : undefined,
+            left: `${coords.left}px`,
+          }}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
-          <div className="relative">
-            <p className="text-sm text-gray-700 mb-3">{content.description}</p>
+          <p className="text-sm text-gray-700 dark:text-gray-300 mb-3">{content.description}</p>
 
-            <div className="space-y-3">
-              <div>
-                <p className="text-xs font-medium text-gray-700 mb-1">Strengths:</p>
-                <p className="text-xs text-gray-600">{content.pros}</p>
-              </div>
-
-              <div>
-                <p className="text-xs font-medium text-gray-500 mb-1">Limitations:</p>
-                <p className="text-xs text-gray-600">{content.cons}</p>
-              </div>
-
-              {content.link && (
-                <div className="mt-3 pt-2 border-t border-gray-100">
-                  <a
-                    href={content.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center text-xs text-[#2d7d7d] hover:text-[#1f5c5c] transition-colors"
-                  >
-                    <span>Learn more</span>
-                    <ExternalLink className="h-3 w-3 ml-1" />
-                  </a>
-                </div>
-              )}
+          <div className="space-y-3">
+            <div>
+              <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Strengths:</p>
+              <p className="text-xs text-gray-600 dark:text-gray-400">{content.pros}</p>
             </div>
 
-            <div className={`absolute ${
-              resolvedPosition === 'top'
-                ? '-bottom-2 border-t border-r'
-                : '-top-2 border-b border-r'
-            } left-1/2 -translate-x-1/2 w-3 h-3 bg-white/95 transform rotate-45 border-gray-100/50`}></div>
+            <div>
+              <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Limitations:</p>
+              <p className="text-xs text-gray-600 dark:text-gray-400">{content.cons}</p>
+            </div>
+
+            {content.link && (
+              <div className="mt-3 pt-2 border-t border-gray-100 dark:border-slate-700">
+                <a
+                  href={content.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center text-xs text-[#2d7d7d] hover:text-[#1f5c5c] transition-colors"
+                >
+                  <span>Learn more</span>
+                  <ExternalLink className="h-3 w-3 ml-1" />
+                </a>
+              </div>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Switch tooltips from `position: absolute` to `position: fixed` with viewport-aware placement
- Dynamically measure available space and flip direction when needed
- Clamp horizontal position to viewport edges
- Add `max-height` with overflow scroll for long tooltip content (e.g. p-index)
- Added dark mode support for tooltip backgrounds/borders

## Test plan
- [ ] Hover over metric cards near bottom of page — tooltip should flip above
- [ ] Hover over metric cards near top of page — tooltip should appear below
- [ ] Hover over cards at left/right edge — tooltip should not clip horizontally
- [ ] Verify p-index tooltips (longer content) are scrollable if needed
- [ ] Test dark mode styling