### PR TITLE
Add ARIA attributes to modals and fix dark mode gaps

### DIFF
--- a/src/components/ClaimProfileModal.tsx
+++ b/src/components/ClaimProfileModal.tsx
@@ -170,16 +170,16 @@ export function ClaimProfileModal({ onClose, authorId, authorName, onClaimed }: 
 
   if (existingClaim) {
     return (
-      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4 modal-overlay" onClick={onClose}>
+      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4 modal-overlay" role="dialog" aria-modal="true" aria-labelledby="claim-existing-title" onClick={onClose} onKeyDown={e => { if (e.key === 'Escape') onClose(); }}>
         <div
-          className="bg-white rounded-2xl shadow-2xl max-w-md w-full overflow-hidden modal-card"
+          className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-md w-full overflow-hidden modal-card"
           onClick={e => e.stopPropagation()}
         >
           <div className="p-8 text-center">
-            <div className="w-14 h-14 bg-amber-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <div className="w-14 h-14 bg-amber-100 dark:bg-amber-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
               <AlertCircle className="h-7 w-7 text-amber-600" />
             </div>
-            <h2 className="text-xl font-bold text-gray-900 mb-2">Already claimed a profile</h2>
+            <h2 id="claim-existing-title" className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">Already claimed a profile</h2>
             <p className="text-sm text-gray-600 mb-3">
               You already have a claimed profile at{' '}
               <a href={`/${existingClaim}`} className="font-medium text-[#2d7d7d] hover:underline">
@@ -294,9 +294,9 @@ export function ClaimProfileModal({ onClose, authorId, authorName, onClaimed }: 
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4" onClick={onClose}>
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4" role="dialog" aria-modal="true" aria-labelledby="claim-profile-title" onClick={onClose} onKeyDown={e => { if (e.key === 'Escape') onClose(); }}>
       <div
-        className="bg-white rounded-2xl shadow-2xl max-w-md w-full overflow-hidden"
+        className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-md w-full overflow-hidden"
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}
@@ -304,6 +304,7 @@ export function ClaimProfileModal({ onClose, authorId, authorName, onClaimed }: 
           <button
             onClick={onClose}
             className="absolute top-4 right-4 text-white/70 hover:text-white transition-colors"
+            aria-label="Close"
           >
             <X className="h-5 w-5" />
           </button>
@@ -311,7 +312,7 @@ export function ClaimProfileModal({ onClose, authorId, authorName, onClaimed }: 
             <Link className="h-5 w-5 text-amber-300" />
             <span className="text-xs font-medium uppercase tracking-wider text-white/80">Claim Profile</span>
           </div>
-          <h2 className="text-xl font-bold">Get your vanity URL</h2>
+          <h2 id="claim-profile-title" className="text-xl font-bold">Get your vanity URL</h2>
           <p className="text-sm text-white/80 mt-1">
             Claim this Scholar profile and share it with a memorable link.
           </p>

--- a/src/components/CoAuthorCard.tsx
+++ b/src/components/CoAuthorCard.tsx
@@ -26,7 +26,7 @@ export function CoAuthorCard({
   const [showPapers, setShowPapers] = React.useState(false);
 
   return (
-    <div className="bg-white rounded-lg border border-gray-100 hover:border-gray-200 transition-colors overflow-hidden">
+    <div className="bg-white dark:bg-slate-800 rounded-lg border border-gray-100 dark:border-slate-700 hover:border-gray-200 dark:hover:border-slate-600 transition-colors overflow-hidden">
       <div className="p-3 flex items-center justify-between">
         <div className="flex items-center space-x-3">
           {imageUrl ? (
@@ -47,7 +47,7 @@ export function CoAuthorCard({
           )}
           <div className="min-w-0">
             <div className="flex items-center space-x-1">
-              <p className="text-sm font-medium text-gray-900 truncate">{name}</p>
+              <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{name}</p>
               {profileUrl && (
                 <a
                   href={profileUrl}
@@ -59,8 +59,8 @@ export function CoAuthorCard({
                 </a>
               )}
             </div>
-            <p className="text-xs text-gray-600 truncate">{affiliation}</p>
-            <div className="flex items-center space-x-2 text-xs text-gray-500 mt-1">
+            <p className="text-xs text-gray-600 dark:text-gray-400 truncate">{affiliation}</p>
+            <div className="flex items-center space-x-2 text-xs text-gray-500 dark:text-gray-400 mt-1">
               <span>{citations.toLocaleString()} citations</span>
               <span className="text-gray-300">•</span>
               <span>h-index: {hIndex}</span>
@@ -77,10 +77,10 @@ export function CoAuthorCard({
         </div>
       </div>
       {showPapers && sharedPapers.length > 0 && (
-        <div className="border-t border-gray-100 bg-gray-50/50 p-3">
+        <div className="border-t border-gray-100 dark:border-slate-700 bg-gray-50/50 dark:bg-slate-800/50 p-3">
           <ul className="space-y-2">
             {sharedPapers.map((paper, index) => (
-              <li key={index} className="text-xs text-gray-600 hover:text-gray-900">
+              <li key={index} className="text-xs text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200">
                 <a href={paper.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
                   {paper.title}{paper.year > 0 ? ` (${paper.year})` : ''} - {paper.citations} citations
                 </a>

--- a/src/components/CreditPacks.tsx
+++ b/src/components/CreditPacks.tsx
@@ -72,9 +72,16 @@ export function CreditPacks({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4 modal-overlay" onClick={onClose}>
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4 modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="credit-packs-title"
+      onClick={onClose}
+      onKeyDown={e => { if (e.key === 'Escape') onClose(); }}
+    >
       <div
-        className="bg-white rounded-2xl shadow-2xl max-w-lg w-full overflow-hidden modal-card"
+        className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-lg w-full overflow-hidden modal-card"
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}
@@ -82,6 +89,7 @@ export function CreditPacks({ onClose }: { onClose: () => void }) {
           <button
             onClick={onClose}
             className="absolute top-4 right-4 text-white/70 hover:text-white transition-colors"
+            aria-label="Close"
           >
             <X className="h-5 w-5" />
           </button>
@@ -89,7 +97,7 @@ export function CreditPacks({ onClose }: { onClose: () => void }) {
             <Heart className="h-5 w-5 text-amber-300" />
             <span className="text-xs font-medium uppercase tracking-wider text-white/80">Support Scholar Folio</span>
           </div>
-          <h2 className="text-xl font-bold">
+          <h2 id="credit-packs-title" className="text-xl font-bold">
             Keep this open-science tool running
           </h2>
           <p className="text-sm text-white/80 mt-1">

--- a/src/components/EmbedModal.tsx
+++ b/src/components/EmbedModal.tsx
@@ -44,34 +44,42 @@ export function EmbedModal({ isOpen, onClose, scholarId }: EmbedModalProps) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-xl max-w-2xl w-full">
-        <div className="sticky top-0 bg-white border-b border-gray-100 p-4 flex items-center justify-between rounded-t-xl">
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="embed-modal-title"
+      onClick={onClose}
+      onKeyDown={e => { if (e.key === 'Escape') onClose(); }}
+    >
+      <div className="bg-white dark:bg-gray-900 rounded-xl max-w-2xl w-full" onClick={e => e.stopPropagation()}>
+        <div className="sticky top-0 bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-700 p-4 flex items-center justify-between rounded-t-xl">
           <div className="flex items-center space-x-2">
             <Code className="h-5 w-5 text-[#2d7d7d]" />
-            <h2 className="text-lg font-semibold text-gray-900">Embed Metrics</h2>
+            <h2 id="embed-modal-title" className="text-lg font-semibold text-gray-900 dark:text-gray-100">Embed Metrics</h2>
           </div>
           <button
             onClick={onClose}
-            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+            aria-label="Close"
           >
-            <X className="h-5 w-5 text-gray-500" />
+            <X className="h-5 w-5 text-gray-500 dark:text-gray-400" />
           </button>
         </div>
-        
+
         <div className="p-6 space-y-4">
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
             Copy and paste this code into your website to embed your Scholar Folio:
           </p>
-          
+
           <div className="relative">
-            <pre className="bg-gray-50 rounded-lg p-4 text-sm text-gray-800 font-mono overflow-x-auto">
+            <pre className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 text-sm text-gray-800 dark:text-gray-200 font-mono overflow-x-auto">
               {embedCode}
             </pre>
-            
+
             <button
               onClick={handleCopy}
-              className="absolute top-3 right-3 px-3 py-1.5 bg-white border border-gray-200 rounded-md text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors flex items-center space-x-1"
+              className="absolute top-3 right-3 px-3 py-1.5 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors flex items-center space-x-1"
             >
               {copied ? (
                 <>
@@ -86,10 +94,10 @@ export function EmbedModal({ isOpen, onClose, scholarId }: EmbedModalProps) {
               )}
             </button>
           </div>
-          
-          <div className="bg-[#eaf4f4] rounded-lg p-4 text-sm text-[#1e293b]">
+
+          <div className="bg-[#eaf4f4] dark:bg-[#2d7d7d]/10 rounded-lg p-4 text-sm text-[#1e293b] dark:text-gray-200">
             <h3 className="font-medium mb-2">Customization Options:</h3>
-            <ul className="list-disc list-inside space-y-1 text-[#334155]">
+            <ul className="list-disc list-inside space-y-1 text-[#334155] dark:text-gray-300">
               <li>Adjust the width and height attributes to fit your layout</li>
               <li>The embed automatically adapts to light/dark themes</li>
               <li>Metrics are updated in real-time as citations change</li>

--- a/src/components/ErrorModal.tsx
+++ b/src/components/ErrorModal.tsx
@@ -9,30 +9,38 @@ interface ErrorModalProps {
 
 export function ErrorModal({ message, onClose }: ErrorModalProps) {
   return createPortal(
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4" onClick={onClose}>
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="error-modal-title"
+      onClick={onClose}
+      onKeyDown={e => { if (e.key === 'Escape') onClose(); }}
+    >
       <div
-        className="bg-white rounded-xl shadow-lg max-w-md w-full p-6 transform transition-all"
+        className="bg-white dark:bg-gray-900 rounded-xl shadow-lg max-w-md w-full p-6 transform transition-all"
         onClick={e => e.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center">
-            <div className="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center mr-3">
-              <AlertCircle className="w-6 h-6 text-gray-500" />
+            <div className="w-10 h-10 bg-gray-100 dark:bg-gray-800 rounded-full flex items-center justify-center mr-3">
+              <AlertCircle className="w-6 h-6 text-gray-500 dark:text-gray-400" />
             </div>
-            <h3 className="text-lg font-semibold text-gray-900">Error</h3>
+            <h3 id="error-modal-title" className="text-lg font-semibold text-gray-900 dark:text-gray-100">Error</h3>
           </div>
           <button
             onClick={onClose}
-            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+            aria-label="Close"
           >
-            <X className="w-5 h-5 text-gray-500" />
+            <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
           </button>
         </div>
-        <p className="text-gray-600">{message}</p>
+        <p className="text-gray-600 dark:text-gray-300">{message}</p>
         <div className="mt-6 flex justify-end">
           <button
             onClick={onClose}
-            className="px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-800 rounded-lg transition-colors"
+            className="px-4 py-2 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-800 dark:text-gray-200 rounded-lg transition-colors"
           >
             Try Again
           </button>

--- a/src/components/OpenScienceTab.tsx
+++ b/src/components/OpenScienceTab.tsx
@@ -38,20 +38,20 @@ function OaTrend({ publications, publicationOa }: { publications: Author['public
 
   return (
     <div>
-      <h3 className="text-sm font-semibold text-gray-900 mb-3">Open Access Over Time</h3>
-      <div className="bg-white rounded-xl border border-gray-100 shadow-card p-6">
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Open Access Over Time</h3>
+      <div className="bg-white dark:bg-slate-800 rounded-xl border border-gray-100 dark:border-slate-700 shadow-card p-6">
         {/* Hover detail panel */}
         <div className="h-10 mb-3">
           {hoveredData ? (
             <div className="flex items-center gap-4 text-sm animate-in fade-in duration-150">
-              <span className="font-semibold text-gray-900">{hoveredData.year}</span>
+              <span className="font-semibold text-gray-900 dark:text-gray-100">{hoveredData.year}</span>
               <span className="text-[#2d7d7d] font-medium">{hoveredData.oa} open access</span>
-              <span className="text-gray-400">·</span>
-              <span className="text-gray-500">{hoveredData.closed} closed</span>
-              <span className="text-gray-400">·</span>
-              <span className="text-gray-500">{hoveredData.total} total</span>
-              <span className="text-gray-400">·</span>
-              <span className="font-medium text-gray-700">{hoveredData.pct}% OA</span>
+              <span className="text-gray-400 dark:text-gray-500">·</span>
+              <span className="text-gray-500 dark:text-gray-400">{hoveredData.closed} closed</span>
+              <span className="text-gray-400 dark:text-gray-500">·</span>
+              <span className="text-gray-500 dark:text-gray-400">{hoveredData.total} total</span>
+              <span className="text-gray-400 dark:text-gray-500">·</span>
+              <span className="font-medium text-gray-700 dark:text-gray-300">{hoveredData.pct}% OA</span>
             </div>
           ) : (
             <p className="text-xs text-gray-400">Hover over a bar to see the breakdown</p>
@@ -67,7 +67,7 @@ function OaTrend({ publications, publicationOa }: { publications: Author['public
               onMouseLeave={() => setHoveredYear(null)}
             >
               <span className={`w-12 text-xs shrink-0 transition-colors ${hoveredYear === year ? 'text-gray-900 font-medium' : 'text-gray-500'}`}>{year}</span>
-              <div className="flex-1 bg-gray-100 rounded-full h-5 overflow-hidden relative cursor-pointer">
+              <div className="flex-1 bg-gray-100 dark:bg-slate-700 rounded-full h-5 overflow-hidden relative cursor-pointer">
                 <div
                   className="absolute inset-y-0 left-0 bg-gray-200 rounded-full transition-all duration-300"
                   style={{ width: `${(total / maxTotal) * 100}%` }}
@@ -103,7 +103,7 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
 
   if (!oa) {
     return (
-      <div className="bg-white rounded-xl border border-gray-100 shadow-card p-8 text-center">
+      <div className="bg-white dark:bg-slate-800 rounded-xl border border-gray-100 dark:border-slate-700 shadow-card p-8 text-center">
         <Unlock className="h-8 w-8 text-gray-300 mx-auto mb-3" />
         <p className="text-sm text-gray-500">Loading Open Access data...</p>
         <p className="text-xs text-gray-400 mt-1">This may take a few seconds</p>
@@ -115,7 +115,7 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
     <div className="space-y-6">
       {/* Summary metrics — using MetricsCard for consistency */}
       <div>
-        <h3 className="text-sm font-semibold text-gray-900 mb-3">Open Access Metrics</h3>
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Open Access Metrics</h3>
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
           <MetricsCard title="Open Access" value={`${oa.oaPercent}%`} subtitle={`${oa.oa} of ${oa.total} publications`} icon="oaPercent" />
           {oa.gold > 0 && <MetricsCard title="Gold OA" value={oa.gold} subtitle="Fully OA journals" icon="goldOa" />}
@@ -128,8 +128,8 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
 
       {/* Visual breakdown bar */}
       <div>
-        <h3 className="text-sm font-semibold text-gray-900 mb-3">Access Breakdown</h3>
-        <div className="bg-white rounded-xl border border-gray-100 shadow-card p-6">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Access Breakdown</h3>
+        <div className="bg-white dark:bg-slate-800 rounded-xl border border-gray-100 dark:border-slate-700 shadow-card p-6">
           <div className="h-6 rounded-full overflow-hidden flex bg-gray-100">
             {oa.gold > 0 && (
               <div
@@ -169,27 +169,27 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
           </div>
           <div className="flex flex-wrap gap-x-4 gap-y-1 mt-3">
             {oa.gold > 0 && (
-              <span className="flex items-center gap-1.5 text-xs text-gray-600 cursor-help" title="Published in fully open access journals">
+              <span className="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 cursor-help" title="Published in fully open access journals">
                 <span className="w-3 h-3 rounded bg-[#2d7d7d]" /> Gold ({oa.gold})
               </span>
             )}
             {oa.green > 0 && (
-              <span className="flex items-center gap-1.5 text-xs text-gray-600 cursor-help" title="Available via repositories">
+              <span className="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 cursor-help" title="Available via repositories">
                 <span className="w-3 h-3 rounded bg-[#4db6ac]" /> Green ({oa.green})
               </span>
             )}
             {oa.hybrid > 0 && (
-              <span className="flex items-center gap-1.5 text-xs text-gray-600 cursor-help" title="OA in subscription journals">
+              <span className="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 cursor-help" title="OA in subscription journals">
                 <span className="w-3 h-3 rounded bg-[#80cbc4]" /> Hybrid ({oa.hybrid})
               </span>
             )}
             {oa.bronze > 0 && (
-              <span className="flex items-center gap-1.5 text-xs text-gray-600 cursor-help" title="Free to read, no open license">
+              <span className="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 cursor-help" title="Free to read, no open license">
                 <span className="w-3 h-3 rounded bg-[#b2dfdb]" /> Bronze ({oa.bronze})
               </span>
             )}
             {oa.closed > 0 && (
-              <span className="flex items-center gap-1.5 text-xs text-gray-600 cursor-help" title="Behind paywall">
+              <span className="flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 cursor-help" title="Behind paywall">
                 <span className="w-3 h-3 rounded bg-gray-300" /> Closed ({oa.closed})
               </span>
             )}
@@ -203,8 +203,8 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
       {/* ORCID */}
       {oa.orcid && (
         <div>
-          <h3 className="text-sm font-semibold text-gray-900 mb-3">ORCID</h3>
-          <div className="bg-white rounded-xl border border-gray-100 shadow-card p-4">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">ORCID</h3>
+          <div className="bg-white dark:bg-slate-800 rounded-xl border border-gray-100 dark:border-slate-700 shadow-card p-4">
             <a
               href={`https://orcid.org/${oa.orcid}`}
               target="_blank"

--- a/src/components/ScholarSearchModal.tsx
+++ b/src/components/ScholarSearchModal.tsx
@@ -42,19 +42,27 @@ export function ScholarSearchModal({ isOpen, onClose, onSelect }: ScholarSearchM
   if (!isOpen) return null;
 
   return createPortal(
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-start justify-center pt-[15vh] p-4">
-      <div className="bg-white rounded-xl max-w-lg w-full shadow-2xl flex flex-col">
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-start justify-center pt-[15vh] p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="scholar-search-title"
+      onClick={onClose}
+      onKeyDown={e => { if (e.key === 'Escape') onClose(); }}
+    >
+      <div className="bg-white dark:bg-gray-900 rounded-xl max-w-lg w-full shadow-2xl flex flex-col" onClick={e => e.stopPropagation()}>
         {/* Header */}
-        <div className="p-4 border-b border-gray-100 flex items-center justify-between flex-shrink-0">
-          <h2 className="text-base font-semibold text-gray-900 flex items-center">
+        <div className="p-4 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between flex-shrink-0">
+          <h2 id="scholar-search-title" className="text-base font-semibold text-gray-900 dark:text-gray-100 flex items-center">
             <Search className="h-4 w-4 text-[#2d7d7d] mr-2" />
             Find Author on Google Scholar
           </h2>
           <button
             onClick={onClose}
-            className="p-1.5 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+            aria-label="Close"
           >
-            <X className="h-4 w-4 text-gray-500" />
+            <X className="h-4 w-4 text-gray-500 dark:text-gray-400" />
           </button>
         </div>
 
@@ -66,7 +74,7 @@ export function ScholarSearchModal({ isOpen, onClose, onSelect }: ScholarSearchM
               1
             </div>
             <div className="flex-1">
-              <p className="text-sm font-medium text-gray-800 mb-2">
+              <p className="text-sm font-medium text-gray-800 dark:text-gray-200 mb-2">
                 Search for the author on Google Scholar
               </p>
               <button
@@ -85,7 +93,7 @@ export function ScholarSearchModal({ isOpen, onClose, onSelect }: ScholarSearchM
               2
             </div>
             <div className="flex-1">
-              <p className="text-sm font-medium text-gray-800">
+              <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
                 Click on the author's profile, then copy the URL from your browser
               </p>
               <p className="text-xs text-gray-400 mt-1">
@@ -100,7 +108,7 @@ export function ScholarSearchModal({ isOpen, onClose, onSelect }: ScholarSearchM
               3
             </div>
             <div className="flex-1">
-              <p className="text-sm font-medium text-gray-800 mb-2">
+              <p className="text-sm font-medium text-gray-800 dark:text-gray-200 mb-2">
                 Paste the profile URL here
               </p>
               <form onSubmit={handleSubmit}>
@@ -111,7 +119,7 @@ export function ScholarSearchModal({ isOpen, onClose, onSelect }: ScholarSearchM
                     value={pastedUrl}
                     onChange={(e) => { setPastedUrl(e.target.value); setError(null); }}
                     placeholder="https://scholar.google.com/citations?user=..."
-                    className="w-full px-4 py-2.5 pl-10 pr-12 text-sm text-gray-700 bg-gray-50 border border-gray-200 rounded-lg focus:outline-none focus:border-[#2d7d7d] focus:ring-2 focus:ring-[#2d7d7d]/20 focus:bg-white transition-all"
+                    className="w-full px-4 py-2.5 pl-10 pr-12 text-sm text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:border-[#2d7d7d] focus:ring-2 focus:ring-[#2d7d7d]/20 focus:bg-white dark:focus:bg-gray-800 transition-all"
                     autoComplete="off"
                     spellCheck="false"
                   />

--- a/src/components/SignUpWall.tsx
+++ b/src/components/SignUpWall.tsx
@@ -49,18 +49,25 @@ export function SignUpWall({ onClose }: SignUpWallProps) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4 modal-overlay" onClick={onClose}>
-      <div className="bg-white rounded-2xl shadow-2xl max-w-sm w-full p-6 modal-card" onClick={e => e.stopPropagation()}>
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4 modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="signup-wall-title"
+      onClick={onClose}
+      onKeyDown={e => { if (e.key === 'Escape') onClose(); }}
+    >
+      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-sm w-full p-6 modal-card" onClick={e => e.stopPropagation()}>
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">
+          <h2 id="signup-wall-title" className="text-lg font-semibold text-gray-900 dark:text-gray-100">
             {isSignUp ? 'Sign up to continue' : 'Sign in to continue'}
           </h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" aria-label="Close">
             <X className="h-5 w-5" />
           </button>
         </div>
 
-        <p className="text-sm text-gray-600 mb-5">
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-5">
           You've used your free searches. Sign up to <strong>claim your research profile</strong> and get a permanent URL — plus 5 more profile lookups, free.
         </p>
 


### PR DESCRIPTION
## Summary
- Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby` to all 6 active modals (ErrorModal, EmbedModal, ScholarSearchModal, SignUpWall, CreditPacks, ClaimProfileModal)
- Added Escape key handlers and `aria-label` on close buttons for keyboard accessibility
- Fixed dark mode support across OpenScienceTab, CoAuthorCard, and all modals

## Test plan
- [ ] Verify modals announce correctly with screen reader (VoiceOver)
- [ ] Verify Escape key closes all modals
- [ ] Toggle dark mode and check OpenScienceTab, CoAuthorCard, all modal dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)