### PR TITLE
Unify contact emails to info@scholarfolio.org

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,6 +96,12 @@ function Footer({ onNavigate, onSupport }: { onNavigate: (page: Page) => void; o
             Changelog
           </button>
           <a
+            href="mailto:info@scholarfolio.org"
+            className="text-sm text-[#3d9494] hover:text-white transition-colors"
+          >
+            Contact
+          </a>
+          <a
             href={SOCIAL_LINKS.linkedin}
             target="_blank"
             rel="noopener noreferrer"

--- a/src/components/PrivacyPage.tsx
+++ b/src/components/PrivacyPage.tsx
@@ -30,7 +30,7 @@ export function PrivacyPage({ onBack }: PrivacyPageProps) {
             <p>
               Scholar Folio is operated by Jonas Heller, Assistant Professor at Maastricht University, the Netherlands.
               For questions about this policy or your data, contact:{' '}
-              <a href="mailto:privacy@scholarfolio.org" className="text-[#2d7d7d] hover:underline">privacy@scholarfolio.org</a>.
+              <a href="mailto:info@scholarfolio.org" className="text-[#2d7d7d] hover:underline">info@scholarfolio.org</a>.
             </p>
           </section>
 
@@ -91,7 +91,7 @@ export function PrivacyPage({ onBack }: PrivacyPageProps) {
             </ul>
             <p className="mt-3">
               You can request a copy of the applicable transfer safeguards by emailing{' '}
-              <a href="mailto:privacy@scholarfolio.org" className="text-[#2d7d7d] hover:underline">privacy@scholarfolio.org</a>.
+              <a href="mailto:info@scholarfolio.org" className="text-[#2d7d7d] hover:underline">info@scholarfolio.org</a>.
             </p>
           </section>
 
@@ -108,7 +108,7 @@ export function PrivacyPage({ onBack }: PrivacyPageProps) {
             </ul>
             <p className="mt-3">
               To exercise any of these rights, email{' '}
-              <a href="mailto:privacy@scholarfolio.org" className="text-[#2d7d7d] hover:underline">privacy@scholarfolio.org</a>.
+              <a href="mailto:info@scholarfolio.org" className="text-[#2d7d7d] hover:underline">info@scholarfolio.org</a>.
             </p>
           </section>
 

--- a/src/components/TermsPage.tsx
+++ b/src/components/TermsPage.tsx
@@ -124,7 +124,7 @@ export function TermsPage({ onBack }: TermsPageProps) {
             <h2 className="text-lg font-semibold text-[#1e293b] mb-2">10. Contact</h2>
             <p>
               Questions about these terms? Contact:{' '}
-              <a href="mailto:privacy@scholarfolio.org" className="text-[#2d7d7d] hover:underline">privacy@scholarfolio.org</a>
+              <a href="mailto:info@scholarfolio.org" className="text-[#2d7d7d] hover:underline">info@scholarfolio.org</a>
               {' '}or{' '}
               <a
                 href="https://www.linkedin.com/in/hellerjonas/"

--- a/src/services/crossref/index.ts
+++ b/src/services/crossref/index.ts
@@ -3,10 +3,10 @@ import type { JournalRanking } from '../../types/scholar';
 
 export class CrossrefService {
   private readonly API_URL = 'https://api.crossref.org/works';
-  private readonly EMAIL = 'your-email@domain.com'; // For polite pool
+  private readonly EMAIL = 'info@scholarfolio.org';
 
   private readonly headers = {
-    'User-Agent': 'ResearchPortfolio/1.0 (mailto:your-email@domain.com)'
+    'User-Agent': 'ScholarFolio/1.0 (mailto:info@scholarfolio.org)'
   };
 
   public async getJournalMetadata(doi: string): Promise<JournalRanking | null> {

--- a/src/services/openalex/author-lookup.ts
+++ b/src/services/openalex/author-lookup.ts
@@ -2,7 +2,7 @@ import { timeoutSignal } from '../../utils/api';
 import { RateLimiter } from '../scholar/rate-limiter';
 
 const API_URL = 'https://api.openalex.org';
-const EMAIL = 'scholarfolio@scholarfolio.org';
+const EMAIL = 'info@scholarfolio.org';
 export const OA_HEADERS = { 'User-Agent': `ScholarFolio/1.0 (mailto:${EMAIL})` };
 export const OA_EMAIL = EMAIL;
 export const OA_API_URL = API_URL;


### PR DESCRIPTION
## Summary
- All contact emails across Privacy Policy, Terms, and API User-Agent headers now use `info@scholarfolio.org`
- Fixed Crossref placeholder email (`your-email@domain.com` → `info@scholarfolio.org`)
- Fixed OpenAlex non-existent email (`scholarfolio@scholarfolio.org` → `info@scholarfolio.org`)
- Added Contact mailto link in footer

## Test plan
- [ ] Verify footer shows Contact link pointing to info@scholarfolio.org
- [ ] Verify Privacy and Terms pages show info@scholarfolio.org
- [ ] Build passes