### PR TITLE
Search by researcher name with results dropdown

### DIFF
--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -644,7 +644,8 @@ export function generateNarrativeParagraphs(data: Author, pIndexResult?: PIndexR
         collabParagraph += ` ${lastName}'s most frequent collaborator is ${metrics.topCoAuthor}, with whom they have published **${metrics.topCoAuthorPapers}** papers.`;
       }
       const otherCoAuthors = (metrics.topCoAuthors ?? [])
-        .filter(a => a.papers >= 2 && a.name !== metrics.topCoAuthor);
+        .slice(1) // skip #1 (already mentioned above)
+        .filter(a => a.papers >= 2);
       if (otherCoAuthors.length > 0) {
         const names = otherCoAuthors.map(a => `${a.name} (${a.papers})`);
         const last = names.pop()!;

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
-import { Search, ExternalLink, Loader2, AlertCircle, BookOpen } from 'lucide-react';
-import { ApiError } from '../utils/api';
+import { Search, ExternalLink, Loader2, AlertCircle, BookOpen, User } from 'lucide-react';
 import DOMPurify from 'dompurify';
+import { scholarService, type AuthorSearchResult } from '../services/scholar/index';
 
 interface SearchBarProps {
   onSearch: (url: string) => void;
@@ -10,23 +10,35 @@ interface SearchBarProps {
   error?: string | null;
 }
 
+function isScholarUrl(input: string): boolean {
+  try {
+    const urlObj = new URL(input.trim());
+    return urlObj.hostname.includes('scholar.google.') && urlObj.searchParams.has('user');
+  } catch {
+    return false;
+  }
+}
+
 export function SearchBar({ onSearch, isLoading = false, compact = false, error: externalError }: SearchBarProps) {
-  const [url, setUrl] = useState('');
+  const [input, setInput] = useState('');
   const [localError, setLocalError] = useState<string | null>(null);
   const [progress, setProgress] = useState(0);
   const progressRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [searchResults, setSearchResults] = useState<AuthorSearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [showResults, setShowResults] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const error = externalError || localError;
 
-  // Progress bar that accelerates to ~90% over ~8s, then waits for completion
+  // Progress bar
   useEffect(() => {
     if (isLoading) {
       setProgress(0);
       const startTime = Date.now();
-      const estimatedDuration = 8000; // 8 seconds estimated
+      const estimatedDuration = 8000;
       progressRef.current = setInterval(() => {
         const elapsed = Date.now() - startTime;
-        // Asymptotic curve: approaches 90% but never reaches it
         const p = 90 * (1 - Math.exp(-2.5 * elapsed / estimatedDuration));
         setProgress(Math.min(p, 90));
       }, 100);
@@ -36,7 +48,6 @@ export function SearchBar({ onSearch, isLoading = false, compact = false, error:
         progressRef.current = null;
       }
       if (progress > 0) {
-        // Animate to 100% on completion
         setProgress(100);
         const timeout = setTimeout(() => setProgress(0), 500);
         return () => clearTimeout(timeout);
@@ -50,81 +61,96 @@ export function SearchBar({ onSearch, isLoading = false, compact = false, error:
     };
   }, [isLoading]);
 
-  const validateUrl = useCallback((url: string): boolean => {
-    try {
-      // Parse URL to validate format
-      const urlObj = new URL(url.trim());
-      
-      // Check if it's a Google Scholar URL (any country domain)
-      const isGoogleScholar = urlObj.hostname.includes('scholar.google.');
-      
-      // Check if it has a user parameter
-      const hasUserParam = urlObj.searchParams.has('user');
-      
-      // Check if the user parameter has a valid format
-      const userId = urlObj.searchParams.get('user');
-      const validUserIdFormat = userId && userId.length >= 12;
-      
-      return isGoogleScholar && hasUserParam && validUserIdFormat;
-    } catch (e) {
-      // If URL parsing fails, it's not a valid URL
-      return false;
-    }
-  }, []);
+  // Close results dropdown when clicking outside
+  useEffect(() => {
+    if (!showResults) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShowResults(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showResults]);
 
   const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
-    const trimmedUrl = url.trim();
+    const trimmed = input.trim();
     setLocalError(null);
-    
-    if (!trimmedUrl) {
-      setLocalError('Please enter a Google Scholar profile URL');
+
+    if (!trimmed) {
+      setLocalError('Enter a researcher name or Google Scholar URL');
       return;
     }
 
-    // Clear any previous errors before validation
-    setLocalError(null);
-    
-    if (!validateUrl(trimmedUrl)) {
-      setLocalError('Invalid URL format. Please enter a valid Google Scholar profile URL');
-      return;
-    }
-
-    try {
-      // Sanitize URL before processing
-      const sanitizedUrl = DOMPurify.sanitize(trimmedUrl);
-      
-      // Normalize the URL
-      const urlObj = new URL(sanitizedUrl);
-      const userId = urlObj.searchParams.get('user');
-      
-      if (!userId) {
-        setLocalError('Invalid Google Scholar URL. Missing user ID parameter.');
-        return;
+    // If it looks like a URL, handle it directly
+    if (isScholarUrl(trimmed)) {
+      const sanitized = DOMPurify.sanitize(trimmed);
+      try {
+        const urlObj = new URL(sanitized);
+        const userId = urlObj.searchParams.get('user');
+        if (!userId || userId.length < 12) {
+          setLocalError('Invalid Google Scholar URL. Missing or invalid user ID.');
+          return;
+        }
+        const normalizedUrl = `https://scholar.google.com/citations?user=${encodeURIComponent(userId)}`;
+        setShowResults(false);
+        onSearch(normalizedUrl);
+      } catch {
+        setLocalError('Invalid URL format.');
       }
-
-      // Create a clean normalized URL with just the user parameter
-      const normalizedUrl = `https://scholar.google.com/citations?user=${encodeURIComponent(userId)}`;
-
-      onSearch(normalizedUrl);
-    } catch (err) {
-      setLocalError('Invalid URL format. Please check the URL and try again.');
+      return;
     }
-  }, [url, onSearch, validateUrl]);
 
-  const handleUrlChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setUrl(e.target.value);
+    // Otherwise, search by name
+    if (trimmed.length < 2) {
+      setLocalError('Please enter at least 2 characters to search');
+      return;
+    }
+
+    setSearching(true);
+    setSearchResults([]);
+    setShowResults(true);
+    try {
+      const results = await scholarService.searchAuthors(trimmed);
+      setSearchResults(results);
+      if (results.length === 0) {
+        setLocalError('No researchers found. Try a different name or paste a Google Scholar URL.');
+        setShowResults(false);
+      }
+    } catch {
+      setLocalError('Search failed. Try pasting a Google Scholar URL instead.');
+      setShowResults(false);
+    } finally {
+      setSearching(false);
+    }
+  }, [input, onSearch]);
+
+  const handleSelectAuthor = useCallback((result: AuthorSearchResult) => {
+    const url = `https://scholar.google.com/citations?user=${encodeURIComponent(result.authorId)}`;
+    setShowResults(false);
+    setSearchResults([]);
+    setInput(result.name);
+    onSearch(url);
+  }, [onSearch]);
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput(e.target.value);
     setLocalError(null);
+    if (!e.target.value.trim()) {
+      setShowResults(false);
+      setSearchResults([]);
+    }
   }, []);
 
   const handleSampleLink = useCallback(() => {
     const sampleUrl = 'https://scholar.google.com/citations?user=NOSPtp8AAAAJ&hl=en';
-    setUrl(sampleUrl);
+    setInput(sampleUrl);
     setLocalError(null);
   }, []);
 
   return (
-    <form onSubmit={handleSubmit} className="w-full">
+    <form onSubmit={handleSubmit} className="w-full" ref={containerRef}>
       <div className="relative search-focus-glow rounded-lg transition-all">
         {error && (
           <div className="absolute -top-6 left-0 right-0 text-xs text-[#64748b] flex items-center">
@@ -133,14 +159,14 @@ export function SearchBar({ onSearch, isLoading = false, compact = false, error:
           </div>
         )}
         <input
-          type="url"
-          value={url}
-          onChange={handleUrlChange}
-          placeholder="Enter Google Scholar profile URL..."
+          type="text"
+          value={input}
+          onChange={handleInputChange}
+          placeholder="Search by name or paste Google Scholar URL..."
           disabled={isLoading}
           className={`w-full ${
-            compact 
-              ? 'py-1.5 pl-9 pr-16 text-xs' 
+            compact
+              ? 'py-1.5 pl-9 pr-16 text-xs'
               : 'py-3 pl-12 pr-24 text-sm'
           } text-gray-700 bg-white border ${
             error ? 'border-[#64748b] focus:border-[#2d7d7d] focus:ring-[#2d7d7d]/20' : 'border-gray-200 focus:border-[#2d7d7d] focus:ring-[#2d7d7d]/20'
@@ -151,19 +177,19 @@ export function SearchBar({ onSearch, isLoading = false, compact = false, error:
         <div className={`absolute ${
           compact ? 'left-3 top-2' : 'left-4 top-3.5'
         } flex items-center justify-center`}>
-          <ExternalLink className={`h-5 w-5 ${error ? 'text-[#64748b]' : 'gradient-icon'}`} />
+          <Search className={`h-5 w-5 ${error ? 'text-[#64748b]' : 'gradient-icon'}`} />
         </div>
         <button
           type="submit"
-          disabled={!url.trim() || isLoading}
+          disabled={!input.trim() || isLoading || searching}
           className={`absolute flex items-center justify-center ${
             compact ? 'right-2 top-1' : 'right-2 top-2'
           } px-4 py-1.5 bg-[#2d7d7d] text-white rounded-lg btn-lift disabled:opacity-50 disabled:cursor-not-allowed space-x-2 text-xs min-w-[80px]`}
         >
-          {isLoading ? (
+          {isLoading || searching ? (
             <>
               <div className="h-4 w-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-              <span>Loading...</span>
+              <span>{searching ? 'Searching...' : 'Loading...'}</span>
             </>
           ) : (
             <>
@@ -172,6 +198,61 @@ export function SearchBar({ onSearch, isLoading = false, compact = false, error:
             </>
           )}
         </button>
+
+        {/* Search results dropdown */}
+        {showResults && searchResults.length > 0 && (
+          <div className="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-xl shadow-xl z-50 max-h-[400px] overflow-y-auto">
+            <div className="px-3 py-2 border-b border-gray-100 dark:border-slate-700">
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {searchResults.length} result{searchResults.length !== 1 ? 's' : ''} found — select a profile
+              </p>
+            </div>
+            {searchResults.map((result, i) => (
+              <button
+                key={result.authorId}
+                type="button"
+                onClick={() => handleSelectAuthor(result)}
+                className={`w-full text-left px-3 py-3 hover:bg-gray-50 dark:hover:bg-slate-700/50 transition-colors flex items-start gap-3 ${
+                  i < searchResults.length - 1 ? 'border-b border-gray-100 dark:border-slate-700/50' : ''
+                }`}
+              >
+                {result.imageUrl ? (
+                  <img
+                    src={result.imageUrl}
+                    alt=""
+                    className="h-10 w-10 rounded-full object-cover flex-shrink-0 bg-gray-100"
+                    onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                  />
+                ) : (
+                  <div className="h-10 w-10 rounded-full bg-gray-100 dark:bg-slate-700 flex items-center justify-center flex-shrink-0">
+                    <User className="h-5 w-5 text-gray-400" />
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                    {result.name}
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5">
+                    {result.affiliation}
+                  </p>
+                  <div className="flex items-center gap-3 mt-1">
+                    {result.citedBy > 0 && (
+                      <span className="text-xs text-gray-400 dark:text-gray-500">
+                        {result.citedBy.toLocaleString()} citations
+                      </span>
+                    )}
+                    {result.interests.length > 0 && (
+                      <span className="text-xs text-gray-400 dark:text-gray-500 truncate">
+                        {result.interests.slice(0, 3).join(', ')}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <ExternalLink className="h-4 w-4 text-gray-300 dark:text-gray-600 flex-shrink-0 mt-1" />
+              </button>
+            ))}
+          </div>
+        )}
       </div>
 
       {isLoading && (
@@ -191,7 +272,7 @@ export function SearchBar({ onSearch, isLoading = false, compact = false, error:
           </p>
         </div>
       )}
-      
+
       {error && !compact && (
         <div className="mt-2 flex items-start space-x-1">
           <div className="flex items-center space-x-1 text-[#64748b] text-xs">
@@ -200,12 +281,12 @@ export function SearchBar({ onSearch, isLoading = false, compact = false, error:
           </div>
         </div>
       )}
-      
+
       {!error && !compact && (
         <div className="mt-2 flex items-center justify-between text-xs text-gray-500">
           <div className="flex items-center space-x-1">
             <Search className="h-3.5 w-3.5 gradient-icon" />
-            <span>Enter a Google Scholar profile URL to explore your profile</span>
+            <span>Search by name or paste a Google Scholar profile URL</span>
           </div>
           <button
             type="button"


### PR DESCRIPTION
## Summary
- SearchBar now accepts both **researcher names** and Google Scholar URLs
- Typing a name and pressing Explore triggers author search (SerpAPI → fallback scraper)
- Results appear in a dropdown showing photo, name, affiliation, citation count, interests
- Clicking a result loads their full profile
- Also fixed co-author narrative dedup bug (top co-author appeared twice)

## Test plan
- [ ] Type a name (e.g. "Jonas Heller") → see dropdown with results
- [ ] Click a result → profile loads correctly
- [ ] Paste a Scholar URL → still works as before (no dropdown)
- [ ] Verify co-author paragraph doesn't repeat names

🤖 Generated with [Claude Code](https://claude.com/claude-code)