### PR TITLE
Reduce bundle size from 1.9MB to 1.15MB

### DIFF
--- a/src/components/CitationNetwork.tsx
+++ b/src/components/CitationNetwork.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react';
-import * as d3 from 'd3';
+import { select, selectAll } from 'd3-selection';
+import { forceSimulation, forceLink, forceManyBody, forceCenter, forceCollide } from 'd3-force';
+import type { Simulation as D3Simulation, SimulationNodeDatum as D3SimulationNode } from 'd3-force';
+import { drag, type D3DragEvent } from 'd3-drag';
+import { zoom, zoomIdentity } from 'd3-zoom';
+import { scaleSequential } from 'd3-scale';
+import { interpolateRdYlGn, interpolateViridis } from 'd3-scale-chromatic';
 import { Network, Share2, BookOpen, Presentation as Citation, Users, Info, Clock, GitBranch, Waypoints, TrendingUp, UserCheck, Sparkles } from 'lucide-react';
 import type { Publication } from '../types/scholar';
 import { extractLastName } from '../utils/names';
@@ -183,7 +189,7 @@ const CLUSTER_COLORS = [
 
 export function CitationNetwork({ publications, fullScreen = false }: CitationNetworkProps) {
   const svgRef = useRef<SVGSVGElement>(null);
-  const simulationRef = useRef<d3.Simulation<Node, Link> | null>(null);
+  const simulationRef = useRef<D3Simulation<Node, Link> | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('publications');
   const [connectionLimit, setConnectionLimit] = useState<10 | 20>(10);
 
@@ -207,7 +213,7 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
   useEffect(() => {
     if (!svgRef.current || !publications.length) return;
 
-    d3.select(svgRef.current).selectAll('*').remove();
+    select(svgRef.current).selectAll('*').remove();
     stopSimulation();
 
     const showCitations = viewMode === 'citations';
@@ -346,14 +352,14 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
     const allYears = links.map(l => l.lastYear).filter((y): y is number => y != null);
     const minYear = allYears.length > 0 ? Math.min(...allYears) : 2000;
     const maxYear = allYears.length > 0 ? Math.max(...allYears) : 2024;
-    const temporalColorScale = d3.scaleSequential(d3.interpolateRdYlGn)
+    const temporalColorScale = scaleSequential(interpolateRdYlGn)
       .domain([minYear, maxYear]);
 
     // --- Set up visualization ---
     const width = svgRef.current.clientWidth;
     const height = svgRef.current.clientHeight;
 
-    const svg = d3.select(svgRef.current)
+    const svg = select(svgRef.current)
       .attr('viewBox', [0, 0, width, height]);
 
     const defs = svg.append('defs');
@@ -383,7 +389,7 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
     // Color scale for collaboration strength (used in non-cluster views)
     const maxPubs = Math.max(...nodes.filter(n => n.group !== 1).map(n => n.sharedPublications), 1);
     const maxCites = Math.max(...nodes.filter(n => n.group !== 1).map(n => n.sharedCitations), 1);
-    const strengthColorScale = d3.scaleSequential(d3.interpolateViridis)
+    const strengthColorScale = scaleSequential(interpolateViridis)
       .domain([0, showCitations ? maxCites : maxPubs]);
 
     // Node color based on view mode
@@ -441,8 +447,8 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
     }
 
     // Simulation
-    simulationRef.current = d3.forceSimulation(nodes as d3.SimulationNode[])
-      .force('link', d3.forceLink(links)
+    simulationRef.current = forceSimulation(nodes as D3SimulationNode[])
+      .force('link', forceLink(links)
         .id((d: any) => d.id)
         .distance(d => {
           const value = showCitations
@@ -451,15 +457,15 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
           return 250 / Math.sqrt(value);
         })
       )
-      .force('charge', d3.forceManyBody()
+      .force('charge', forceManyBody()
         .strength(d => {
           const node = d as Node;
           const value = showCitations ? node.sharedCitations : node.sharedPublications;
           return -300 * Math.sqrt(value);
         })
       )
-      .force('center', d3.forceCenter(width / 2, height / 2))
-      .force('collision', d3.forceCollide()
+      .force('center', forceCenter(width / 2, height / 2))
+      .force('collision', forceCollide()
         .radius(d => {
           const node = d as Node;
           const value = showCitations ? node.sharedCitations : node.sharedPublications;
@@ -503,7 +509,7 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
       .selectAll('g')
       .data(nodes)
       .join('g')
-      .call(d3.drag<SVGGElement, Node>()
+      .call(drag<SVGGElement, Node>()
         .on('start', dragstarted)
         .on('drag', dragged)
         .on('end', dragended));
@@ -590,7 +596,7 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
     });
 
     // Zoom — only transform the container, not individual node groups
-    const zoom = d3.zoom<SVGSVGElement, unknown>()
+    const zoom = zoom<SVGSVGElement, unknown>()
       .scaleExtent([0.1, 4])
       .on('zoom', (event) => {
         container.attr('transform', event.transform);
@@ -601,7 +607,7 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
     const initialScale = 0.8;
     svg.call(
       zoom.transform,
-      d3.zoomIdentity
+      zoomIdentity
         .translate(width / 2, height / 2)
         .scale(initialScale)
         .translate(-width / 2, -height / 2)
@@ -619,18 +625,18 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
         .attr('transform', d => `translate(${(d as any).x},${(d as any).y})`);
     });
 
-    function dragstarted(event: d3.D3DragEvent<SVGGElement, Node, Node>) {
+    function dragstarted(event: D3DragEvent<SVGGElement, Node, Node>) {
       if (!event.active && simulationRef.current) simulationRef.current.alphaTarget(0.3).restart();
       event.subject.fx = event.subject.x;
       event.subject.fy = event.subject.y;
     }
 
-    function dragged(event: d3.D3DragEvent<SVGGElement, Node, Node>) {
+    function dragged(event: D3DragEvent<SVGGElement, Node, Node>) {
       event.subject.fx = event.x;
       event.subject.fy = event.y;
     }
 
-    function dragended(event: d3.D3DragEvent<SVGGElement, Node, Node>) {
+    function dragended(event: D3DragEvent<SVGGElement, Node, Node>) {
       if (!event.active && simulationRef.current) simulationRef.current.alphaTarget(0);
       event.subject.fx = null;
       event.subject.fy = null;

--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
-import * as d3 from 'd3';
+import { select } from 'd3-selection';
+import { zoom as d3Zoom, zoomIdentity, type ZoomBehavior } from 'd3-zoom';
+import { geoNaturalEarth1, geoPath, geoCentroid, geoInterpolate, type GeoPermissibleObjects, type GeoProjection } from 'd3-geo';
 import * as topojson from 'topojson-client';
 import type { Topology, GeometryCollection } from 'topojson-specification';
 import { Globe, Info, MapPin, Users, Flag, ZoomIn, ZoomOut, RotateCcw } from 'lucide-react';
@@ -30,7 +32,7 @@ interface WorldTopology extends Topology {
 
 // Continent classification based on geographic centroid
 function classifyContinent(feature: GeoJSON.Feature): string {
-  const [lng, lat] = d3.geoCentroid(feature);
+  const [lng, lat] = geoCentroid(feature);
   if (lng >= -30 && lng <= 50 && lat > 35) return 'europe';
   if (lng >= -25 && lng <= 55 && lat <= 37 && lat >= -40) return 'africa';
   if (lng < -25 && lat > 15) return 'north-america';
@@ -69,8 +71,8 @@ const REGION_VIEWS = [
 export function CoAuthorMap({ publications, authorName, authorAffiliation, prefetchedData }: CoAuthorMapProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const zoomRef = useRef<d3.ZoomBehavior<SVGSVGElement, unknown> | null>(null);
-  const projectionRef = useRef<d3.GeoProjection | null>(null);
+  const zoomRef = useRef<ZoomBehavior<SVGSVGElement, unknown> | null>(null);
+  const projectionRef = useRef<GeoProjection | null>(null);
   const [loading, setLoading] = useState(true);
   const [geoData, setGeoData] = useState<{ mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null>(null);
   const [tooltip, setTooltip] = useState<TooltipState>({ visible: false, x: 0, y: 0, data: null });
@@ -105,8 +107,8 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
     setActiveRegion(regionId);
 
     if (regionId === 'world') {
-      d3.select(svg).transition().duration(750)
-        .call(zoom.transform, d3.zoomIdentity);
+      select(svg).transition().duration(750)
+        .call(zoom.transform, zoomIdentity);
       return;
     }
 
@@ -119,24 +121,24 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
     const pt = projection(region.center);
     if (!pt) return;
 
-    const transform = d3.zoomIdentity
+    const transform = zoomIdentity
       .translate(width / 2, height / 2)
       .scale(region.scale)
       .translate(-pt[0], -pt[1]);
 
-    d3.select(svg).transition().duration(750)
+    select(svg).transition().duration(750)
       .call(zoom.transform, transform);
   }, []);
 
   const handleZoomIn = useCallback(() => {
     if (!svgRef.current || !zoomRef.current) return;
-    d3.select(svgRef.current).transition().duration(300)
+    select(svgRef.current).transition().duration(300)
       .call(zoomRef.current.scaleBy, 1.5);
   }, []);
 
   const handleZoomOut = useCallback(() => {
     if (!svgRef.current || !zoomRef.current) return;
-    d3.select(svgRef.current).transition().duration(300)
+    select(svgRef.current).transition().duration(300)
       .call(zoomRef.current.scaleBy, 1 / 1.5);
   }, []);
 
@@ -153,22 +155,22 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
     const isMobile = width < 640;
     const height = isMobile ? Math.max(280, Math.round(width * 0.65)) : Math.max(360, Math.round(width * 0.5));
 
-    const svg = d3.select(svgRef.current);
+    const svg = select(svgRef.current);
     svg.selectAll('*').remove();
     svg.attr('viewBox', `0 0 ${width} ${height}`).attr('width', width).attr('height', height);
 
-    const projection = d3.geoNaturalEarth1()
+    const projection = geoNaturalEarth1()
       .scale(width / 6.5)
       .translate([width / 2, height / 2]);
     projectionRef.current = projection;
 
-    const pathGen = d3.geoPath().projection(projection);
+    const pathGen = geoPath().projection(projection);
 
     // Zoom behaviour
     const zoomGroup = svg.append('g');
 
     let currentScale = 1;
-    const zoom = d3.zoom<SVGSVGElement, unknown>()
+    const zoom = d3Zoom<SVGSVGElement, unknown>()
       .scaleExtent([0.5, 20])
       .on('zoom', event => {
         zoomGroup.attr('transform', event.transform);
@@ -197,7 +199,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
 
         // Outer sphere (ocean)
         zoomGroup.insert('path', ':first-child')
-          .datum({ type: 'Sphere' } as d3.GeoPermissibleObjects)
+          .datum({ type: 'Sphere' } as GeoPermissibleObjects)
           .attr('d', pathGen as unknown as string)
           .attr('fill', '#eaf4f4')
           .attr('stroke', '#d1fae5')
@@ -234,7 +236,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
               geometry: {
                 type: 'LineString',
                 coordinates: (() => {
-                  const interp = d3.geoInterpolate(
+                  const interp = geoInterpolate(
                     [geoData.mainAuthor!.lng, geoData.mainAuthor!.lat],
                     [coAuthor.lng, coAuthor.lat]
                   );

--- a/src/components/NarrativeCvTab.tsx
+++ b/src/components/NarrativeCvTab.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Download, Info, Loader2 } from 'lucide-react';
-import { exportNarrativeCv } from '../utils/narrativeCvExport';
-import type { NarrativeCvFormat } from '../utils/narrativeCvExport';
+// docx (~650KB) is dynamically imported on export click
+type NarrativeCvFormat = 'nwo' | 'erc' | 'msca';
 import type { Author, CoAuthorGeoData } from '../types/scholar';
 
 interface NarrativeCvTabProps {
@@ -54,6 +54,7 @@ export function NarrativeCvTab({ data, geoData }: NarrativeCvTabProps) {
   const handleExport = async (format: NarrativeCvFormat) => {
     setExporting(format);
     try {
+      const { exportNarrativeCv } = await import('../utils/narrativeCvExport');
       await exportNarrativeCv(data, format, geoData);
     } catch (err) {
       console.error('Narrative CV export failed:', err);

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -3,7 +3,7 @@ import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as Cha
 import { NarrativeCvTab } from './NarrativeCvTab';
 import { EmbedModal } from './EmbedModal';
 import { ClaimProfileModal } from './ClaimProfileModal';
-import { exportProfilePdf } from '../utils/pdfExport';
+// pdfExport is dynamically imported on click to avoid bundling jsPDF (344KB)
 import { SearchBar } from './SearchBar';
 import { TopicsList } from './TopicsList';
 import { PublicationsList } from './PublicationsList';
@@ -257,8 +257,9 @@ export function ProfileView({
                     </button>
                   )}
                   <button
-                    onClick={() => {
+                    onClick={async () => {
                       if (!data) return;
+                      const { exportProfilePdf } = await import('../utils/pdfExport');
                       exportProfilePdf(data, scholarId || undefined, prefetchedGeo);
                     }}
                     className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] hover:text-[#1a5c5c] bg-[#eaf4f4] hover:bg-[#d5ecec] px-2.5 py-1 rounded-full transition-colors"


### PR DESCRIPTION
## Summary
- Dynamic import jsPDF + pdfExport (397KB → separate chunk, loaded on PDF button click)
- Dynamic import docx + narrativeCvExport (364KB → separate chunk, loaded on export click)
- D3 sub-module imports instead of `import * as d3` (~300KB tree-shaken out)

**Result: popup.js 1,919KB → 1,152KB (40% reduction, 234KB gzip savings)**

## Test plan
- [ ] PDF export still works (click PDF button on profile)
- [ ] Narrative CV export still works (click Export .docx on Narrative CV tab)
- [ ] Citation network renders correctly
- [ ] Co-author map renders correctly