### PR TITLE
Fix credit race conditions + persistent rate limiting

### DIFF
--- a/supabase/functions/scholar/index.ts
+++ b/supabase/functions/scholar/index.ts
@@ -20,39 +20,20 @@ function getCorsHeaders(req: Request) {
 // In-flight request coalescing to prevent duplicate API calls
 const inflightRequests = new Map<string, Promise<any>>();
 
-// --- IP-based rate limiting (in-memory, per edge function instance) ---
-const ipRequestLog = new Map<string, number[]>();
-const RATE_LIMIT_WINDOW = 3600_000; // 1 hour in ms
+// --- Rate limit constants ---
 const RATE_LIMIT_MAX_PROFILE = 10;  // max profile fetches per IP per hour
 const RATE_LIMIT_MAX_SEARCH = 20;   // max name searches per IP per hour
 const ANON_DAILY_LIMIT = 5;         // max profile fetches per IP per day (anonymous)
-const ANON_DAILY_WINDOW = 86400_000;
-
-function checkRateLimit(ip: string, limit: number, window: number = RATE_LIMIT_WINDOW): boolean {
-  const now = Date.now();
-  const timestamps = ipRequestLog.get(ip) || [];
-  const recent = timestamps.filter(t => t > now - window);
-  ipRequestLog.set(ip, recent);
-  if (recent.length >= limit) return false; // rate limited
-  recent.push(now);
-  return true; // allowed
-}
 
 function getRequestIp(req: Request): string {
-  return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
-    || req.headers.get('x-real-ip')
-    || 'unknown';
-}
-
-// Clean up old entries every 10 minutes to prevent memory leaks
-setInterval(() => {
-  const cutoff = Date.now() - ANON_DAILY_WINDOW;
-  for (const [ip, timestamps] of ipRequestLog) {
-    const recent = timestamps.filter(t => t > cutoff);
-    if (recent.length === 0) ipRequestLog.delete(ip);
-    else ipRequestLog.set(ip, recent);
+  // Use last entry in x-forwarded-for chain (harder to spoof)
+  const xff = req.headers.get('x-forwarded-for');
+  if (xff) {
+    const parts = xff.split(',').map(s => s.trim()).filter(Boolean);
+    return parts[parts.length - 1] || 'unknown';
   }
-}, 600_000);
+  return req.headers.get('x-real-ip') || 'unknown';
+}
 
 const CACHE_DURATION = 604800; // 7 days in seconds
 const SERPAPI_KEY = Deno.env.get('SERPAPI_KEY') ?? '';
@@ -793,8 +774,8 @@ Deno.serve(async (req) => {
     const jwt = authHeader.replace('Bearer ', '');
     let userId: string | null = null;
 
-    // Try to get authenticated user from JWT
-    if (jwt && jwt !== (Deno.env.get('SUPABASE_ANON_KEY') ?? '')) {
+    // Attempt auth on any non-empty bearer token
+    if (jwt) {
       const { data: { user: authUser }, error: authError } = await supabase.auth.getUser(jwt);
       if (!authError && authUser) {
         userId = authUser.id;
@@ -803,12 +784,20 @@ Deno.serve(async (req) => {
 
     // --- Author search by name (no credit cost, but rate limited) ---
     if (action === 'search' && query) {
-      if (!checkRateLimit(`search:${clientIp}`, RATE_LIMIT_MAX_SEARCH)) {
+      const { data: searchAllowed } = await supabase.rpc('check_search_rate_limit', {
+        p_ip: clientIp, p_limit: RATE_LIMIT_MAX_SEARCH
+      });
+      if (searchAllowed === false) {
         return new Response(
           JSON.stringify({ error: "Too many searches. Please try again later." }),
           { status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" } }
         );
       }
+      // Log the search request for rate limiting
+      await supabase.from('request_logs').insert({
+        ip: clientIp, source: 'search', user_id: userId || null,
+        author_id: null, origin: req.headers.get('Origin'), user_agent: req.headers.get('User-Agent')
+      }).catch(() => {});
       console.log(`[Search] Searching for authors: ${query}`);
       const results = await searchAuthorsByName(query);
       return new Response(
@@ -827,21 +816,28 @@ Deno.serve(async (req) => {
       );
     }
 
-    // --- Rate limit profile fetches ---
-    // Per-hour limit for all users (prevents rapid-fire abuse)
-    if (!checkRateLimit(`profile:${clientIp}`, RATE_LIMIT_MAX_PROFILE)) {
+    // --- Rate limit profile fetches (persistent, DB-backed) ---
+    const { data: profileAllowed } = await supabase.rpc('check_rate_limit', {
+      p_ip: clientIp, p_limit: RATE_LIMIT_MAX_PROFILE, p_window_seconds: 3600
+    });
+    if (profileAllowed === false) {
       return new Response(
         JSON.stringify({ error: "Too many requests. Please try again later." }),
         { status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" } }
       );
     }
 
-    // Tighter daily limit for anonymous users (server-side enforcement)
-    if (!userId && !checkRateLimit(`anon:${clientIp}`, ANON_DAILY_LIMIT, ANON_DAILY_WINDOW)) {
-      return new Response(
-        JSON.stringify({ error: "Daily search limit reached. Sign up for more free searches." }),
-        { status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" } }
-      );
+    // Tighter daily limit for anonymous users
+    if (!userId) {
+      const { data: anonAllowed } = await supabase.rpc('check_anon_daily_limit', {
+        p_ip: clientIp, p_limit: ANON_DAILY_LIMIT
+      });
+      if (anonAllowed === false) {
+        return new Response(
+          JSON.stringify({ error: "Daily search limit reached. Sign up for more free searches." }),
+          { status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        );
+      }
     }
 
     console.log(`Processing request for URL: ${profileUrl}`);
@@ -946,18 +942,10 @@ Deno.serve(async (req) => {
 
       if (decrError) {
         console.error("Credit decrement error:", decrError);
-        // Fallback: check credits manually
-        const { data: fallback } = await supabase
-          .from('user_credits')
-          .select('credits_remaining')
-          .eq('user_id', userId)
-          .maybeSingle();
-        if ((fallback?.credits_remaining ?? 0) <= 0) {
-          return new Response(
-            JSON.stringify({ error: "No credits remaining. Please purchase more searches." }),
-            { status: 403, headers: { ...corsHeaders, "Content-Type": "application/json" } }
-          );
-        }
+        return new Response(
+          JSON.stringify({ error: "Credit check failed. Please try again." }),
+          { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        );
       } else if (success === false) {
         return new Response(
           JSON.stringify({ error: "No credits remaining. Please purchase more searches." }),
@@ -985,18 +973,7 @@ Deno.serve(async (req) => {
     } catch (fetchError) {
       if (creditDeducted && userId) {
         console.log(`[Credits] Refunding deducted credit after failed fetch for user ${userId}`);
-        const { data: currentCredits } = await supabase
-          .from('user_credits')
-          .select('credits_remaining')
-          .eq('user_id', userId)
-          .maybeSingle();
-
-        if (currentCredits) {
-          await supabase
-            .from('user_credits')
-            .update({ credits_remaining: currentCredits.credits_remaining + 1 })
-            .eq('user_id', userId);
-        }
+        await supabase.rpc('refund_credit', { p_user_id: userId });
       }
       throw fetchError;
     }

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -77,31 +77,8 @@ Deno.serve(async (req) => {
         });
       }
 
-      // Add credits to user
-      const { data: current } = await supabase
-        .from('user_credits')
-        .select('credits_remaining, total_purchased')
-        .eq('user_id', userId)
-        .maybeSingle();
-
-      if (current) {
-        await supabase
-          .from('user_credits')
-          .update({
-            credits_remaining: current.credits_remaining + credits,
-            total_purchased: current.total_purchased + credits,
-          })
-          .eq('user_id', userId);
-      } else {
-        // User row doesn't exist yet (shouldn't happen with trigger, but just in case)
-        await supabase
-          .from('user_credits')
-          .insert({
-            user_id: userId,
-            credits_remaining: credits,
-            total_purchased: credits,
-          });
-      }
+      // Atomically add credits (handles upsert internally)
+      await supabase.rpc('increment_credits', { p_user_id: userId, p_amount: credits });
 
       console.log(`[Webhook] Successfully added ${credits} credits for user ${userId}`);
     }

--- a/supabase/migrations/20260603_credit_atomicity_and_rate_limits.sql
+++ b/supabase/migrations/20260603_credit_atomicity_and_rate_limits.sql
@@ -1,0 +1,104 @@
+-- 1. Atomic credit increment (for refunds and webhook credit adds)
+CREATE OR REPLACE FUNCTION increment_credits(p_user_id uuid, p_amount integer DEFAULT 1)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  UPDATE user_credits
+  SET credits_remaining = credits_remaining + p_amount,
+      total_purchased = total_purchased + p_amount
+  WHERE user_id = p_user_id;
+
+  -- If no row existed, create one
+  IF NOT FOUND THEN
+    INSERT INTO user_credits (user_id, credits_remaining, total_purchased)
+    VALUES (p_user_id, p_amount, p_amount);
+  END IF;
+END;
+$$;
+
+-- 2. Atomic refund (only increments credits_remaining, not total_purchased)
+CREATE OR REPLACE FUNCTION refund_credit(p_user_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  UPDATE user_credits
+  SET credits_remaining = credits_remaining + 1
+  WHERE user_id = p_user_id;
+END;
+$$;
+
+-- 3. Persistent rate limit check using request_logs table
+-- Returns true if the request is ALLOWED, false if rate-limited
+CREATE OR REPLACE FUNCTION check_rate_limit(
+  p_ip text,
+  p_limit integer,
+  p_window_seconds integer DEFAULT 3600
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  recent_count integer;
+BEGIN
+  SELECT COUNT(*)
+  INTO recent_count
+  FROM request_logs
+  WHERE ip = p_ip
+    AND created_at > now() - (p_window_seconds || ' seconds')::interval;
+
+  RETURN recent_count < p_limit;
+END;
+$$;
+
+-- 4. Anon daily limit check (by IP, 24h window)
+CREATE OR REPLACE FUNCTION check_anon_daily_limit(p_ip text, p_limit integer DEFAULT 5)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  recent_count integer;
+BEGIN
+  SELECT COUNT(*)
+  INTO recent_count
+  FROM request_logs
+  WHERE ip = p_ip
+    AND user_id IS NULL
+    AND created_at > now() - interval '24 hours';
+
+  RETURN recent_count < p_limit;
+END;
+$$;
+
+-- 5. Search rate limit (separate from profile fetches)
+CREATE OR REPLACE FUNCTION check_search_rate_limit(p_ip text, p_limit integer DEFAULT 20)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  recent_count integer;
+BEGIN
+  SELECT COUNT(*)
+  INTO recent_count
+  FROM request_logs
+  WHERE ip = p_ip
+    AND source = 'search'
+    AND created_at > now() - interval '1 hour';
+
+  RETURN recent_count < p_limit;
+END;
+$$;
+
+-- 6. Index on request_logs for efficient rate limit queries
+CREATE INDEX IF NOT EXISTS idx_request_logs_ip_created
+  ON request_logs (ip, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_request_logs_ip_source_created
+  ON request_logs (ip, source, created_at DESC)
+  WHERE source = 'search';


### PR DESCRIPTION
## Summary
- **Credit atomicity**: All credit mutations now use atomic RPCs (`refund_credit`, `increment_credits`) instead of read-then-write patterns that allowed race conditions
- **Persistent rate limiting**: Replaced in-memory Maps (reset on cold start, per-instance) with DB-backed RPCs querying `request_logs` table — rate limits now actually persist across instances
- **JWT auth fix**: Removed fragile anon-key string comparison; now calls `getUser()` on any bearer token
- **IP spoofing mitigation**: Uses last entry in `x-forwarded-for` chain instead of first

## Pre-deploy checklist
- [ ] Apply SQL migration in Supabase dashboard (SQL Editor → paste `20260603_credit_atomicity_and_rate_limits.sql`)
- [ ] Deploy edge functions: `supabase functions deploy scholar --no-verify-jwt` and `supabase functions deploy stripe-webhook --no-verify-jwt`

## Test plan
- [ ] Verify credit deduction still works for authenticated users
- [ ] Verify refund on fetch failure
- [ ] Verify rate limiting blocks after threshold
- [ ] Verify Stripe webhook still adds credits
- [ ] Verify anonymous daily limit enforcement