### PR TITLE
Increase category heading font size

### DIFF
--- a/src/components/PIndexSection.tsx
+++ b/src/components/PIndexSection.tsx
@@ -235,7 +235,7 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
 
   return (
     <div>
-      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2">
+      <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2">
         <span className="w-1.5 h-1.5 rounded-full bg-violet-500"></span>
         P-Index
         <span className="text-[10px] font-normal text-gray-400 dark:text-gray-500">(Pham, Wu &amp; Wang, 2024)</span>

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -406,7 +406,7 @@ export function ProfileView({
         <div className={activeTab === 'metrics' ? 'tab-content-enter' : 'hidden'}>
           <div className="space-y-6">
             <div>
-              <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-cat-impact-from"></span>Impact Metrics</h3>
+              <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-cat-impact-from"></span>Impact Metrics</h3>
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
                 <MetricsCard title="Total Citations" value={data.totalCitations.toLocaleString()} icon="citations" />
                 <MetricsCard title="h-index" value={data.metrics.hIndex} icon="hIndex" />
@@ -446,7 +446,7 @@ export function ProfileView({
 
             {data.fieldMetrics && (data.fieldMetrics.fwci !== null || data.fieldMetrics.meanCitedness !== null || data.fieldMetrics.rcrMean !== null) && (
               <div>
-                <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-cat-field-from"></span>Field-Normalized Metrics</h3>
+                <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-cat-field-from"></span>Field-Normalized Metrics</h3>
                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
                   {data.fieldMetrics.fwci !== null && (
                     <MetricsCard
@@ -479,7 +479,7 @@ export function ProfileView({
             )}
 
             <div>
-              <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-cat-collab-from"></span>Collaboration Metrics</h3>
+              <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-cat-collab-from"></span>Collaboration Metrics</h3>
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
                 <MetricsCard title="Co-authors" value={data.metrics.totalCoAuthors} icon="coAuthors" />
                 <MetricsCard title="Avg Authors/Paper" value={data.metrics.averageAuthors} icon="avgAuthors" />


### PR DESCRIPTION
## Summary
- Bumped section headings (Impact Metrics, Field-Normalized, Collaboration, p-index) from `text-sm` (14px) to `text-base` (16px)
- Headings already use `text-gray-900` (near-black) so color is fine
- Feedback from Fulvio Scognamiglio: headings were too small and hard to read

## Test plan
- [ ] Category headings are visibly larger and readable
- [ ] Dark mode headings still look good
- [ ] Build passes