### PR TITLE
Shrink tooltip fonts and dimensions

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -54,7 +54,7 @@ export function Tooltip({ content, children, position = 'bottom' }: TooltipProps
 
       // Center horizontally, clamped to viewport
       const centerX = rect.left + rect.width / 2;
-      const tooltipWidth = 288; // w-72 = 18rem = 288px
+      const tooltipWidth = 240; // w-60 = 15rem = 240px
       let left = centerX - tooltipWidth / 2;
       left = Math.max(8, Math.min(left, window.innerWidth - tooltipWidth - 8));
 
@@ -88,7 +88,7 @@ export function Tooltip({ content, children, position = 'bottom' }: TooltipProps
       {isVisible && (
         <div
           ref={tooltipRef}
-          className="fixed z-50 w-72 p-4 bg-white/95 dark:bg-slate-800/95 backdrop-blur-lg rounded-xl shadow-lg border border-gray-100/50 dark:border-slate-700/50 max-h-[min(400px,70vh)] overflow-y-auto"
+          className="fixed z-50 w-60 p-3 bg-white/95 dark:bg-slate-800/95 backdrop-blur-lg rounded-lg shadow-lg border border-gray-100/50 dark:border-slate-700/50 max-h-[min(320px,60vh)] overflow-y-auto"
           style={{
             top: coords.placement === 'bottom' ? `${coords.top}px` : undefined,
             bottom: coords.placement === 'top' ? `${window.innerHeight - coords.top}px` : undefined,
@@ -97,29 +97,29 @@ export function Tooltip({ content, children, position = 'bottom' }: TooltipProps
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
-          <p className="text-sm text-gray-700 dark:text-gray-300 mb-3">{content.description}</p>
+          <p className="text-[11px] leading-relaxed text-gray-700 dark:text-gray-300 mb-2">{content.description}</p>
 
-          <div className="space-y-3">
+          <div className="space-y-2">
             <div>
-              <p className="text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">Strengths:</p>
-              <p className="text-xs text-gray-600 dark:text-gray-400">{content.pros}</p>
+              <p className="text-[10px] font-medium text-gray-700 dark:text-gray-300 mb-0.5">Strengths:</p>
+              <p className="text-[10px] leading-relaxed text-gray-500 dark:text-gray-400">{content.pros}</p>
             </div>
 
             <div>
-              <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Limitations:</p>
-              <p className="text-xs text-gray-600 dark:text-gray-400">{content.cons}</p>
+              <p className="text-[10px] font-medium text-gray-500 dark:text-gray-400 mb-0.5">Limitations:</p>
+              <p className="text-[10px] leading-relaxed text-gray-500 dark:text-gray-400">{content.cons}</p>
             </div>
 
             {content.link && (
-              <div className="mt-3 pt-2 border-t border-gray-100 dark:border-slate-700">
+              <div className="mt-2 pt-1.5 border-t border-gray-100 dark:border-slate-700">
                 <a
                   href={content.link}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center text-xs text-[#2d7d7d] hover:text-[#1f5c5c] transition-colors"
+                  className="inline-flex items-center text-[10px] text-[#2d7d7d] hover:text-[#1f5c5c] transition-colors"
                 >
                   <span>Learn more</span>
-                  <ExternalLink className="h-3 w-3 ml-1" />
+                  <ExternalLink className="h-2.5 w-2.5 ml-1" />
                 </a>
               </div>
             )}


### PR DESCRIPTION
## Summary
- Reduced all tooltip font sizes to be smaller than the metric cards they describe
- Narrower width (240px vs 288px), less padding, tighter spacing
- Tooltips now feel proportional to the cards instead of overshadowing them

## Test plan
- [ ] Hover over any metric card — tooltip should be compact and readable
- [ ] Verify text doesn't feel cramped despite smaller size
- [ ] Check dark mode