### PR TITLE
Add P-Index to landing and about pages

### DIFF
--- a/src/components/AboutPage.tsx
+++ b/src/components/AboutPage.tsx
@@ -28,7 +28,7 @@ export function AboutPage({ onBack }: AboutPageProps) {
             <p>
               Scholar Folio is a free, open-source research portfolio tool. Paste your Google Scholar URL
               and get a shareable page with your publication history, citation metrics, collaboration network,
-              co-author world map, open access profile, and field-normalized impact — all generated automatically.
+              co-author world map, open access profile, field-normalized impact, and p-index (thought leadership score) — all generated automatically.
             </p>
           </section>
 
@@ -40,6 +40,7 @@ export function AboutPage({ onBack }: AboutPageProps) {
               <li><strong>Citation trends</strong> — year-by-year charts, cumulative growth, publication output, and momentum analysis</li>
               <li><strong>Co-author network</strong> — interactive visualization of your collaboration patterns and key partnerships</li>
               <li><strong>World map</strong> — where your co-authors are, mapped by institution location</li>
+              <li><strong>P-Index</strong> — thought leadership score based on within-journal citation percentile ranks (Pham, Wu &amp; Wang, 2024), with Abbas (2011) authorship weighting. Computed on-demand from OpenAlex data after selecting and reviewing your publications</li>
               <li><strong>Open access profile</strong> — gold, green, hybrid, and bronze OA breakdown with per-paper status</li>
             </ul>
           </section>
@@ -48,8 +49,8 @@ export function AboutPage({ onBack }: AboutPageProps) {
             <h2 className="font-serif text-xl font-semibold text-[#1e293b] mb-3">Where the data comes from</h2>
             <p className="mb-2">
               Profile data is sourced from <strong>Google Scholar</strong> (via SerpAPI, with direct scraping as fallback).
-              Open access stats, co-author geography, ORCID, and field-normalized metrics come from <strong>OpenAlex</strong>, an
-              open bibliometric database.
+              Open access stats, co-author geography, ORCID, field-normalized metrics, and p-index journal citation
+              distributions come from <strong>OpenAlex</strong>, an open bibliometric database.
             </p>
             <p>
               No data is stored beyond a 7-day cache to reduce API calls. ScholarFolio does not scrape, store,

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { CheckCircle, Search, Network, BarChart, BookOpen, ArrowRight, Menu, X, ExternalLink, User, Link, BadgeCheck, Globe, Gauge, TrendingUp, Unlock } from 'lucide-react';
+import { CheckCircle, Search, Network, BarChart, BookOpen, ArrowRight, Menu, X, ExternalLink, User, Link, BadgeCheck, Globe, Gauge, TrendingUp, Unlock, Award } from 'lucide-react';
 import { SearchBar } from './SearchBar';
 import { ScholarSearchModal } from './ScholarSearchModal';
 import { Logo } from './Logo';
@@ -174,7 +174,7 @@ export function LandingPage({ onSearch, loading, error, onNavigate, authControls
               Your research, one link away
             </h2>
             <p className="text-sm text-[#64748b] max-w-lg mx-auto">
-              A clear, honest picture of your research — built from your Google Scholar profile, shareable in one click.
+              A clear, honest picture of your research — impact metrics, p-index, collaboration network, and more — built from your Google Scholar profile, shareable in one click.
             </p>
           </div>
 
@@ -214,6 +214,13 @@ export function LandingPage({ onSearch, loading, error, onNavigate, authControls
                 description: "See where your collaborators are — an interactive map of co-author institutions across the globe.",
                 color: '#2d7d7d',
                 bg: '#eaf4f4',
+              },
+              {
+                icon: Award,
+                title: "P-Index (Thought Leadership)",
+                description: "Within-journal citation percentile ranking with authorship weighting. See how your papers perform relative to their venue.",
+                color: '#7c3aed',
+                bg: '#f3f0ff',
               },
               {
                 icon: Unlock,


### PR DESCRIPTION
## Summary
- Added P-Index feature card to landing page features grid
- Updated landing subtitle to mention p-index
- Updated About page: "What it is", "What it shows", and data source sections

## Test plan
- [ ] Landing page shows 7 feature cards including P-Index
- [ ] About page lists P-Index in "What it shows"
- [ ] About page mentions OpenAlex for p-index data