### PR TITLE
Auto-fill narrative CV from ORCID data

### DIFF
--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -290,9 +290,9 @@ export function ProfileView({
                     {showNarrativeCvMenu && (
                       <div className="absolute top-full left-0 mt-1 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-lg py-1 z-50 min-w-[200px]">
                         <button
-                          onClick={() => {
+                          onClick={async () => {
                             if (!data) return;
-                            exportNarrativeCv(data, 'nwo', prefetchedGeo);
+                            await exportNarrativeCv(data, 'nwo', prefetchedGeo);
                             setShowNarrativeCvMenu(false);
                           }}
                           className="w-full text-left px-3 py-2 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
@@ -301,9 +301,9 @@ export function ProfileView({
                           <span className="text-gray-400 dark:text-gray-500 ml-1">— Evidence-Based CV</span>
                         </button>
                         <button
-                          onClick={() => {
+                          onClick={async () => {
                             if (!data) return;
-                            exportNarrativeCv(data, 'erc', prefetchedGeo);
+                            await exportNarrativeCv(data, 'erc', prefetchedGeo);
                             setShowNarrativeCvMenu(false);
                           }}
                           className="w-full text-left px-3 py-2 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"

--- a/src/services/orcid.ts
+++ b/src/services/orcid.ts
@@ -1,0 +1,189 @@
+const ORCID_BASE = 'https://pub.orcid.org/v3.0';
+const ORCID_HEADERS = { Accept: 'application/vnd.orcid+json' };
+const TIMEOUT_MS = 10_000;
+
+export interface OrcidEducation {
+  degree: string;
+  department: string;
+  institution: string;
+  city: string;
+  country: string;
+  startYear: number | null;
+  endYear: number | null;
+}
+
+export interface OrcidEmployment {
+  role: string;
+  department: string;
+  institution: string;
+  city: string;
+  country: string;
+  startYear: number | null;
+  startMonth: number | null;
+  endYear: number | null;
+}
+
+export interface OrcidFunding {
+  title: string;
+  funder: string;
+  type: string;
+  startYear: number | null;
+  endYear: number | null;
+}
+
+export interface OrcidDistinction {
+  title: string;
+  organization: string;
+  year: number | null;
+}
+
+export interface OrcidProfile {
+  educations: OrcidEducation[];
+  employments: OrcidEmployment[];
+  fundings: OrcidFunding[];
+  distinctions: OrcidDistinction[];
+}
+
+const cache = new Map<string, OrcidProfile>();
+
+function parseYear(dateObj: { year?: { value?: string } | null } | null | undefined): number | null {
+  const val = dateObj?.year?.value;
+  if (!val) return null;
+  const n = parseInt(val, 10);
+  return isNaN(n) ? null : n;
+}
+
+function parseMonth(dateObj: { month?: { value?: string } | null } | null | undefined): number | null {
+  const val = dateObj?.['month']?.value;
+  if (!val) return null;
+  const n = parseInt(val, 10);
+  return isNaN(n) ? null : n;
+}
+
+function fetchWithTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  return fetch(url, { headers: ORCID_HEADERS, signal: controller.signal }).finally(() =>
+    clearTimeout(timer)
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseEducations(json: any): OrcidEducation[] {
+  const groups = json?.['affiliation-group'] ?? [];
+  const results: OrcidEducation[] = [];
+  for (const group of groups) {
+    for (const summary of group?.summaries ?? []) {
+      const ed = summary?.['education-summary'];
+      if (!ed) continue;
+      results.push({
+        degree: ed['role-title'] ?? '',
+        department: ed['department-name'] ?? '',
+        institution: ed?.organization?.name ?? '',
+        city: ed?.organization?.address?.city ?? '',
+        country: ed?.organization?.address?.country ?? '',
+        startYear: parseYear(ed['start-date']),
+        endYear: parseYear(ed['end-date']),
+      });
+    }
+  }
+  return results.sort((a, b) => (b.endYear ?? 0) - (a.endYear ?? 0));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseEmployments(json: any): OrcidEmployment[] {
+  const groups = json?.['affiliation-group'] ?? [];
+  const results: OrcidEmployment[] = [];
+  for (const group of groups) {
+    for (const summary of group?.summaries ?? []) {
+      const em = summary?.['employment-summary'];
+      if (!em) continue;
+      results.push({
+        role: em['role-title'] ?? '',
+        department: em['department-name'] ?? '',
+        institution: em?.organization?.name ?? '',
+        city: em?.organization?.address?.city ?? '',
+        country: em?.organization?.address?.country ?? '',
+        startYear: parseYear(em['start-date']),
+        startMonth: parseMonth(em['start-date']),
+        endYear: parseYear(em['end-date']),
+      });
+    }
+  }
+  // Current positions (endYear === null) first, then by start year desc
+  return results.sort((a, b) => {
+    if (a.endYear === null && b.endYear !== null) return -1;
+    if (a.endYear !== null && b.endYear === null) return 1;
+    return (b.startYear ?? 0) - (a.startYear ?? 0);
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseFundings(json: any): OrcidFunding[] {
+  const groups = json?.group ?? [];
+  const results: OrcidFunding[] = [];
+  for (const group of groups) {
+    for (const summary of group?.['funding-summary'] ?? []) {
+      results.push({
+        title: summary?.title?.title?.value ?? '',
+        funder: summary?.organization?.name ?? '',
+        type: summary?.type ?? '',
+        startYear: parseYear(summary['start-date']),
+        endYear: parseYear(summary['end-date']),
+      });
+    }
+  }
+  return results.sort((a, b) => (b.startYear ?? 0) - (a.startYear ?? 0));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseDistinctions(json: any): OrcidDistinction[] {
+  const groups = json?.['affiliation-group'] ?? [];
+  const results: OrcidDistinction[] = [];
+  for (const group of groups) {
+    for (const summary of group?.summaries ?? []) {
+      const dist = summary?.['distinction-summary'];
+      if (!dist) continue;
+      results.push({
+        title: dist['role-title'] ?? '',
+        organization: dist?.organization?.name ?? '',
+        year: parseYear(dist['start-date']),
+      });
+    }
+  }
+  return results.sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
+}
+
+export async function fetchOrcidProfile(orcidId: string): Promise<OrcidProfile | null> {
+  if (cache.has(orcidId)) return cache.get(orcidId)!;
+
+  const endpoints = ['educations', 'employments', 'fundings', 'distinctions'] as const;
+  const urls = endpoints.map(ep => `${ORCID_BASE}/${orcidId}/${ep}`);
+
+  try {
+    const responses = await Promise.all(urls.map(url => fetchWithTimeout(url)));
+
+    // If any response is 404 treat the ORCID as invalid
+    if (responses.some(r => r.status === 404)) return null;
+
+    const jsons = await Promise.all(
+      responses.map(r => (r.ok ? r.json() : Promise.resolve(null)))
+    );
+
+    if (jsons.every(j => j === null)) return null;
+
+    const [edJson, emJson, fuJson, diJson] = jsons;
+
+    const profile: OrcidProfile = {
+      educations: edJson ? parseEducations(edJson) : [],
+      employments: emJson ? parseEmployments(emJson) : [],
+      fundings: fuJson ? parseFundings(fuJson) : [],
+      distinctions: diJson ? parseDistinctions(diJson) : [],
+    };
+
+    cache.set(orcidId, profile);
+    return profile;
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/narrativeCvExport.ts
+++ b/src/utils/narrativeCvExport.ts
@@ -1,6 +1,8 @@
 import jsPDF from 'jspdf';
 import type { Author, Publication, OpenAccessStats, CoAuthorGeoData } from '../types/scholar';
 import { generateNarrativeParagraphs } from '../components/ResearcherNarrative';
+import { fetchOrcidProfile } from '../services/orcid';
+import type { OrcidProfile } from '../services/orcid';
 
 const PAGE_W = 210;
 const PAGE_H = 297;
@@ -42,16 +44,28 @@ function isOA(pub: Publication, openAccess?: OpenAccessStats): boolean {
   return !!entry && entry.status !== 'closed';
 }
 
-export function exportNarrativeCv(
+export async function exportNarrativeCv(
   data: Author,
   format: 'nwo' | 'erc',
   geoData?: { mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null
-): void {
+): Promise<void> {
+  const orcidId = data.openAccess?.orcid;
+  const orcid = orcidId ? await fetchOrcidProfile(orcidId) : null;
+
   if (format === 'nwo') {
-    exportNwo(data, geoData);
+    exportNwo(data, geoData, orcid);
   } else {
-    exportErc(data, geoData);
+    exportErc(data, geoData, orcid);
   }
+}
+
+// ============================================================
+// ORCID formatting helpers
+// ============================================================
+
+function orcidDateRange(startYear: number | null, endYear: number | null): string {
+  if (!startYear) return '';
+  return endYear ? `${startYear}–${endYear}` : `${startYear}–present`;
 }
 
 // ============================================================
@@ -60,7 +74,8 @@ export function exportNarrativeCv(
 
 function exportNwo(
   data: Author,
-  _geoData?: { mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null
+  _geoData?: { mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null,
+  orcid?: OrcidProfile | null
 ): void {
   const doc = new jsPDF({ unit: 'mm', format: 'a4' });
   let y = M;
@@ -222,6 +237,112 @@ function exportNwo(
 
   y += 3;
 
+  // --- ORCID: Education ---
+  if (orcid?.educations && orcid.educations.length > 0) {
+    doc.setFontSize(9.5);
+    doc.setFont('helvetica', 'bold');
+    setColor(DARK);
+    doc.text('Education', M, y);
+    y += 5;
+    for (const ed of orcid.educations) {
+      ensureSpace(10);
+      const dateRange = orcidDateRange(ed.startYear, ed.endYear);
+      const degreeLabel = [ed.degree, ed.department].filter(Boolean).join(' in ');
+      doc.setFontSize(9);
+      doc.setFont('helvetica', 'bold');
+      setColor(DARK);
+      doc.text(degreeLabel, M, y);
+      if (dateRange) {
+        doc.setFont('helvetica', 'normal');
+        setColor(GRAY);
+        doc.text(dateRange, PAGE_W - M, y, { align: 'right' });
+      }
+      y += 4;
+      const locationParts = [ed.city, ed.country].filter(Boolean).join(', ');
+      const institutionLine = [ed.institution, locationParts].filter(Boolean).join(', ');
+      bodyText(institutionLine, 0);
+      y += 1;
+    }
+    y += 2;
+  }
+
+  // --- ORCID: Employment ---
+  if (orcid?.employments && orcid.employments.length > 0) {
+    doc.setFontSize(9.5);
+    doc.setFont('helvetica', 'bold');
+    setColor(DARK);
+    doc.text('Academic & Professional Positions', M, y);
+    y += 5;
+    for (const em of orcid.employments) {
+      ensureSpace(10);
+      const dateRange = orcidDateRange(em.startYear, em.endYear);
+      doc.setFontSize(9);
+      doc.setFont('helvetica', 'bold');
+      setColor(DARK);
+      doc.text(em.role || '(Role not specified)', M, y);
+      if (dateRange) {
+        doc.setFont('helvetica', 'normal');
+        setColor(GRAY);
+        doc.text(dateRange, PAGE_W - M, y, { align: 'right' });
+      }
+      y += 4;
+      const locationParts = [em.city, em.country].filter(Boolean).join(', ');
+      const instLine = [em.institution, locationParts].filter(Boolean).join(', ');
+      bodyText(instLine, 0);
+      y += 1;
+    }
+    y += 2;
+  }
+
+  // --- ORCID: Grants & Funding ---
+  if (orcid?.fundings && orcid.fundings.length > 0) {
+    doc.setFontSize(9.5);
+    doc.setFont('helvetica', 'bold');
+    setColor(DARK);
+    doc.text('Grants & Funding', M, y);
+    y += 5;
+    for (const fu of orcid.fundings) {
+      ensureSpace(10);
+      const dateRange = orcidDateRange(fu.startYear, fu.endYear);
+      doc.setFontSize(9);
+      doc.setFont('helvetica', 'bold');
+      setColor(DARK);
+      const titleLines = doc.splitTextToSize(fu.title || '(Untitled grant)', CW - 30);
+      doc.text(titleLines[0], M, y);
+      if (dateRange) {
+        doc.setFont('helvetica', 'normal');
+        setColor(GRAY);
+        doc.text(dateRange, PAGE_W - M, y, { align: 'right' });
+      }
+      y += 4;
+      for (let i = 1; i < titleLines.length; i++) {
+        ensureSpace(4);
+        doc.setFont('helvetica', 'bold');
+        setColor(DARK);
+        doc.text(titleLines[i], M, y);
+        y += 4;
+      }
+      bodyText(fu.funder, 0);
+      y += 1;
+    }
+    y += 2;
+  }
+
+  // --- ORCID: Distinctions ---
+  if (orcid?.distinctions && orcid.distinctions.length > 0) {
+    doc.setFontSize(9.5);
+    doc.setFont('helvetica', 'bold');
+    setColor(DARK);
+    doc.text('Awards & Distinctions', M, y);
+    y += 5;
+    for (const dist of orcid.distinctions) {
+      ensureSpace(6);
+      const yearStr = dist.year ? ` (${dist.year})` : '';
+      bodyText(`${dist.title} — ${dist.organization}${yearStr}`);
+    }
+    y += 2;
+  }
+
   // NWO-specific placeholder prompts
   doc.setFontSize(9);
   doc.setFont('helvetica', 'bold');
@@ -233,7 +354,9 @@ function exportNwo(
     '[Describe your most significant scientific achievements and their broader societal relevance.]',
     '[Explain how your research profile fits the NWO programme or call you are applying to.]',
     '[Describe any scientific leadership roles, editorial boards, or programme committees you have held.]',
-    '[List any prizes, grants, or fellowships received (e.g. NWO Veni/Vidi/Vici, ERC, Marie Curie).]',
+    ...((!orcid?.fundings || orcid.fundings.length === 0)
+      ? ['[List any prizes, grants, or fellowships received (e.g. NWO Veni/Vidi/Vici, ERC, Marie Curie).]']
+      : []),
     '[Add information about research integrity, open science practices, and data management.]',
   ];
   for (const prompt of nwoPrompts) {
@@ -337,7 +460,8 @@ function exportNwo(
 
 function exportErc(
   data: Author,
-  _geoData?: { mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null
+  _geoData?: { mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null,
+  orcid?: OrcidProfile | null
 ): void {
   const doc = new jsPDF({ unit: 'mm', format: 'a4' });
   let y = M;
@@ -494,10 +618,33 @@ function exportErc(
   // ==============================
   sectionTitle('B. Education & Key Qualifications');
 
-  placeholderText('[PhD degree, institution, year, thesis title]');
-  placeholderText('[MSc / MA degree, institution, year]');
-  placeholderText('[BSc / BA degree, institution, year]');
-  placeholderText('[Any additional qualifications, certifications, or relevant training]');
+  if (orcid?.educations && orcid.educations.length > 0) {
+    for (const ed of orcid.educations) {
+      ensureSpace(10);
+      const dateRange = orcidDateRange(ed.startYear, ed.endYear);
+      const degreeLabel = [ed.degree, ed.department].filter(Boolean).join(' in ');
+      doc.setFontSize(9);
+      doc.setFont('helvetica', 'bold');
+      setColor(DARK);
+      doc.text(degreeLabel || '(Degree not specified)', M, y);
+      if (dateRange) {
+        doc.setFont('helvetica', 'normal');
+        setColor(GRAY);
+        doc.text(dateRange, PAGE_W - M, y, { align: 'right' });
+      }
+      y += 4;
+      const locationParts = [ed.city, ed.country].filter(Boolean).join(', ');
+      const institutionLine = [ed.institution, locationParts].filter(Boolean).join(', ');
+      bodyText(institutionLine, 0);
+      y += 1;
+    }
+    placeholderText('[Add: thesis title or additional qualifications if relevant]');
+  } else {
+    placeholderText('[PhD degree, institution, year, thesis title]');
+    placeholderText('[MSc / MA degree, institution, year]');
+    placeholderText('[BSc / BA degree, institution, year]');
+    placeholderText('[Any additional qualifications, certifications, or relevant training]');
+  }
   y += 3;
 
   // ==============================
@@ -505,16 +652,37 @@ function exportErc(
   // ==============================
   sectionTitle('C. Current and Previous Positions');
 
-  if (data.affiliation) {
-    doc.setFontSize(9);
-    doc.setFont('helvetica', 'normal');
-    setColor(DARK);
-    doc.text(`Current: ${data.affiliation}`, M, y);
-    y += 5;
+  if (orcid?.employments && orcid.employments.length > 0) {
+    for (const em of orcid.employments) {
+      ensureSpace(10);
+      const dateRange = orcidDateRange(em.startYear, em.endYear);
+      doc.setFontSize(9);
+      doc.setFont('helvetica', 'bold');
+      setColor(DARK);
+      doc.text(em.role || '(Role not specified)', M, y);
+      if (dateRange) {
+        doc.setFont('helvetica', 'normal');
+        setColor(GRAY);
+        doc.text(dateRange, PAGE_W - M, y, { align: 'right' });
+      }
+      y += 4;
+      const locationParts = [em.city, em.country].filter(Boolean).join(', ');
+      const instLine = [em.institution, locationParts].filter(Boolean).join(', ');
+      bodyText(instLine, 0);
+      y += 1;
+    }
+    placeholderText('[Add: visiting appointments or industry roles if relevant]');
+  } else {
+    if (data.affiliation) {
+      doc.setFontSize(9);
+      doc.setFont('helvetica', 'normal');
+      setColor(DARK);
+      doc.text(`Current: ${data.affiliation}`, M, y);
+      y += 5;
+    }
+    placeholderText('[Add: previous positions with institution name, role, and dates (YYYY–YYYY)]');
+    placeholderText('[Include postdoctoral positions, visiting appointments, and industry roles if relevant]');
   }
-
-  placeholderText('[Add: previous positions with institution name, role, and dates (YYYY–YYYY)]');
-  placeholderText('[Include postdoctoral positions, visiting appointments, and industry roles if relevant]');
   y += 3;
 
   // ==============================
@@ -547,10 +715,46 @@ function exportErc(
   }
 
   subHeading('Grants & funding');
-  placeholderText('[List research grants received, funding body, amount, and period (e.g. NWO Veni, ERC StG)]');
+  if (orcid?.fundings && orcid.fundings.length > 0) {
+    for (const fu of orcid.fundings) {
+      ensureSpace(10);
+      const dateRange = orcidDateRange(fu.startYear, fu.endYear);
+      doc.setFontSize(9);
+      doc.setFont('helvetica', 'bold');
+      setColor(DARK);
+      const titleLines = doc.splitTextToSize(fu.title || '(Untitled grant)', CW - 30);
+      doc.text(titleLines[0], M, y);
+      if (dateRange) {
+        doc.setFont('helvetica', 'normal');
+        setColor(GRAY);
+        doc.text(dateRange, PAGE_W - M, y, { align: 'right' });
+      }
+      y += 4;
+      for (let i = 1; i < titleLines.length; i++) {
+        ensureSpace(4);
+        doc.setFont('helvetica', 'bold');
+        setColor(DARK);
+        doc.text(titleLines[i], M, y);
+        y += 4;
+      }
+      bodyText(fu.funder, 0);
+      y += 1;
+    }
+    placeholderText('[Add: funding amounts where relevant]');
+  } else {
+    placeholderText('[List research grants received, funding body, amount, and period (e.g. NWO Veni, ERC StG)]');
+  }
 
   subHeading('Awards & prizes');
-  placeholderText('[List academic awards, best paper prizes, teaching awards, etc.]');
+  if (orcid?.distinctions && orcid.distinctions.length > 0) {
+    for (const dist of orcid.distinctions) {
+      const yearStr = dist.year ? ` (${dist.year})` : '';
+      bodyText(`${dist.title} — ${dist.organization}${yearStr}`);
+    }
+    y += 1;
+  } else {
+    placeholderText('[List academic awards, best paper prizes, teaching awards, etc.]');
+  }
 
   subHeading('Editorial & professional roles');
   placeholderText('[List editorial board memberships, conference programme committee roles, society memberships]');


### PR DESCRIPTION
## Summary
- New ORCID public API v3.0 service that fetches education, employment, funding, and distinctions
- Fetches all 4 endpoints in parallel, no auth needed, with 10s timeout and in-memory cache
- Narrative CV export (`exportNarrativeCv`) is now async — fetches ORCID data before generating PDF
- **NWO format**: education history, employment timeline, grants & funding, and awards/distinctions sections auto-filled from ORCID
- **ERC format**: Section B (Education), C (Positions), and D (Grants/Awards) auto-filled from ORCID
- Placeholder prompts remain for sections where ORCID has no data
- Graceful fallback: if no ORCID ID on profile or fetch fails, keeps all placeholders as before

## Test plan
- [x] Build passes
- [ ] Test NWO export with a profile that has ORCID data
- [ ] Test ERC export with a profile that has ORCID data
- [ ] Test export with a profile that has no ORCID (should show placeholders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)