### PR TITLE
Narrative CV: dedicated tab with NWO, ERC, MSCA formats

### DIFF
--- a/src/components/NarrativeCvTab.tsx
+++ b/src/components/NarrativeCvTab.tsx
@@ -1,0 +1,162 @@
+import React, { useState } from 'react';
+import { Download, Info, Loader2 } from 'lucide-react';
+import { exportNarrativeCv } from '../utils/narrativeCvExport';
+import type { NarrativeCvFormat } from '../utils/narrativeCvExport';
+import type { Author, CoAuthorGeoData } from '../types/scholar';
+
+interface NarrativeCvTabProps {
+  data: Author;
+  geoData?: { mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null;
+}
+
+const formats: Array<{
+  id: NarrativeCvFormat;
+  name: string;
+  subtitle: string;
+  description: string;
+  grants: string;
+  metrics: string;
+  color: string;
+}> = [
+  {
+    id: 'nwo',
+    name: 'NWO Evidence-Based CV',
+    subtitle: 'Dutch Research Council',
+    description: 'Narrative academic profile + max 10 key outputs. NWO explicitly bans Journal Impact Factors and h-indices — the export strips these automatically.',
+    grants: 'Veni, Vidi, Vici, Rubicon, and all other NWO programmes',
+    metrics: 'No h-index, no JIF, no citation counts',
+    color: 'border-orange-200 bg-orange-50/50',
+  },
+  {
+    id: 'erc',
+    name: 'ERC CV & Track Record',
+    subtitle: 'European Research Council',
+    description: 'Structured CV (4-page target) with 6 sections covering personal info, education, positions, achievements, publications, and a narrative track record. Journal Impact Factors are discouraged, but citation counts are acceptable as evidence.',
+    grants: 'Starting Grant, Consolidator Grant, Advanced Grant',
+    metrics: 'No JIF; citation counts allowed',
+    color: 'border-blue-200 bg-blue-50/50',
+  },
+  {
+    id: 'msca',
+    name: 'MSCA Postdoctoral Fellowship CV',
+    subtitle: 'Marie Skłodowska-Curie Actions',
+    description: 'Part B2 researcher CV for MSCA Postdoctoral Fellowship applications. Focuses on research experience, publications, international mobility, and transferable skills. No strict page limit but should be concise.',
+    grants: 'MSCA Postdoctoral Fellowships (European & Global)',
+    metrics: 'Citation counts allowed; focus on quality over quantity',
+    color: 'border-purple-200 bg-purple-50/50',
+  },
+];
+
+export function NarrativeCvTab({ data, geoData }: NarrativeCvTabProps) {
+  const [exporting, setExporting] = useState<NarrativeCvFormat | null>(null);
+  const [showTooltip, setShowTooltip] = useState<NarrativeCvFormat | null>(null);
+
+  const handleExport = async (format: NarrativeCvFormat) => {
+    setExporting(format);
+    try {
+      await exportNarrativeCv(data, format, geoData);
+    } catch (err) {
+      console.error('Narrative CV export failed:', err);
+    } finally {
+      setExporting(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1">
+          Narrative CV Export
+        </h3>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
+          Generate an editable Word document (.docx) pre-filled with your profile data, ORCID records, and selected publications.
+          Complete the placeholder sections before submission.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {formats.map(fmt => (
+          <div
+            key={fmt.id}
+            className={`relative rounded-xl border-2 ${fmt.color} p-5 transition-shadow hover:shadow-md`}
+          >
+            <div className="flex items-start justify-between mb-3">
+              <div>
+                <h4 className="text-sm font-bold text-gray-900 dark:text-gray-100">
+                  {fmt.name}
+                </h4>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                  {fmt.subtitle}
+                </p>
+              </div>
+              <div className="relative">
+                <button
+                  onMouseEnter={() => setShowTooltip(fmt.id)}
+                  onMouseLeave={() => setShowTooltip(null)}
+                  onClick={() => setShowTooltip(showTooltip === fmt.id ? null : fmt.id)}
+                  className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                  aria-label={`Info about ${fmt.name}`}
+                >
+                  <Info className="h-4 w-4" />
+                </button>
+                {showTooltip === fmt.id && (
+                  <div className="absolute right-0 top-full mt-1 w-64 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-lg p-3 z-50 text-xs">
+                    <p className="text-gray-700 dark:text-gray-300 mb-2">{fmt.description}</p>
+                    <div className="space-y-1">
+                      <p className="text-gray-500 dark:text-gray-400">
+                        <span className="font-medium text-gray-700 dark:text-gray-300">Use for:</span> {fmt.grants}
+                      </p>
+                      <p className="text-gray-500 dark:text-gray-400">
+                        <span className="font-medium text-gray-700 dark:text-gray-300">Metrics policy:</span> {fmt.metrics}
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <p className="text-xs text-gray-600 dark:text-gray-400 mb-1">
+              <span className="font-medium">Use for:</span> {fmt.grants}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
+              <span className="font-medium">Metrics:</span> {fmt.metrics}
+            </p>
+
+            <button
+              onClick={() => handleExport(fmt.id)}
+              disabled={exporting !== null}
+              className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-[#2d7d7d] hover:bg-[#246666] disabled:bg-gray-300 dark:disabled:bg-slate-600 rounded-lg transition-colors"
+            >
+              {exporting === fmt.id ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Generating...
+                </>
+              ) : (
+                <>
+                  <Download className="h-4 w-4" />
+                  Export .docx
+                </>
+              )}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div className="bg-gray-50 dark:bg-slate-800/50 rounded-lg p-4 text-xs text-gray-500 dark:text-gray-400 space-y-1.5">
+        <p className="font-medium text-gray-700 dark:text-gray-300">What's included automatically:</p>
+        <ul className="list-disc list-inside space-y-0.5">
+          <li>Research narrative generated from your publication data</li>
+          <li>Top 10 publications ranked by journal prestige and citations</li>
+          <li>Education, employment, grants, and awards from ORCID (if available)</li>
+          <li>Open Access flags on publications</li>
+          <li>Placeholder prompts for sections that need manual input</li>
+        </ul>
+        <p className="mt-2 text-gray-400 dark:text-gray-500 italic">
+          Tip: Ensure your ORCID profile is up-to-date for the best auto-fill results.
+          The exported document is fully editable in Microsoft Word or Google Docs.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock, ExternalLink, Heart, BadgeCheck, Link, Globe, FileText } from 'lucide-react';
+import { NarrativeCvTab } from './NarrativeCvTab';
 import { EmbedModal } from './EmbedModal';
 import { ClaimProfileModal } from './ClaimProfileModal';
 import { exportProfilePdf } from '../utils/pdfExport';
-import { exportNarrativeCv } from '../utils/narrativeCvExport';
 import { SearchBar } from './SearchBar';
 import { TopicsList } from './TopicsList';
 import { PublicationsList } from './PublicationsList';
@@ -42,6 +42,7 @@ const tabs = [
   { id: 'worldmap', label: 'World Map', icon: Globe },
   { id: 'openscience', label: 'Open Science', icon: Unlock },
   { id: 'publications', label: 'Publications', icon: BookOpen },
+  { id: 'narrativecv', label: 'Narrative CV', icon: FileText },
 ] as const;
 
 type TabId = typeof tabs[number]['id'];
@@ -85,7 +86,6 @@ export function ProfileView({
   const [claimedByCurrentUser, setClaimedByCurrentUser] = useState(false);
   const [prefetchedGeo, setPrefetchedGeo] = useState<{ mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null>(null);
   const [pIndexResult, setPIndexResult] = useState<PIndexResult | null>(null);
-  const [showNarrativeCvMenu, setShowNarrativeCvMenu] = useState(false);
 
   // Prefetch co-author geo data as soon as profile loads (don't wait for tab click)
   useEffect(() => {
@@ -96,19 +96,6 @@ export function ProfileView({
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [data?.name, data?.affiliation, data?.publications]);
-
-  // Close narrative CV dropdown when clicking outside
-  useEffect(() => {
-    if (!showNarrativeCvMenu) return;
-    const handler = (e: MouseEvent) => {
-      const target = e.target as HTMLElement;
-      if (!target.closest('[data-narrative-cv-menu]')) {
-        setShowNarrativeCvMenu(false);
-      }
-    };
-    document.addEventListener('click', handler);
-    return () => document.removeEventListener('click', handler);
-  }, [showNarrativeCvMenu]);
 
   // Extract scholar ID from URL params or profileUrl
   const scholarId = new URLSearchParams(window.location.search).get('user')
@@ -279,41 +266,6 @@ export function ProfileView({
                     <Download className="h-3 w-3" />
                     PDF
                   </button>
-                  <div className="relative" data-narrative-cv-menu>
-                    <button
-                      onClick={() => setShowNarrativeCvMenu(!showNarrativeCvMenu)}
-                      className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] hover:text-[#1a5c5c] bg-[#eaf4f4] hover:bg-[#d5ecec] px-2.5 py-1 rounded-full transition-colors"
-                    >
-                      <FileText className="h-3 w-3" />
-                      Narrative CV
-                    </button>
-                    {showNarrativeCvMenu && (
-                      <div className="absolute top-full left-0 mt-1 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg shadow-lg py-1 z-50 min-w-[200px]">
-                        <button
-                          onClick={async () => {
-                            if (!data) return;
-                            await exportNarrativeCv(data, 'nwo', prefetchedGeo);
-                            setShowNarrativeCvMenu(false);
-                          }}
-                          className="w-full text-left px-3 py-2 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
-                        >
-                          <span className="font-medium">NWO</span>
-                          <span className="text-gray-400 dark:text-gray-500 ml-1">— Evidence-Based CV</span>
-                        </button>
-                        <button
-                          onClick={async () => {
-                            if (!data) return;
-                            await exportNarrativeCv(data, 'erc', prefetchedGeo);
-                            setShowNarrativeCvMenu(false);
-                          }}
-                          className="w-full text-left px-3 py-2 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
-                        >
-                          <span className="font-medium">ERC</span>
-                          <span className="text-gray-400 dark:text-gray-500 ml-1">— CV & Track Record</span>
-                        </button>
-                      </div>
-                    )}
-                  </div>
                   {claimedSlug ? (
                     <span className="inline-flex items-center gap-1.5 text-xs text-emerald-700 bg-emerald-50 px-2.5 py-1 rounded-full font-medium">
                       <BadgeCheck className="h-3.5 w-3.5" />
@@ -545,6 +497,10 @@ export function ProfileView({
 
         {activeTab === 'publications' && (
           <PublicationsList publications={data.publications} openAccess={data.openAccess} />
+        )}
+
+        {activeTab === 'narrativecv' && (
+          <NarrativeCvTab data={data} geoData={prefetchedGeo} />
         )}
         </div>
       </main>

--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -640,15 +640,16 @@ export function generateNarrativeParagraphs(data: Author, pIndexResult?: PIndexR
         collabPct = `A small fraction (${metrics.collaborationScore}%)`;
       }
       collabParagraph = `${collabPct} of ${lastName}'s publications are co-authored, with an average of **${metrics.averageAuthors}** authors per paper across **${metrics.totalCoAuthors}** unique co-author${metrics.totalCoAuthors !== 1 ? 's' : ''}.`;
-      const topAuthors = metrics.topCoAuthors?.filter(a => a.papers >= 2) ?? [];
-      if (topAuthors.length > 0) {
-        const authorList = topAuthors.map(a => `${a.name} (${a.papers})`);
-        if (authorList.length === 1) {
-          collabParagraph += ` ${lastName}'s most frequent collaborator is ${authorList[0]} papers.`;
-        } else {
-          const last = authorList.pop()!;
-          collabParagraph += ` ${lastName}'s most frequent collaborators are ${authorList.join(', ')}, and ${last} papers.`;
-        }
+      if (metrics.topCoAuthor && metrics.topCoAuthorPapers >= 2) {
+        collabParagraph += ` ${lastName}'s most frequent collaborator is ${metrics.topCoAuthor}, with whom they have published **${metrics.topCoAuthorPapers}** papers.`;
+      }
+      const otherCoAuthors = (metrics.topCoAuthors ?? [])
+        .filter(a => a.papers >= 2 && a.name !== metrics.topCoAuthor);
+      if (otherCoAuthors.length > 0) {
+        const names = otherCoAuthors.map(a => `${a.name} (${a.papers})`);
+        const last = names.pop()!;
+        const list = names.length > 0 ? `${names.join(', ')}, and ${last}` : last;
+        collabParagraph += ` Other frequent co-authors include ${list}.`;
       }
       paragraphs.push(collabParagraph);
     } else if (publications.length > 0) {

--- a/src/utils/narrativeCvExport.ts
+++ b/src/utils/narrativeCvExport.ts
@@ -232,9 +232,11 @@ function topicString(data: Author): string {
 // Main export
 // ============================================================
 
+export type NarrativeCvFormat = 'nwo' | 'erc' | 'msca';
+
 export async function exportNarrativeCv(
   data: Author,
-  format: 'nwo' | 'erc',
+  format: NarrativeCvFormat,
   geoData?: { mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null
 ): Promise<void> {
   let resolvedOrcidId = data.openAccess?.orcid;
@@ -244,9 +246,13 @@ export async function exportNarrativeCv(
   }
   const orcid = resolvedOrcidId ? await fetchOrcidProfile(resolvedOrcidId) : null;
 
-  const children = format === 'nwo'
-    ? buildNwo(data, orcid, resolvedOrcidId, geoData)
-    : buildErc(data, orcid, resolvedOrcidId, geoData);
+  const builders: Record<NarrativeCvFormat, () => Paragraph[]> = {
+    nwo: () => buildNwo(data, orcid, resolvedOrcidId, geoData),
+    erc: () => buildErc(data, orcid, resolvedOrcidId, geoData),
+    msca: () => buildMsca(data, orcid, resolvedOrcidId, geoData),
+  };
+
+  const children = builders[format]();
 
   const doc = new Document({
     sections: [{
@@ -260,8 +266,8 @@ export async function exportNarrativeCv(
   const blob = await Packer.toBlob(doc);
   const safeName = data.name.replace(/[^a-zA-Z0-9]/g, '_');
   const dateStr = new Date().toISOString().slice(0, 10);
-  const prefix = format === 'nwo' ? 'NWO_EBCV' : 'ERC_CV';
-  saveAs(blob, `ScholarFolio_${prefix}_${safeName}_${dateStr}.docx`);
+  const prefixes: Record<NarrativeCvFormat, string> = { nwo: 'NWO_EBCV', erc: 'ERC_CV', msca: 'MSCA_CV' };
+  saveAs(blob, `ScholarFolio_${prefixes[format]}_${safeName}_${dateStr}.docx`);
 }
 
 // ============================================================
@@ -540,5 +546,121 @@ function buildErc(
   p.push(placeholderParagraph('[Add: international collaborations, research networks, and mobility.]'));
 
   p.push(footerParagraph('ERC CV & Track Record'));
+  return p;
+}
+
+// ============================================================
+// MSCA Postdoctoral Fellowship (Part B2 - CV)
+// Citation counts acceptable, no JIF requirement
+// ============================================================
+
+function buildMsca(
+  data: Author,
+  orcid: OrcidProfile | null,
+  orcidId: string | undefined,
+  _geoData?: { mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null,
+): Paragraph[] {
+  const p: Paragraph[] = [];
+  const narrative = generateNarrativeParagraphs(data);
+
+  // Header
+  p.push(new Paragraph({
+    children: [new TextRun({ text: 'MSCA POSTDOCTORAL FELLOWSHIP — CV (Part B2)', font: 'Calibri', size: 16, color: PLACEHOLDER })],
+    spacing: { after: 100 },
+  }));
+  p.push(new Paragraph({
+    children: [new TextRun({ text: data.name, bold: true, font: 'Calibri', size: 36, color: DARK })],
+    spacing: { after: 60 },
+  }));
+  if (data.affiliation) {
+    p.push(new Paragraph({
+      children: [new TextRun({ text: data.affiliation, font: 'Calibri', size: 22, color: GRAY })],
+      spacing: { after: 200 },
+    }));
+  }
+
+  p.push(placeholderParagraph(
+    'MSCA Postdoctoral Fellowship CV. No strict page limit for Part B2, but keep concise. ' +
+    'Complete placeholder sections before submission.'
+  ));
+
+  // Personal details
+  p.push(sectionHeading('Personal Details'));
+  p.push(labelValueParagraph('Name', data.name));
+  if (data.affiliation) p.push(labelValueParagraph('Current affiliation', data.affiliation));
+  if (orcidId) p.push(labelValueParagraph('ORCID', orcidId));
+  if (data.topics.length > 0) {
+    const topicNames = data.topics.map(t =>
+      typeof t.name === 'object' ? (t.name as { title?: string }).title || '' : String(t.name)
+    ).filter(Boolean);
+    p.push(labelValueParagraph('Research areas', topicNames.slice(0, 5).join(', ')));
+  }
+  p.push(placeholderParagraph('[Add: nationality, date of birth, contact details]'));
+
+  // Education
+  p.push(sectionHeading('Education'));
+  if (orcid?.educations?.length) {
+    p.push(...educationEntries(orcid.educations));
+  } else {
+    p.push(placeholderParagraph('[PhD degree, institution, year, thesis title]'));
+    p.push(placeholderParagraph('[MSc / MA degree, institution, year]'));
+  }
+
+  // Research experience
+  p.push(sectionHeading('Research Experience & Positions'));
+  if (orcid?.employments?.length) {
+    p.push(...employmentEntries(orcid.employments));
+  } else {
+    if (data.affiliation) p.push(bodyParagraph(`Current: ${data.affiliation}`));
+    p.push(placeholderParagraph('[Add: previous research positions with dates]'));
+  }
+
+  // Publications
+  p.push(sectionHeading('Publications'));
+  if (narrative[0]) p.push(bodyParagraph(stripMarkdown(narrative[0])));
+
+  p.push(subHeading('Selected publications'));
+  const keyOutputs = selectKeyOutputs(data.publications);
+  p.push(...publicationEntries(keyOutputs, data.openAccess, true));
+
+  // Grants & awards
+  p.push(sectionHeading('Grants, Fellowships & Awards'));
+  if (orcid?.fundings?.length) {
+    p.push(...fundingEntries(orcid.fundings));
+  } else {
+    p.push(placeholderParagraph('[List research grants and fellowships received]'));
+  }
+  if (orcid?.distinctions?.length) {
+    p.push(subHeading('Awards'));
+    for (const dist of orcid.distinctions) {
+      const yearStr = dist.year ? ` (${dist.year})` : '';
+      p.push(bodyParagraph(`${dist.title} — ${dist.organization}${yearStr}`));
+    }
+  } else {
+    p.push(placeholderParagraph('[List academic awards and prizes]'));
+  }
+
+  // Supervision & teaching
+  p.push(sectionHeading('Supervision & Teaching'));
+  p.push(placeholderParagraph('[List students supervised (PhD, MSc), courses taught, mentoring activities]'));
+
+  // Institutional responsibilities
+  p.push(sectionHeading('Institutional Responsibilities & Service'));
+  p.push(placeholderParagraph('[List editorial board memberships, reviewing activities, conference organisation]'));
+
+  // International mobility
+  p.push(sectionHeading('International Mobility & Collaboration'));
+  const collabPara = narrative.find(n =>
+    n.includes('co-authored') || n.includes('collaborator') || n.includes('single-authored')
+  );
+  if (collabPara) p.push(bodyParagraph(stripMarkdown(collabPara)));
+  p.push(placeholderParagraph('[Describe international research stays, mobility, and collaboration networks]'));
+
+  // Transferable skills & career breaks
+  p.push(sectionHeading('Transferable Skills & Career Breaks'));
+  p.push(placeholderParagraph('[Describe transferable skills (project management, outreach, industry collaboration)]'));
+  p.push(placeholderParagraph('[If applicable, explain any career breaks, parental leave, or non-standard career paths]'));
+
+  p.push(footerParagraph('MSCA Postdoctoral Fellowship CV'));
   return p;
 }


### PR DESCRIPTION
## Summary
- Moved Narrative CV from a tiny header dropdown to a full **dedicated tab** with 3 format cards
- Each card shows: grant names it covers, metrics policy, info tooltip, and export button
- Added **MSCA Postdoctoral Fellowship** CV format (Part B2)
- Fixed co-author narrative: names top collaborator by name, then lists up to 3 others with ≥2 shared papers
- Removed old dropdown from profile header

## Test plan
- [ ] Verify "Narrative CV" tab appears in the tab bar with FileText icon
- [ ] Click each format card → .docx downloads correctly
- [ ] Info tooltips show on hover/click with detailed format descriptions
- [ ] Co-author paragraph: "most frequent collaborator is X (N papers). Other frequent co-authors include Y (N), Z (N)."

🤖 Generated with [Claude Code](https://claude.com/claude-code)