### PR TITLE
GDPR compliance: privacy policy, account deletion, log retention

### DIFF
--- a/src/components/AuthHeaderControls.tsx
+++ b/src/components/AuthHeaderControls.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Coins, Shield, LogOut, User, ChevronDown } from 'lucide-react';
+import { Coins, Shield, LogOut, User, ChevronDown, Trash2, Loader2 } from 'lucide-react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { AuthButton } from './AuthButton';
 import { useAuth } from '../contexts/AuthContext';
@@ -18,6 +18,9 @@ export function AuthHeaderControls({ onBuyCredits, onAdmin, anonSearchesUsed = 0
   const { user, credits, signOut } = useAuth();
   const isAdmin = user?.email === ADMIN_EMAIL;
   const [unresolvedCount, setUnresolvedCount] = useState(0);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isAdmin) return;
@@ -27,6 +30,32 @@ export function AuthHeaderControls({ onBuyCredits, onAdmin, anonSearchesUsed = 0
       .eq('resolved', false)
       .then(({ count }) => { if (count != null) setUnresolvedCount(count); });
   }, [isAdmin]);
+
+  const handleDeleteAccount = async () => {
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) throw new Error('Not authenticated');
+      const res = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL || ''}/functions/v1/delete-account`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session.access_token}`,
+          },
+        }
+      );
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error || 'Failed to delete account');
+      await supabase.auth.signOut();
+      window.location.reload();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : 'Something went wrong');
+      setDeleting(false);
+    }
+  };
 
   if (!user) {
     return (
@@ -117,17 +146,64 @@ export function AuthHeaderControls({ onBuyCredits, onAdmin, anonSearchesUsed = 0
             <DropdownMenu.Separator className="my-1.5 h-px bg-gray-200 dark:bg-gray-700" />
 
             <DropdownMenu.Item
-              className="flex items-center gap-2 px-3 py-2 text-xs text-red-600 dark:text-red-400 outline-none cursor-pointer hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+              className="flex items-center gap-2 px-3 py-2 text-xs text-gray-700 dark:text-gray-300 outline-none cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
               onSelect={signOut}
             >
               <LogOut className="h-3.5 w-3.5" />
               Sign out
             </DropdownMenu.Item>
 
+            <DropdownMenu.Item
+              className="flex items-center gap-2 px-3 py-2 text-xs text-red-600 dark:text-red-400 outline-none cursor-pointer hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+              onSelect={() => setShowDeleteConfirm(true)}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete account
+            </DropdownMenu.Item>
+
             <div className="h-1.5" />
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
       </DropdownMenu.Root>
+
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm">
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl border border-gray-200 dark:border-gray-700 p-6 max-w-sm mx-4">
+            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-2">Delete your account?</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+              This will permanently delete your account, credits, and all associated data. This action cannot be undone.
+            </p>
+            {deleteError && (
+              <p className="text-xs text-red-600 dark:text-red-400 mb-3 bg-red-50 dark:bg-red-900/20 rounded-lg p-2">
+                {deleteError}
+              </p>
+            )}
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => { setShowDeleteConfirm(false); setDeleteError(null); }}
+                disabled={deleting}
+                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleDeleteAccount}
+                disabled={deleting}
+                className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+              >
+                {deleting ? (
+                  <>
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    Deleting...
+                  </>
+                ) : (
+                  'Delete permanently'
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/PrivacyPage.tsx
+++ b/src/components/PrivacyPage.tsx
@@ -20,34 +20,105 @@ export function PrivacyPage({ onBack }: PrivacyPageProps) {
       </nav>
 
       <div className="max-w-2xl mx-auto px-6 py-20">
-        <h1 className="font-serif text-4xl font-bold text-[#1e293b] mb-10">Privacy Policy</h1>
+        <h1 className="font-serif text-4xl font-bold text-[#1e293b] mb-4">Privacy Policy</h1>
+        <p className="text-sm text-gray-500 mb-10">Last updated: June 3, 2026</p>
 
         <div className="space-y-8 text-[15px] text-[#334155] leading-relaxed">
-          <p>Scholar Folio collects the minimum data needed to run the service and prevent abuse.</p>
 
-          <p>
-            It does not use cookies beyond what is strictly necessary for the app to function.
-          </p>
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">1. Data Controller</h2>
+            <p>
+              Scholar Folio is operated by Jonas Heller, Assistant Professor at Maastricht University, the Netherlands.
+              For questions about this policy or your data, contact:{' '}
+              <a href="mailto:privacy@scholarfolio.org" className="text-[#2d7d7d] hover:underline">privacy@scholarfolio.org</a>.
+            </p>
+          </section>
 
-          <p>
-            Google Scholar profile IDs may be cached for a limited time so repeated profile refreshes are faster
-            and do not create unnecessary paid API requests.
-          </p>
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">2. What Data We Collect</h2>
+            <p className="mb-3">We collect and process the following categories of personal data:</p>
+            <ul className="list-disc list-inside space-y-1.5 ml-2">
+              <li><strong>Account data</strong> — email address and hashed password (when you sign up), or Google account email (when using Google Sign-In).</li>
+              <li><strong>Purchase data</strong> — Stripe payment session IDs, credit pack purchased, and amount. We do not store credit card numbers; Stripe handles all payment processing.</li>
+              <li><strong>Technical logs</strong> — IP address, user agent, request timestamp, and the Google Scholar profile ID searched. These are used for rate limiting, abuse prevention, and debugging. Logs are automatically deleted after 30 days.</li>
+              <li><strong>Local storage</strong> — We store a theme preference (<code>sf_theme</code>) and an anonymous search counter (<code>sf_searches</code>) in your browser's localStorage. These are strictly functional and contain no personal identifiers.</li>
+              <li><strong>Cached profile data</strong> — Publicly available Google Scholar profile data (name, affiliation, publications) is cached for up to 7 days to reduce redundant API calls.</li>
+            </ul>
+          </section>
 
-          <p>
-            Search requests may be logged with technical metadata such as timestamp, profile ID, IP address,
-            origin, and user agent. These logs are used for rate limiting, abuse prevention, debugging, and
-            basic service analytics.
-          </p>
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">3. Legal Basis for Processing</h2>
+            <ul className="list-disc list-inside space-y-1.5 ml-2">
+              <li><strong>Contract performance</strong> (Art. 6(1)(b) GDPR) — processing your account and purchase data to provide the service you signed up for.</li>
+              <li><strong>Legitimate interest</strong> (Art. 6(1)(f) GDPR) — technical logging for rate limiting, abuse prevention, and service stability. We have balanced this interest against your privacy rights and minimise the data collected.</li>
+              <li><strong>Legitimate interest</strong> (Art. 6(1)(f) GDPR) — caching publicly available Google Scholar data to provide the core service functionality.</li>
+            </ul>
+          </section>
 
-          <p>
-            No third-party advertising or data brokers.
-          </p>
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">4. Third-Party Processors</h2>
+            <p className="mb-3">We use the following third-party services to operate Scholar Folio:</p>
+            <ul className="list-disc list-inside space-y-1.5 ml-2">
+              <li><strong>Supabase</strong> (EU/US) — authentication, database hosting, and serverless functions.</li>
+              <li><strong>Stripe</strong> (US) — payment processing. Subject to <a href="https://stripe.com/privacy" target="_blank" rel="noopener noreferrer" className="text-[#2d7d7d] hover:underline">Stripe's Privacy Policy</a>.</li>
+              <li><strong>Netlify</strong> (US) — web hosting and CDN.</li>
+              <li><strong>SerpAPI</strong> (US) — Google Scholar data retrieval.</li>
+              <li><strong>OpenAlex / ORCID</strong> — public academic APIs used to enrich profile data. No personal data is sent to these services beyond the public identifiers being looked up.</li>
+            </ul>
+          </section>
 
-          <p>
-            The tool is hosted on Netlify. Netlify's own privacy policy applies to
-            infrastructure-level data.
-          </p>
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">5. Data Retention</h2>
+            <ul className="list-disc list-inside space-y-1.5 ml-2">
+              <li><strong>Account data</strong> — retained until you delete your account.</li>
+              <li><strong>Purchase records</strong> — retained for legal/tax compliance (7 years).</li>
+              <li><strong>Technical logs</strong> — automatically deleted after 30 days.</li>
+              <li><strong>Cached profiles</strong> — expire after 7 days and are periodically cleaned up.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">6. Your Rights</h2>
+            <p className="mb-3">Under the GDPR, you have the right to:</p>
+            <ul className="list-disc list-inside space-y-1.5 ml-2">
+              <li><strong>Access</strong> — request a copy of the personal data we hold about you.</li>
+              <li><strong>Rectification</strong> — correct inaccurate data.</li>
+              <li><strong>Erasure</strong> — delete your account and all associated data. You can do this directly from the user menu in the app, or by emailing us.</li>
+              <li><strong>Data portability</strong> — receive your data in a machine-readable format.</li>
+              <li><strong>Object</strong> — object to processing based on legitimate interest.</li>
+              <li><strong>Complaint</strong> — lodge a complaint with your local data protection authority. In the Netherlands, this is the <a href="https://autoriteitpersoonsgegevens.nl" target="_blank" rel="noopener noreferrer" className="text-[#2d7d7d] hover:underline">Autoriteit Persoonsgegevens</a>.</li>
+            </ul>
+            <p className="mt-3">
+              To exercise any of these rights, email{' '}
+              <a href="mailto:privacy@scholarfolio.org" className="text-[#2d7d7d] hover:underline">privacy@scholarfolio.org</a>.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">7. Cookies & Local Storage</h2>
+            <p>
+              Scholar Folio does not use tracking cookies or third-party analytics. We use browser localStorage
+              for two strictly functional purposes: storing your theme preference and counting anonymous searches
+              for rate limiting. Supabase authentication uses session tokens stored in localStorage.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">8. No Advertising or Data Sales</h2>
+            <p>
+              We do not use advertising, tracking pixels, or data brokers. We do not sell or share your personal
+              data with third parties for marketing purposes.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">9. Changes to This Policy</h2>
+            <p>
+              We may update this policy to reflect changes in our practices or legal requirements. Material
+              changes will be communicated via the app. The "last updated" date at the top indicates the
+              most recent revision.
+            </p>
+          </section>
         </div>
       </div>
     </main>

--- a/src/components/TermsPage.tsx
+++ b/src/components/TermsPage.tsx
@@ -28,7 +28,9 @@ export function TermsPage({ onBack }: TermsPageProps) {
           </p>
 
           <p>
-            It uses publicly available data from Google Scholar. It does not store, sell, or share user data.
+            It uses publicly available data from Google Scholar. We store only the minimum data needed to
+            operate the service (see our Privacy Policy for details). We do not sell or share your data
+            with third parties for marketing purposes.
           </p>
 
           <p>

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,93 @@
+import { createClient } from "npm:@supabase/supabase-js@2.39.3";
+
+const ALLOWED_ORIGINS = [
+  'https://scholarfolio.org',
+  'https://www.scholarfolio.org',
+  'https://scholarfolio.netlify.app',
+];
+
+function getCorsHeaders(req: Request) {
+  const origin = req.headers.get('Origin') || '';
+  const allowedOrigin = ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0];
+  return {
+    "Access-Control-Allow-Origin": allowedOrigin,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  };
+}
+
+const supabase = createClient(
+  Deno.env.get('SUPABASE_URL') ?? '',
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+);
+
+Deno.serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    // Authenticate the user from their JWT
+    const authHeader = req.headers.get('Authorization') || '';
+    const jwt = authHeader.replace('Bearer ', '');
+
+    if (!jwt) {
+      return new Response(
+        JSON.stringify({ error: 'Authentication required' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser(jwt);
+
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid or expired session' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const userId = user.id;
+    console.log(`[DeleteAccount] Deleting account for user ${userId}`);
+
+    // Anonymise request_logs (ON DELETE SET NULL handles user_id, but also clear IP)
+    await supabase
+      .from('request_logs')
+      .update({ ip: null, user_agent: null })
+      .eq('user_id', userId);
+
+    // Delete claimed profiles (CASCADE should handle this, but be explicit)
+    await supabase
+      .from('claimed_profiles')
+      .delete()
+      .eq('user_id', userId);
+
+    // user_credits and credit_purchases have ON DELETE CASCADE
+
+    // Delete the auth user (this cascades to user_credits, credit_purchases)
+    const { error: deleteError } = await supabase.auth.admin.deleteUser(userId);
+
+    if (deleteError) {
+      console.error(`[DeleteAccount] Failed to delete user ${userId}:`, deleteError);
+      return new Response(
+        JSON.stringify({ error: 'Failed to delete account. Please try again or contact support.' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    console.log(`[DeleteAccount] Successfully deleted user ${userId}`);
+
+    return new Response(
+      JSON.stringify({ success: true }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('[DeleteAccount] Unexpected error:', error);
+    return new Response(
+      JSON.stringify({ error: 'Internal error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Rewrote privacy policy with full GDPR compliance (data controller, legal basis, data subject rights, processor list, retention periods)
- Fixed Terms of Use false claim about not storing user data
- Added `delete-account` edge function for GDPR Art. 17 right to erasure (anonymises logs, deletes user)
- Added "Delete account" menu item with confirmation dialog in user dropdown
- Enabled pg_cron with daily cleanup of request_logs older than 30 days

## Test plan
- [ ] Verify privacy policy page renders correctly
- [ ] Verify "Delete account" appears in user dropdown menu
- [ ] Test delete account flow with confirmation dialog
- [ ] Confirm request_logs cleanup cron job is scheduled

🤖 Generated with [Claude Code](https://claude.com/claude-code)