### PR TITLE
Add Narrative CV export (NWO & ERC formats)

### DIFF
--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock, ExternalLink, Heart, BadgeCheck, Link, Globe } from 'lucide-react';
+import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock, ExternalLink, Heart, BadgeCheck, Link, Globe, FileText } from 'lucide-react';
 import { EmbedModal } from './EmbedModal';
 import { ClaimProfileModal } from './ClaimProfileModal';
 import { exportProfilePdf } from '../utils/pdfExport';
+import { exportNarrativeCv } from '../utils/narrativeCvExport';
 import { SearchBar } from './SearchBar';
 import { TopicsList } from './TopicsList';
 import { PublicationsList } from './PublicationsList';
@@ -84,6 +85,7 @@ export function ProfileView({
   const [claimedByCurrentUser, setClaimedByCurrentUser] = useState(false);
   const [prefetchedGeo, setPrefetchedGeo] = useState<{ mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null>(null);
   const [pIndexResult, setPIndexResult] = useState<PIndexResult | null>(null);
+  const [showNarrativeCvMenu, setShowNarrativeCvMenu] = useState(false);
 
   // Prefetch co-author geo data as soon as profile loads (don't wait for tab click)
   useEffect(() => {
@@ -94,6 +96,19 @@ export function ProfileView({
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [data?.name, data?.affiliation, data?.publications]);
+
+  // Close narrative CV dropdown when clicking outside
+  useEffect(() => {
+    if (!showNarrativeCvMenu) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!target.closest('[data-narrative-cv-menu]')) {
+        setShowNarrativeCvMenu(false);
+      }
+    };
+    document.addEventListener('click', handler);
+    return () => document.removeEventListener('click', handler);
+  }, [showNarrativeCvMenu]);
 
   // Extract scholar ID from URL params or profileUrl
   const scholarId = new URLSearchParams(window.location.search).get('user')
@@ -264,6 +279,41 @@ export function ProfileView({
                     <Download className="h-3 w-3" />
                     PDF
                   </button>
+                  <div className="relative" data-narrative-cv-menu>
+                    <button
+                      onClick={() => setShowNarrativeCvMenu(!showNarrativeCvMenu)}
+                      className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] hover:text-[#1a5c5c] bg-[#eaf4f4] hover:bg-[#d5ecec] px-2.5 py-1 rounded-full transition-colors"
+                    >
+                      <FileText className="h-3 w-3" />
+                      Narrative CV
+                    </button>
+                    {showNarrativeCvMenu && (
+                      <div className="absolute top-full left-0 mt-1 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-lg py-1 z-50 min-w-[200px]">
+                        <button
+                          onClick={() => {
+                            if (!data) return;
+                            exportNarrativeCv(data, 'nwo', prefetchedGeo);
+                            setShowNarrativeCvMenu(false);
+                          }}
+                          className="w-full text-left px-3 py-2 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+                        >
+                          <span className="font-medium">NWO</span>
+                          <span className="text-gray-400 dark:text-gray-500 ml-1">— Evidence-Based CV</span>
+                        </button>
+                        <button
+                          onClick={() => {
+                            if (!data) return;
+                            exportNarrativeCv(data, 'erc', prefetchedGeo);
+                            setShowNarrativeCvMenu(false);
+                          }}
+                          className="w-full text-left px-3 py-2 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+                        >
+                          <span className="font-medium">ERC</span>
+                          <span className="text-gray-400 dark:text-gray-500 ml-1">— CV & Track Record</span>
+                        </button>
+                      </div>
+                    )}
+                  </div>
                   {claimedSlug ? (
                     <span className="inline-flex items-center gap-1.5 text-xs text-emerald-700 bg-emerald-50 px-2.5 py-1 rounded-full font-medium">
                       <BadgeCheck className="h-3.5 w-3.5" />

--- a/src/utils/narrativeCvExport.ts
+++ b/src/utils/narrativeCvExport.ts
@@ -1,0 +1,741 @@
+import jsPDF from 'jspdf';
+import type { Author, Publication, OpenAccessStats, CoAuthorGeoData } from '../types/scholar';
+import { generateNarrativeParagraphs } from '../components/ResearcherNarrative';
+
+const PAGE_W = 210;
+const PAGE_H = 297;
+const M = 18; // margin
+const CW = PAGE_W - M * 2;
+const TEAL = [45, 125, 125] as const;
+const DARK = [30, 41, 59] as const;
+const GRAY = [100, 116, 139] as const;
+const LIGHT_GRAY = [203, 213, 225] as const;
+const PLACEHOLDER_GRAY = [148, 163, 184] as const; // #94a3b8
+
+function stripMarkdown(text: string): string {
+  return text.replace(/\*\*(.*?)\*\*/g, '$1');
+}
+
+function normalizeTitle(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function selectKeyOutputs(publications: Publication[], limit = 10): Publication[] {
+  return [...publications]
+    .sort((a, b) => {
+      const aFt = a.journalRanking?.ft50 ? 1 : 0;
+      const bFt = b.journalRanking?.ft50 ? 1 : 0;
+      if (aFt !== bFt) return bFt - aFt;
+      const absOrder: Record<string, number> = { '4*': 5, '4': 4, '3': 3, '2': 2, '1': 1 };
+      const aAbs = absOrder[a.journalRanking?.abs || ''] || 0;
+      const bAbs = absOrder[b.journalRanking?.abs || ''] || 0;
+      if (aAbs !== bAbs) return bAbs - aAbs;
+      return b.citations - a.citations;
+    })
+    .slice(0, limit);
+}
+
+function isOA(pub: Publication, openAccess?: OpenAccessStats): boolean {
+  if (!openAccess?.publicationOa) return false;
+  const key = normalizeTitle(pub.title);
+  const entry = openAccess.publicationOa[key];
+  return !!entry && entry.status !== 'closed';
+}
+
+export function exportNarrativeCv(
+  data: Author,
+  format: 'nwo' | 'erc',
+  geoData?: { mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null
+): void {
+  if (format === 'nwo') {
+    exportNwo(data, geoData);
+  } else {
+    exportErc(data, geoData);
+  }
+}
+
+// ============================================================
+// NWO Evidence-Based CV
+// ============================================================
+
+function exportNwo(
+  data: Author,
+  _geoData?: { mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null
+): void {
+  const doc = new jsPDF({ unit: 'mm', format: 'a4' });
+  let y = M;
+
+  const setColor = (c: readonly [number, number, number]) => doc.setTextColor(c[0], c[1], c[2]);
+  const setFill = (c: readonly [number, number, number]) => doc.setFillColor(c[0], c[1], c[2]);
+
+  const ensureSpace = (need: number) => {
+    if (y + need > PAGE_H - 18) {
+      doc.addPage();
+      drawPageHeader(doc, setFill);
+      y = M + 4;
+    }
+  };
+
+  const sectionTitle = (text: string) => {
+    ensureSpace(14);
+    setColor(TEAL);
+    doc.setFontSize(12);
+    doc.setFont('helvetica', 'bold');
+    doc.text(text, M, y);
+    y += 2;
+    doc.setDrawColor(TEAL[0], TEAL[1], TEAL[2]);
+    doc.setLineWidth(0.4);
+    doc.line(M, y, PAGE_W - M, y);
+    y += 5;
+    setColor(DARK);
+  };
+
+  const bodyText = (text: string, indent = 0) => {
+    doc.setFontSize(9);
+    doc.setFont('helvetica', 'normal');
+    setColor(DARK);
+    const lines = doc.splitTextToSize(text, CW - indent);
+    for (const line of lines) {
+      ensureSpace(4);
+      doc.text(line, M + indent, y);
+      y += 4;
+    }
+  };
+
+  const placeholderText = (text: string) => {
+    doc.setFontSize(9);
+    doc.setFont('helvetica', 'italic');
+    setColor(PLACEHOLDER_GRAY);
+    const lines = doc.splitTextToSize(text, CW);
+    for (const line of lines) {
+      ensureSpace(4);
+      doc.text(line, M, y);
+      y += 4;
+    }
+    y += 1;
+  };
+
+  // === COVER HEADER ===
+  drawPageHeader(doc, setFill);
+  y = M + 4;
+
+  // Format label
+  setColor(PLACEHOLDER_GRAY);
+  doc.setFontSize(8);
+  doc.setFont('helvetica', 'normal');
+  doc.text('NWO EVIDENCE-BASED CV', M, y);
+  y += 6;
+
+  // Name
+  setColor(DARK);
+  doc.setFontSize(20);
+  doc.setFont('helvetica', 'bold');
+  doc.text(data.name, M, y);
+  y += 7;
+
+  // Affiliation
+  if (data.affiliation) {
+    doc.setFontSize(10);
+    doc.setFont('helvetica', 'normal');
+    setColor(GRAY);
+    doc.text(data.affiliation, M, y);
+    y += 5;
+  }
+
+  // Key stats inline
+  const stats = [
+    `h-index: ${data.hIndex}`,
+    `Citations: ${data.totalCitations.toLocaleString()}`,
+    `Publications: ${data.publications.length}`,
+  ];
+  doc.setFontSize(8);
+  setColor(TEAL);
+  doc.text(stats.join('   |   '), M, y);
+  y += 8;
+
+  // Topics
+  if (data.topics.length > 0) {
+    const topicNames = data.topics.map(t =>
+      typeof t.name === 'object' ? (t.name as { title?: string }).title || '' : String(t.name)
+    ).filter(Boolean);
+    doc.setFontSize(8);
+    doc.setFont('helvetica', 'normal');
+    setColor(GRAY);
+    const topicLine = topicNames.join('  ·  ');
+    const tLines = doc.splitTextToSize(topicLine, CW);
+    doc.text(tLines, M, y);
+    y += tLines.length * 3.5 + 6;
+  }
+
+  // Divider
+  doc.setDrawColor(LIGHT_GRAY[0], LIGHT_GRAY[1], LIGHT_GRAY[2]);
+  doc.setLineWidth(0.3);
+  doc.line(M, y, PAGE_W - M, y);
+  y += 8;
+
+  // ==============================
+  // SECTION 1: ACADEMIC PROFILE
+  // ==============================
+  sectionTitle('1. Academic Profile');
+
+  const narrativeParagraphs = generateNarrativeParagraphs(data);
+
+  // Career overview
+  if (narrativeParagraphs[0]) {
+    bodyText(stripMarkdown(narrativeParagraphs[0]));
+    y += 2;
+  }
+
+  // Research methods — from paragraph that usually mentions "draws on"
+  const methodsPara = narrativeParagraphs.find(p => p.includes('draws on') || p.includes('methods'));
+  if (methodsPara && methodsPara !== narrativeParagraphs[0]) {
+    bodyText(stripMarkdown(methodsPara));
+    y += 2;
+  }
+
+  // Research evolution
+  const evolutionPara = narrativeParagraphs.find(p =>
+    p.includes('earlier work') || p.includes('shifted towards') || p.includes('consistently centered')
+  );
+  if (evolutionPara) {
+    bodyText(stripMarkdown(evolutionPara));
+    y += 2;
+  }
+
+  // Collaboration profile
+  const collabPara = narrativeParagraphs.find(p =>
+    p.includes('co-authored') || p.includes('collaborator') || p.includes('single-authored')
+  );
+  if (collabPara) {
+    bodyText(stripMarkdown(collabPara));
+    y += 2;
+  }
+
+  // Impact paragraph
+  const impactPara = narrativeParagraphs.find(p =>
+    p.includes('h-index') || p.includes('citations') || p.includes('most cited')
+  );
+  if (impactPara) {
+    bodyText(stripMarkdown(impactPara));
+    y += 2;
+  }
+
+  y += 3;
+
+  // NWO-specific placeholder prompts
+  doc.setFontSize(9);
+  doc.setFont('helvetica', 'bold');
+  setColor(DARK);
+  doc.text('Additional information to complete manually:', M, y);
+  y += 5;
+
+  const nwoPrompts = [
+    '[Describe your most significant scientific achievements and their broader societal relevance.]',
+    '[Explain how your research profile fits the NWO programme or call you are applying to.]',
+    '[Describe any scientific leadership roles, editorial boards, or programme committees you have held.]',
+    '[List any prizes, grants, or fellowships received (e.g. NWO Veni/Vidi/Vici, ERC, Marie Curie).]',
+    '[Add information about research integrity, open science practices, and data management.]',
+  ];
+  for (const prompt of nwoPrompts) {
+    placeholderText(prompt);
+  }
+
+  y += 4;
+
+  // ==============================
+  // SECTION 2: KEY OUTPUTS
+  // ==============================
+  sectionTitle('2. Key Outputs (max. 10)');
+
+  const keyOutputs = selectKeyOutputs(data.publications);
+  const hasOaData = !!data.openAccess?.publicationOa;
+
+  doc.setFontSize(8);
+  doc.setFont('helvetica', 'italic');
+  setColor(GRAY);
+  doc.text(
+    'Publications ranked by journal prestige (FT50, then ABS rating) and citation count. Max. 10 shown.',
+    M, y
+  );
+  y += 5;
+
+  if (hasOaData) {
+    doc.setFontSize(7.5);
+    doc.setFont('helvetica', 'normal');
+    setColor(TEAL);
+    doc.text('[OA] = Open Access', M, y);
+    y += 4;
+  }
+
+  for (let i = 0; i < keyOutputs.length; i++) {
+    const pub = keyOutputs[i];
+    ensureSpace(18);
+
+    const oaFlag = hasOaData && isOA(pub, data.openAccess) ? ' [OA]' : '';
+
+    // Number + title
+    doc.setFontSize(8.5);
+    doc.setFont('helvetica', 'bold');
+    setColor(DARK);
+    const titleText = `${i + 1}. ${pub.title}${oaFlag}`;
+    const titleLines = doc.splitTextToSize(titleText, CW);
+    for (const line of titleLines) {
+      ensureSpace(4);
+      doc.text(line, M, y);
+      y += 4;
+    }
+
+    // Authors
+    doc.setFontSize(8);
+    doc.setFont('helvetica', 'normal');
+    setColor(GRAY);
+    const authorsText = pub.authors.slice(0, 6).join(', ') + (pub.authors.length > 6 ? ' et al.' : '');
+    const aLines = doc.splitTextToSize(authorsText, CW);
+    for (const line of aLines) {
+      ensureSpace(4);
+      doc.text(line, M + 4, y);
+      y += 3.5;
+    }
+
+    // Venue, year, citations, ranking badges
+    const venue = pub.venue ? pub.venue.replace(/,.*$/, '').trim() : '';
+    const rankingParts: string[] = [];
+    if (pub.journalRanking?.ft50) rankingParts.push('FT50');
+    if (pub.journalRanking?.abs) rankingParts.push(`ABS ${pub.journalRanking.abs}`);
+    if (pub.journalRanking?.abdc) rankingParts.push(`ABDC ${pub.journalRanking.abdc}`);
+    if (pub.journalRanking?.sjr) rankingParts.push(`SJR ${pub.journalRanking.sjr}`);
+
+    const metaParts = [
+      venue,
+      pub.year ? String(pub.year) : '',
+      pub.citations > 0 ? `${pub.citations} citation${pub.citations !== 1 ? 's' : ''}` : '',
+    ].filter(Boolean);
+    const metaLine = metaParts.join('  ·  ');
+
+    doc.setFontSize(7.5);
+    setColor(GRAY);
+    doc.text(metaLine, M + 4, y);
+
+    if (rankingParts.length > 0) {
+      const metaW = doc.getTextWidth(metaLine);
+      setColor(TEAL);
+      doc.text('  ' + rankingParts.join(' · '), M + 4 + metaW, y);
+    }
+
+    y += 6;
+  }
+
+  addFooter(doc, 'NWO Evidence-Based CV');
+  const safeName = data.name.replace(/[^a-zA-Z0-9]/g, '_');
+  const dateStr = new Date().toISOString().slice(0, 10);
+  doc.save(`ScholarFolio_NWO_CV_${safeName}_${dateStr}.pdf`);
+}
+
+// ============================================================
+// ERC CV & Track Record
+// ============================================================
+
+function exportErc(
+  data: Author,
+  _geoData?: { mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null
+): void {
+  const doc = new jsPDF({ unit: 'mm', format: 'a4' });
+  let y = M;
+  let pageCount = 1;
+
+  const setColor = (c: readonly [number, number, number]) => doc.setTextColor(c[0], c[1], c[2]);
+  const setFill = (c: readonly [number, number, number]) => doc.setFillColor(c[0], c[1], c[2]);
+
+  const ensureSpace = (need: number) => {
+    if (y + need > PAGE_H - 18) {
+      doc.addPage();
+      pageCount++;
+      drawPageHeader(doc, setFill);
+      y = M + 4;
+    }
+  };
+
+  const sectionTitle = (text: string) => {
+    ensureSpace(14);
+    setColor(TEAL);
+    doc.setFontSize(12);
+    doc.setFont('helvetica', 'bold');
+    doc.text(text, M, y);
+    y += 2;
+    doc.setDrawColor(TEAL[0], TEAL[1], TEAL[2]);
+    doc.setLineWidth(0.4);
+    doc.line(M, y, PAGE_W - M, y);
+    y += 5;
+    setColor(DARK);
+  };
+
+  const subHeading = (text: string) => {
+    ensureSpace(8);
+    doc.setFontSize(9.5);
+    doc.setFont('helvetica', 'bold');
+    setColor(DARK);
+    doc.text(text, M, y);
+    y += 5;
+  };
+
+  const bodyText = (text: string, indent = 0) => {
+    doc.setFontSize(9);
+    doc.setFont('helvetica', 'normal');
+    setColor(DARK);
+    const lines = doc.splitTextToSize(text, CW - indent);
+    for (const line of lines) {
+      ensureSpace(4);
+      doc.text(line, M + indent, y);
+      y += 4;
+    }
+  };
+
+  const placeholderText = (text: string, indent = 0) => {
+    doc.setFontSize(9);
+    doc.setFont('helvetica', 'italic');
+    setColor(PLACEHOLDER_GRAY);
+    const lines = doc.splitTextToSize(text, CW - indent);
+    for (const line of lines) {
+      ensureSpace(4);
+      doc.text(line, M + indent, y);
+      y += 4;
+    }
+    y += 1;
+  };
+
+  const labelValue = (label: string, value: string) => {
+    ensureSpace(5);
+    doc.setFontSize(9);
+    doc.setFont('helvetica', 'bold');
+    setColor(DARK);
+    doc.text(label + ': ', M, y);
+    const labelW = doc.getTextWidth(label + ': ');
+    doc.setFont('helvetica', 'normal');
+    setColor(GRAY);
+    const valLines = doc.splitTextToSize(value, CW - labelW);
+    doc.text(valLines[0], M + labelW, y);
+    y += 4;
+    for (let i = 1; i < valLines.length; i++) {
+      ensureSpace(4);
+      doc.text(valLines[i], M + labelW, y);
+      y += 4;
+    }
+  };
+
+  // === COVER HEADER ===
+  drawPageHeader(doc, setFill);
+  y = M + 4;
+
+  setColor(PLACEHOLDER_GRAY);
+  doc.setFontSize(8);
+  doc.setFont('helvetica', 'normal');
+  doc.text('ERC CV & TRACK RECORD', M, y);
+  y += 6;
+
+  setColor(DARK);
+  doc.setFontSize(20);
+  doc.setFont('helvetica', 'bold');
+  doc.text(data.name, M, y);
+  y += 7;
+
+  if (data.affiliation) {
+    doc.setFontSize(10);
+    doc.setFont('helvetica', 'normal');
+    setColor(GRAY);
+    doc.text(data.affiliation, M, y);
+    y += 5;
+  }
+
+  const stats = [
+    `h-index: ${data.hIndex}`,
+    `Citations: ${data.totalCitations.toLocaleString()}`,
+    `Publications: ${data.publications.length}`,
+  ];
+  doc.setFontSize(8);
+  setColor(TEAL);
+  doc.text(stats.join('   |   '), M, y);
+  y += 8;
+
+  doc.setDrawColor(LIGHT_GRAY[0], LIGHT_GRAY[1], LIGHT_GRAY[2]);
+  doc.setLineWidth(0.3);
+  doc.line(M, y, PAGE_W - M, y);
+  y += 8;
+
+  // ERC guidance note
+  doc.setFontSize(7.5);
+  doc.setFont('helvetica', 'italic');
+  setColor(PLACEHOLDER_GRAY);
+  const ercNote = 'ERC CV & Track Record: target 4 pages. Complete placeholder sections before submission. ' +
+    'Do not include journal impact factors per ERC guidelines.';
+  const noteLines = doc.splitTextToSize(ercNote, CW);
+  doc.text(noteLines, M, y);
+  y += noteLines.length * 3.5 + 6;
+
+  // ==============================
+  // SECTION A: PERSONAL INFORMATION
+  // ==============================
+  sectionTitle('A. Personal Information');
+
+  labelValue('Name', data.name);
+  if (data.affiliation) labelValue('Current affiliation', data.affiliation);
+
+  if (data.topics.length > 0) {
+    const topicNames = data.topics.map(t =>
+      typeof t.name === 'object' ? (t.name as { title?: string }).title || '' : String(t.name)
+    ).filter(Boolean);
+    labelValue('Research areas', topicNames.slice(0, 5).join(', '));
+  }
+
+  placeholderText('[Add: ORCID iD, nationality, date of birth (if required by call)]');
+  y += 3;
+
+  // ==============================
+  // SECTION B: EDUCATION & KEY QUALIFICATIONS
+  // ==============================
+  sectionTitle('B. Education & Key Qualifications');
+
+  placeholderText('[PhD degree, institution, year, thesis title]');
+  placeholderText('[MSc / MA degree, institution, year]');
+  placeholderText('[BSc / BA degree, institution, year]');
+  placeholderText('[Any additional qualifications, certifications, or relevant training]');
+  y += 3;
+
+  // ==============================
+  // SECTION C: CURRENT AND PREVIOUS POSITIONS
+  // ==============================
+  sectionTitle('C. Current and Previous Positions');
+
+  if (data.affiliation) {
+    doc.setFontSize(9);
+    doc.setFont('helvetica', 'normal');
+    setColor(DARK);
+    doc.text(`Current: ${data.affiliation}`, M, y);
+    y += 5;
+  }
+
+  placeholderText('[Add: previous positions with institution name, role, and dates (YYYY–YYYY)]');
+  placeholderText('[Include postdoctoral positions, visiting appointments, and industry roles if relevant]');
+  y += 3;
+
+  // ==============================
+  // SECTION D: RESEARCH ACHIEVEMENTS & PEER RECOGNITION
+  // ==============================
+  sectionTitle('D. Research Achievements & Peer Recognition');
+
+  const narrativeParagraphs = generateNarrativeParagraphs(data);
+
+  subHeading('Career summary');
+  if (narrativeParagraphs[0]) {
+    bodyText(stripMarkdown(narrativeParagraphs[0]));
+    y += 2;
+  }
+
+  const impactPara = narrativeParagraphs.find(p =>
+    p.includes('h-index') || p.includes('citations') || p.includes('most cited')
+  );
+  if (impactPara) {
+    bodyText(stripMarkdown(impactPara));
+    y += 2;
+  }
+
+  const trendPara = narrativeParagraphs.find(p =>
+    p.includes('publication output') || p.includes('publication pace') || p.includes('publication rate')
+  );
+  if (trendPara) {
+    bodyText(stripMarkdown(trendPara));
+    y += 3;
+  }
+
+  subHeading('Grants & funding');
+  placeholderText('[List research grants received, funding body, amount, and period (e.g. NWO Veni, ERC StG)]');
+
+  subHeading('Awards & prizes');
+  placeholderText('[List academic awards, best paper prizes, teaching awards, etc.]');
+
+  subHeading('Editorial & professional roles');
+  placeholderText('[List editorial board memberships, conference programme committee roles, society memberships]');
+
+  subHeading('Invited talks');
+  placeholderText('[List keynotes, invited seminar talks, and conference presentations (last 5 years)]');
+
+  subHeading('Media & societal impact');
+  placeholderText('[Describe any policy impact, media coverage, consultancy, or knowledge transfer activities]');
+
+  y += 3;
+
+  // ==============================
+  // SECTION E: SELECTED PUBLICATIONS & OUTPUTS
+  // ==============================
+  sectionTitle('E. Selected Publications & Outputs (max. 10)');
+
+  doc.setFontSize(8);
+  doc.setFont('helvetica', 'italic');
+  setColor(GRAY);
+  const pubNote = 'Ranked by journal prestige (FT50, then ABS) and citation count. ' +
+    'Note: journal impact factors are not included per ERC guidelines.';
+  const pubNoteLines = doc.splitTextToSize(pubNote, CW);
+  doc.text(pubNoteLines, M, y);
+  y += pubNoteLines.length * 3.5 + 4;
+
+  const keyOutputs = selectKeyOutputs(data.publications);
+  const hasOaData = !!data.openAccess?.publicationOa;
+
+  if (hasOaData) {
+    doc.setFontSize(7.5);
+    doc.setFont('helvetica', 'normal');
+    setColor(TEAL);
+    doc.text('[OA] = Open Access', M, y);
+    y += 4;
+  }
+
+  for (let i = 0; i < keyOutputs.length; i++) {
+    const pub = keyOutputs[i];
+    ensureSpace(18);
+
+    const oaFlag = hasOaData && isOA(pub, data.openAccess) ? ' [OA]' : '';
+
+    doc.setFontSize(8.5);
+    doc.setFont('helvetica', 'bold');
+    setColor(DARK);
+    const titleText = `${i + 1}. ${pub.title}${oaFlag}`;
+    const titleLines = doc.splitTextToSize(titleText, CW);
+    for (const line of titleLines) {
+      ensureSpace(4);
+      doc.text(line, M, y);
+      y += 4;
+    }
+
+    doc.setFontSize(8);
+    doc.setFont('helvetica', 'normal');
+    setColor(GRAY);
+    const authorsText = pub.authors.slice(0, 6).join(', ') + (pub.authors.length > 6 ? ' et al.' : '');
+    const aLines = doc.splitTextToSize(authorsText, CW);
+    for (const line of aLines) {
+      ensureSpace(4);
+      doc.text(line, M + 4, y);
+      y += 3.5;
+    }
+
+    const venue = pub.venue ? pub.venue.replace(/,.*$/, '').trim() : '';
+    const rankingParts: string[] = [];
+    if (pub.journalRanking?.ft50) rankingParts.push('FT50');
+    if (pub.journalRanking?.abs) rankingParts.push(`ABS ${pub.journalRanking.abs}`);
+    if (pub.journalRanking?.abdc) rankingParts.push(`ABDC ${pub.journalRanking.abdc}`);
+    if (pub.journalRanking?.sjr) rankingParts.push(`SJR ${pub.journalRanking.sjr}`);
+
+    const metaParts = [
+      venue,
+      pub.year ? String(pub.year) : '',
+      pub.citations > 0 ? `${pub.citations} citation${pub.citations !== 1 ? 's' : ''}` : '',
+    ].filter(Boolean);
+    const metaLine = metaParts.join('  ·  ');
+
+    doc.setFontSize(7.5);
+    setColor(GRAY);
+    doc.text(metaLine, M + 4, y);
+
+    if (rankingParts.length > 0) {
+      const metaW = doc.getTextWidth(metaLine);
+      setColor(TEAL);
+      doc.text('  ' + rankingParts.join(' · '), M + 4 + metaW, y);
+    }
+
+    y += 6;
+  }
+
+  // ==============================
+  // SECTION F: NARRATIVE ON TRACK RECORD
+  // ==============================
+  sectionTitle('F. Narrative on Track Record');
+
+  subHeading('Research evolution');
+  const evolutionPara = narrativeParagraphs.find(p =>
+    p.includes('earlier work') || p.includes('shifted towards') || p.includes('consistently centered')
+  );
+  if (evolutionPara) {
+    bodyText(stripMarkdown(evolutionPara));
+    y += 2;
+  } else {
+    placeholderText('[Describe how your research has evolved over your career and where it is headed.]');
+  }
+
+  subHeading('Research methods & approach');
+  const methodsPara = narrativeParagraphs.find(p =>
+    p.includes('draws on') || p.includes('methods')
+  );
+  if (methodsPara && methodsPara !== narrativeParagraphs[0]) {
+    bodyText(stripMarkdown(methodsPara));
+    y += 2;
+  } else {
+    placeholderText('[Describe the methods and approaches that characterise your research.]');
+  }
+
+  subHeading('Research themes');
+  if (data.topics.length > 0) {
+    const topicNames = data.topics.map(t =>
+      typeof t.name === 'object' ? (t.name as { title?: string }).title || '' : String(t.name)
+    ).filter(Boolean);
+    bodyText('Core research themes: ' + topicNames.slice(0, 6).join(', ') + '.');
+    y += 2;
+  }
+  placeholderText('[Expand on the central themes of your research programme and their scientific significance.]');
+  placeholderText('[Explain how these themes connect to broader challenges in your field and to the proposed project.]');
+
+  subHeading('Collaboration & international profile');
+  const collabPara = narrativeParagraphs.find(p =>
+    p.includes('co-authored') || p.includes('collaborator') || p.includes('single-authored')
+  );
+  if (collabPara) {
+    bodyText(stripMarkdown(collabPara));
+    y += 2;
+  }
+  placeholderText('[Add information about international collaborations, research networks, and mobility.]');
+
+  // Page count note
+  ensureSpace(10);
+  y += 3;
+  doc.setFontSize(7.5);
+  doc.setFont('helvetica', 'italic');
+  setColor(PLACEHOLDER_GRAY);
+  doc.text(
+    `This document currently spans ${doc.getNumberOfPages()} page(s). ERC CV target is 4 pages — trim placeholder sections before submission.`,
+    M, y
+  );
+
+  addFooter(doc, 'ERC CV & Track Record');
+  const safeName = data.name.replace(/[^a-zA-Z0-9]/g, '_');
+  const dateStr = new Date().toISOString().slice(0, 10);
+  doc.save(`ScholarFolio_ERC_CV_${safeName}_${dateStr}.pdf`);
+}
+
+// ============================================================
+// Shared helpers
+// ============================================================
+
+function drawPageHeader(
+  doc: jsPDF,
+  setFill: (c: readonly [number, number, number]) => void
+): void {
+  setFill(TEAL);
+  doc.rect(0, 0, PAGE_W, 3, 'F');
+}
+
+function addFooter(doc: jsPDF, label: string): void {
+  const now = new Date();
+  const dateStr = now.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+  const totalPages = doc.getNumberOfPages();
+
+  for (let i = 1; i <= totalPages; i++) {
+    doc.setPage(i);
+
+    // Bottom accent bar
+    doc.setFillColor(TEAL[0], TEAL[1], TEAL[2]);
+    doc.rect(0, PAGE_H - 3, PAGE_W, 3, 'F');
+
+    doc.setFontSize(7);
+    doc.setFont('helvetica', 'normal');
+    doc.setTextColor(150, 150, 150);
+    doc.text(`Generated by ScholarFolio · scholarfolio.org · ${label} · ${dateStr}`, M, PAGE_H - 6);
+    doc.text(`Page ${i} of ${totalPages}`, PAGE_W - M, PAGE_H - 6, { align: 'right' });
+  }
+}


### PR DESCRIPTION
## Summary
- New **"Narrative CV"** dropdown button in profile header, next to PDF export
- Two format options: **NWO Evidence-Based CV** and **ERC CV & Track Record**
- Auto-fills from existing ScholarFolio profile data:
  - Career overview, research methods, research evolution, collaboration profile
  - Top 10 publications ranked by FT50 → ABS rank → citation count
  - Open Access flags on publications (when OA data available)
  - Journal ranking badges (FT50, ABS, ABDC, SJR)
- Gray italic placeholder sections with instructional prompts for sections we can't auto-fill (education, grants, awards, etc.)
- Professional PDF output with teal accent headers, page numbers, footer branding

### NWO format:
1. Academic Profile (narrative)
2. Key Outputs (max 10, with OA indicators)

### ERC format (targeting 4 pages):
A. Personal Information
B. Education & Key Qualifications
C. Current and Previous Positions
D. Research Achievements & Peer Recognition
E. Selected Publications & Outputs (max 10)
F. Narrative on Track Record

## Test plan
- [x] Build passes
- [ ] Test NWO export with a profile
- [ ] Test ERC export with a profile
- [ ] Verify dropdown opens/closes correctly
- [ ] Verify click-outside closes dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)