### PR TITLE
Update Terms and Privacy for all data sources

### DIFF
--- a/src/components/PrivacyPage.tsx
+++ b/src/components/PrivacyPage.tsx
@@ -63,7 +63,9 @@ export function PrivacyPage({ onBack }: PrivacyPageProps) {
               <li><strong>Stripe</strong> (US) — payment processing. Subject to <a href="https://stripe.com/privacy" target="_blank" rel="noopener noreferrer" className="text-[#2d7d7d] hover:underline">Stripe's Privacy Policy</a>.</li>
               <li><strong>Netlify</strong> (US) — web hosting and CDN.</li>
               <li><strong>SerpAPI</strong> (US) — Google Scholar data retrieval.</li>
-              <li><strong>OpenAlex / ORCID</strong> — public academic APIs used to enrich profile data. No personal data is sent to these services beyond the public identifiers being looked up.</li>
+              <li><strong>OpenAlex</strong> — open academic API used for open access data, field-normalized metrics, co-author geography, and p-index computation. Only public author/work identifiers are queried.</li>
+              <li><strong>ORCID</strong> — public API used to retrieve education, employment, and grant records when an ORCID identifier is available. No personal data is sent beyond the public ORCID iD.</li>
+              <li><strong>NIH iCite</strong> — public API used to retrieve Relative Citation Ratios for PubMed-indexed papers. Only PubMed identifiers are queried.</li>
             </ul>
           </section>
 
@@ -85,7 +87,7 @@ export function PrivacyPage({ onBack }: PrivacyPageProps) {
             </p>
             <ul className="list-disc list-inside space-y-1.5 ml-2">
               <li><strong>Supabase, Stripe, Netlify, SerpAPI</strong> — transfers are covered by the EU-U.S. Data Privacy Framework and/or EU Standard Contractual Clauses (SCCs) as adopted by the European Commission.</li>
-              <li><strong>OpenAlex / ORCID</strong> — only public identifiers are sent to these APIs; no personal data is transferred.</li>
+              <li><strong>OpenAlex, ORCID, NIH iCite</strong> — only public academic identifiers are sent to these APIs; no personal data is transferred.</li>
             </ul>
             <p className="mt-3">
               You can request a copy of the applicable transfer safeguards by emailing{' '}

--- a/src/components/TermsPage.tsx
+++ b/src/components/TermsPage.tsx
@@ -20,53 +20,122 @@ export function TermsPage({ onBack }: TermsPageProps) {
       </nav>
 
       <div className="max-w-2xl mx-auto px-6 py-20">
-        <h1 className="font-serif text-4xl font-bold text-[#1e293b] mb-10">Terms of Use</h1>
+        <h1 className="font-serif text-4xl font-bold text-[#1e293b] mb-4">Terms of Use</h1>
+        <p className="text-sm text-gray-500 mb-10">Last updated: June 4, 2026</p>
 
         <div className="space-y-8 text-[15px] text-[#334155] leading-relaxed">
-          <p>
-            Scholar Folio is provided free of charge, as-is, for personal and academic use.
-          </p>
 
-          <p>
-            It uses publicly available data from Google Scholar. We store only the minimum data needed to
-            operate the service (see our Privacy Policy for details). We do not sell or share your data
-            with third parties for marketing purposes.
-          </p>
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">1. Service Description</h2>
+            <p>
+              Scholar Folio is a free tool that generates visual academic portfolios from publicly available research data.
+              It is provided as-is for personal and academic use. The service is operated by Jonas Heller,
+              Assistant Professor at Maastricht University, the Netherlands.
+            </p>
+          </section>
 
-          <p>
-            The tool is not affiliated with Google or Google Scholar.
-          </p>
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">2. Data Sources</h2>
+            <p className="mb-3">
+              Scholar Folio aggregates publicly available data from multiple academic data sources:
+            </p>
+            <ul className="list-disc list-inside space-y-1.5 ml-2">
+              <li><strong>Google Scholar</strong> (via SerpAPI) — publication lists, citation counts, h-index, and profile information.</li>
+              <li><strong>OpenAlex</strong> — open access status, field-normalized citation metrics (FWCI), co-author institution data, and journal-level statistics for the p-index.</li>
+              <li><strong>ORCID</strong> — education history, employment records, grants, and awards (when an ORCID identifier is available).</li>
+              <li><strong>NIH iCite</strong> — Relative Citation Ratio (RCR) for papers indexed in PubMed.</li>
+            </ul>
+            <p className="mt-3">
+              Scholar Folio is not affiliated with Google, Google Scholar, OpenAlex, ORCID, or NIH.
+            </p>
+          </section>
 
-          <p>
-            Citation and index figures are pulled directly from Google Scholar and may differ from other
-            sources. We make no guarantees of accuracy.
-          </p>
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">3. Accuracy Disclaimer</h2>
+            <p>
+              Citation counts, metrics, and index figures are retrieved from the sources listed above and may
+              differ across databases. The p-index, FWCI, and other derived metrics are computed algorithmically
+              and should be interpreted in context. We make no guarantees of accuracy or completeness.
+            </p>
+          </section>
 
-          <p>
-            This tool is not intended for institutional evaluation, hiring decisions, or performance
-            assessment of researchers. Using it for those purposes is contrary to its intent.
-          </p>
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">4. Responsible Use</h2>
+            <p className="mb-3">
+              This tool is designed for researchers to understand and communicate their own work. It is
+              explicitly <strong>not intended</strong> for:
+            </p>
+            <ul className="list-disc list-inside space-y-1.5 ml-2">
+              <li>Institutional evaluation, hiring decisions, or performance assessment of researchers.</li>
+              <li>Ranking or comparing researchers for employment or promotion decisions.</li>
+              <li>Automated scraping or data harvesting beyond personal use.</li>
+            </ul>
+            <p className="mt-3">
+              By using Scholar Folio you agree to use the tool responsibly and in line with the
+              principles of responsible research assessment (e.g., DORA, Leiden Manifesto).
+            </p>
+          </section>
 
-          <p>
-            By using Scholar Folio you agree not to use it to rank, compare, or evaluate researchers
-            for employment or promotion decisions.
-          </p>
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">5. Accounts & Credits</h2>
+            <p>
+              Creating an account is optional. Registered users receive a limited number of free profile lookups.
+              Additional lookups can be purchased as credit packs. Payments are processed by Stripe in EUR.
+              Credits are non-refundable and non-transferable.
+            </p>
+          </section>
 
-          <p>
-            The tool is open source. Contributions welcome.
-          </p>
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">6. Intellectual Property</h2>
+            <p>
+              The Scholar Folio application is open source. The academic data displayed belongs to the
+              original sources and their respective terms of use apply. Generated narratives and visualisations
+              are derived works provided for personal academic use.
+            </p>
+          </section>
 
-          <p>
-            Contact:{' '}
-            <a
-              href="https://www.linkedin.com/in/hellerjonas/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[#2d7d7d] hover:underline inline-flex items-center gap-1"
-            >
-              Jonas Heller on LinkedIn <ExternalLink className="h-3 w-3" />
-            </a>
-          </p>
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">7. Limitation of Liability</h2>
+            <p>
+              Scholar Folio is provided "as is" without warranty of any kind. To the maximum extent permitted
+              by applicable law, we disclaim all liability for damages arising from the use of this service,
+              including but not limited to inaccurate data, service interruptions, or reliance on generated metrics.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">8. Governing Law</h2>
+            <p>
+              These terms are governed by the laws of the Netherlands. Any disputes shall be submitted to
+              the competent courts in Maastricht, the Netherlands. If you are a consumer in the EU, you retain
+              any mandatory consumer protection rights under the laws of your country of residence.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">9. Changes</h2>
+            <p>
+              We may update these terms to reflect changes in the service or legal requirements. Material
+              changes will be communicated via the app.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold text-[#1e293b] mb-2">10. Contact</h2>
+            <p>
+              Questions about these terms? Contact:{' '}
+              <a href="mailto:privacy@scholarfolio.org" className="text-[#2d7d7d] hover:underline">privacy@scholarfolio.org</a>
+              {' '}or{' '}
+              <a
+                href="https://www.linkedin.com/in/hellerjonas/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#2d7d7d] hover:underline inline-flex items-center gap-1"
+              >
+                Jonas Heller on LinkedIn <ExternalLink className="h-3 w-3" />
+              </a>
+            </p>
+          </section>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- **Terms of Use** fully rewritten: 10 sections covering data sources (Google Scholar, OpenAlex, ORCID, NIH iCite), responsible use (DORA/Leiden Manifesto), accounts & credits, IP, liability, Dutch governing law
- **Privacy Policy** updated: OpenAlex, ORCID, and NIH iCite listed as separate processors with what data is sent to each

## Test plan
- [ ] Terms page renders all 10 sections
- [ ] Privacy page shows updated processor list (section 4) and transfer safeguards (section 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)