### PR TITLE
Open co-author links in new tab

### DIFF
--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -876,20 +876,20 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
   const [searchingAuthor, setSearchingAuthor] = useState<string | null>(null);
 
   const handleAuthorClick = useCallback(async (authorName: string) => {
-    if (!onSearch || searchingAuthor) return;
+    if (searchingAuthor) return;
     setSearchingAuthor(authorName);
     try {
       const results = await scholarService.searchAuthors(authorName);
       if (results.length >= 1) {
-        const url = `https://scholar.google.com/citations?user=${encodeURIComponent(results[0].authorId)}`;
-        onSearch(url);
+        const userId = encodeURIComponent(results[0].authorId);
+        window.open(`${window.location.origin}?user=${userId}`, '_blank');
       }
     } catch {
       // Silently fail — author might not have a Scholar profile
     } finally {
       setSearchingAuthor(null);
     }
-  }, [onSearch, searchingAuthor]);
+  }, [searchingAuthor]);
 
   /** Replace known co-author names in text with clickable buttons */
   const linkifyText = useCallback((text: string): React.ReactNode => {


### PR DESCRIPTION
## Summary
- Clicking a co-author name in the narrative now opens their profile in a new tab
- Previously it replaced the current profile, which felt broken (nothing visible happened until load completed)
- Uses `window.open` with the ScholarFolio `?user=` URL

## Test plan
- [ ] Click a co-author name in the narrative → opens new tab with their profile
- [ ] Spinner still shows while searching for the author
- [ ] Build passes