### PR TITLE
Fix p-index name splitting for Dutch surname prefixes

### DIFF
--- a/src/components/PIndexSection.tsx
+++ b/src/components/PIndexSection.tsx
@@ -45,9 +45,29 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
   const [showDetails, setShowDetails] = useState(false);
   const [matchStatuses, setMatchStatuses] = useState<Map<string, MatchStatus>>(new Map());
 
-  const nameParts = authorName.split(' ');
-  const [firstName, setFirstName] = useState(nameParts.slice(0, -1).join(' '));
-  const [lastName, setLastName] = useState(nameParts[nameParts.length - 1] || '');
+  const [firstName, setFirstName] = useState(() => {
+    const parts = authorName.trim().split(/\s+/);
+    if (parts.length <= 1) return '';
+    // Find where surname starts: detect surname prefixes (van, de, von, etc.)
+    const prefixes = new Set(['de', 'van', 'von', 'di', 'da', 'del', 'della', 'la', 'le', 'el', 'al', 'bin', 'ben', 'ter', 'ten', 'den', 'der']);
+    let surnameStart = parts.length - 1;
+    for (let i = parts.length - 2; i >= 1; i--) {
+      if (prefixes.has(parts[i].toLowerCase())) surnameStart = i;
+      else break;
+    }
+    return parts.slice(0, surnameStart).join(' ');
+  });
+  const [lastName, setLastName] = useState(() => {
+    const parts = authorName.trim().split(/\s+/);
+    if (parts.length <= 1) return authorName;
+    const prefixes = new Set(['de', 'van', 'von', 'di', 'da', 'del', 'della', 'la', 'le', 'el', 'al', 'bin', 'ben', 'ter', 'ten', 'den', 'der']);
+    let surnameStart = parts.length - 1;
+    for (let i = parts.length - 2; i >= 1; i--) {
+      if (prefixes.has(parts[i].toLowerCase())) surnameStart = i;
+      else break;
+    }
+    return parts.slice(surnameStart).join(' ');
+  });
   const [institution, setInstitution] = useState(() => {
     const stripped = affiliation.replace(/^(Assistant|Associate|Full|Adjunct|Visiting|Emeritus)?\s*(Professor|Lecturer|Researcher|Fellow|Instructor)\s*(of|in|for|,)\s*/i, '');
     if (stripped !== affiliation) return stripped.replace(/^,\s*/, '').trim();


### PR DESCRIPTION
## Summary
- Dutch surname prefixes (van, de, von, ter, etc.) now correctly belong to the last name field
- "Henrico van Roekel" → firstName="Henrico", lastName="van Roekel"
- Previously split as firstName="Henrico van", lastName="Roekel"

## Test plan
- [ ] P-index section pre-fills correctly for Dutch names
- [ ] OpenAlex search still works (query is the same either way)
- [ ] Build passes