### PR TITLE
Dark mode overhaul + light/dark/system toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { Linkedin, Github, ExternalLink, Moon, Sun } from 'lucide-react';
+import { Linkedin, Github, ExternalLink } from 'lucide-react';
+import { ThemeToggle } from './components/ThemeToggle';
 import { AuthHeaderControls } from './components/AuthHeaderControls';
 import { LandingPage } from './components/LandingPage';
 import { ApiError } from './utils/api';
@@ -32,7 +33,7 @@ type Page = 'home' | 'about' | 'terms' | 'privacy' | 'admin' | 'changelog';
 function SocialLinks() {
   return (
     <div className="flex items-center gap-2">
-      <DarkModeToggle />
+      <ThemeToggle />
       <a
         href={SOCIAL_LINKS.linkedin}
         target="_blank"
@@ -126,35 +127,6 @@ function Footer({ onNavigate, onSupport }: { onNavigate: (page: Page) => void; o
   );
 }
 
-function DarkModeToggle() {
-  const [dark, setDark] = useState(() => document.documentElement.classList.contains('dark'));
-
-  const toggle = () => {
-    const next = !dark;
-    setDark(next);
-    document.documentElement.classList.toggle('dark', next);
-    localStorage.setItem('sf_theme', next ? 'dark' : 'light');
-  };
-
-  useEffect(() => {
-    const saved = localStorage.getItem('sf_theme');
-    if (saved === 'dark') {
-      setDark(true);
-      document.documentElement.classList.add('dark');
-    }
-  }, []);
-
-  return (
-    <button
-      onClick={toggle}
-      className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-      aria-label="Toggle dark mode"
-      title={dark ? 'Light mode' : 'Dark mode'}
-    >
-      {dark ? <Sun className="h-4 w-4 text-amber-400" /> : <Moon className="h-4 w-4 text-gray-400" />}
-    </button>
-  );
-}
 
 function AppContent() {
   const [loading, setLoading] = useState(false);

--- a/src/components/CitationNetwork.tsx
+++ b/src/components/CitationNetwork.tsx
@@ -709,7 +709,7 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
   }, [publications]);
 
   return (
-    <div className={`bg-white/80 backdrop-blur-xl rounded-xl border border-primary-start/10 p-6 hover:shadow-lg transition-all ${
+    <div className={`bg-white/80 dark:bg-slate-800/80 backdrop-blur-xl rounded-xl border border-primary-start/10 dark:border-slate-700 p-6 hover:shadow-lg transition-all ${
       fullScreen ? 'min-h-[600px]' : ''
     }`}>
       <div className="flex items-center justify-between mb-4">
@@ -726,13 +726,13 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
                 className={`flex items-center space-x-1 px-2 py-1 rounded-lg text-xs transition-colors ${
                   connectionLimit === 10
                     ? 'bg-[#eaf4f4] text-[#2d7d7d]'
-                    : 'text-gray-600 hover:bg-gray-100'
+                    : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-slate-700'
                 }`}
               >
                 <span>Top 10</span>
               </button>
-              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-48 p-2 bg-white rounded-lg shadow-lg border border-gray-100 text-xs hidden group-hover:block z-20">
-                <p className="text-gray-700">Show top 10 co-authors</p>
+              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-48 p-2 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-gray-100 dark:border-slate-700 text-xs hidden group-hover:block z-20">
+                <p className="text-gray-700 dark:text-gray-300">Show top 10 co-authors</p>
               </div>
             </div>
             <div className="group relative">
@@ -741,17 +741,17 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
                 className={`flex items-center space-x-1 px-2 py-1 rounded-lg text-xs transition-colors ${
                   connectionLimit === 20
                     ? 'bg-[#eaf4f4] text-[#2d7d7d]'
-                    : 'text-gray-600 hover:bg-gray-100'
+                    : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-slate-700'
                 }`}
               >
                 <span>Top 20</span>
               </button>
-              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-48 p-2 bg-white rounded-lg shadow-lg border border-gray-100 text-xs hidden group-hover:block z-20">
-                <p className="text-gray-700">Show top 20 co-authors</p>
+              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-48 p-2 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-gray-100 dark:border-slate-700 text-xs hidden group-hover:block z-20">
+                <p className="text-gray-700 dark:text-gray-300">Show top 20 co-authors</p>
               </div>
             </div>
           </div>
-          <div className="h-4 w-px bg-gray-200" />
+          <div className="h-4 w-px bg-gray-200 dark:bg-slate-600" />
           {/* View mode buttons */}
           <div className="flex items-center space-x-1">
             <ViewModeButton
@@ -839,12 +839,12 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
         />
       </div>
 
-      <div className="mt-4 text-xs text-gray-500 bg-[#eaf4f4]/50 rounded-lg p-3">
+      <div className="mt-4 text-xs text-gray-500 dark:text-gray-400 bg-[#eaf4f4]/50 dark:bg-[#2d7d7d]/10 rounded-lg p-3">
         <div className="flex items-start space-x-2">
           <Info className="h-4 w-4 text-[#2d7d7d] flex-shrink-0 mt-0.5" />
           <div>
-            <p className="font-medium text-[#1e293b] mb-1">Network Visualization Guide</p>
-            <ul className="space-y-1 text-[#64748b]">
+            <p className="font-medium text-[#1e293b] dark:text-gray-100 mb-1">Network Visualization Guide</p>
+            <ul className="space-y-1 text-[#64748b] dark:text-gray-400">
               <li>• Node size represents {viewMode === 'citations' ? 'shared citations' : 'shared publications'}</li>
               <li>• Line thickness shows collaboration strength{viewMode === 'citations' ? ' (citation flow)' : ''}</li>
               {viewMode === 'temporal' && (
@@ -874,19 +874,19 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
             <div className="bg-[#eaf4f4]/50 rounded-lg p-3">
               <p className="text-2xl font-bold text-[#2d7d7d]">{insights.totalCoAuthors}</p>
-              <p className="text-xs text-gray-500">Unique co-authors</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Unique co-authors</p>
             </div>
             <div className="bg-[#eaf4f4]/50 rounded-lg p-3">
               <p className="text-2xl font-bold text-[#2d7d7d]">{insights.avgAuthors}</p>
-              <p className="text-xs text-gray-500">Avg. authors per paper</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Avg. authors per paper</p>
             </div>
             <div className="bg-[#eaf4f4]/50 rounded-lg p-3">
               <p className="text-2xl font-bold text-[#2d7d7d]">{insights.collabPapers}</p>
-              <p className="text-xs text-gray-500">Collaborative papers</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Collaborative papers</p>
             </div>
             <div className="bg-[#eaf4f4]/50 rounded-lg p-3">
               <p className="text-2xl font-bold text-[#2d7d7d]">{insights.soloPapers}</p>
-              <p className="text-xs text-gray-500">Solo papers ({insights.soloPercent}%)</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Solo papers ({insights.soloPercent}%)</p>
             </div>
           </div>
 
@@ -897,10 +897,10 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
                   <Users className="h-3.5 w-3.5 text-[#2d7d7d]" />
                 </div>
                 <div>
-                  <p className="text-gray-900">
+                  <p className="text-gray-900 dark:text-gray-100">
                     <span className="font-medium">{insights.topByPapers.name}</span> is your most frequent collaborator
                   </p>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
                     {insights.topByPapers.papers} shared papers · {insights.topByPapers.citations.toLocaleString()} shared citations
                   </p>
                 </div>
@@ -913,10 +913,10 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
                   <TrendingUp className="h-3.5 w-3.5 text-[#2d7d7d]" />
                 </div>
                 <div>
-                  <p className="text-gray-900">
+                  <p className="text-gray-900 dark:text-gray-100">
                     <span className="font-medium">{insights.topByCitations.name}</span> is your highest-impact collaborator
                   </p>
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
                     {insights.topByCitations.papers} shared papers · {insights.topByCitations.citations.toLocaleString()} shared citations
                   </p>
                 </div>
@@ -929,14 +929,14 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
                   <UserCheck className="h-3.5 w-3.5 text-[#2d7d7d]" />
                 </div>
                 <div>
-                  <p className="text-gray-900">
+                  <p className="text-gray-900 dark:text-gray-100">
                     <span className="font-medium">{insights.oneTimeCollaborators}</span> one-time collaborators
                     {insights.oneTimeCitations > 0 && (
                       <> — together they account for <span className="font-medium">{insights.oneTimeCitations.toLocaleString()}</span> citations</>
                     )}
                   </p>
                   {insights.topOneTimer && insights.topOneTimer.citations > 0 && (
-                    <p className="text-xs text-gray-500">
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
                       Highest impact: {insights.topOneTimer.name} ({insights.topOneTimer.citations.toLocaleString()} citations from 1 paper)
                     </p>
                   )}
@@ -965,14 +965,14 @@ function ViewModeButton({ active, onClick, icon, label, tooltip }: {
         className={`flex items-center space-x-1 px-2 py-1 rounded-lg text-xs transition-colors ${
           active
             ? 'bg-[#eaf4f4] text-[#2d7d7d]'
-            : 'text-gray-600 hover:bg-gray-100'
+            : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-slate-700'
         }`}
       >
         {icon}
         <span>{label}</span>
       </button>
-      <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 p-2 bg-white rounded-lg shadow-lg border border-gray-100 text-xs hidden group-hover:block z-20">
-        <p className="text-gray-700">{tooltip}</p>
+      <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 p-2 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-gray-100 dark:border-slate-700 text-xs hidden group-hover:block z-20">
+        <p className="text-gray-700 dark:text-gray-300">{tooltip}</p>
       </div>
     </div>
   );

--- a/src/components/CitationsChart.tsx
+++ b/src/components/CitationsChart.tsx
@@ -94,7 +94,7 @@ const YoYLabel = (props: any) => {
   );
 };
 
-const tooltipStyle = "bg-white/95 backdrop-blur-sm shadow-lg border border-gray-100 rounded-lg p-3 text-xs";
+const tooltipStyle = "bg-white/95 dark:bg-slate-800/95 backdrop-blur-sm shadow-lg border border-gray-100 dark:border-slate-700 rounded-lg p-3 text-xs";
 
 export function CitationsChart({ citationsPerYear, citationGraphSource, publications = [] }: CitationsChartProps) {
   const [timeRange, setTimeRange] = useState<TimeRange>('all');
@@ -253,7 +253,7 @@ export function CitationsChart({ citationsPerYear, citationGraphSource, publicat
   // --- Empty data guard (after all hooks) ---
   if (!hasData) {
     return (
-      <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-xs text-amber-800">
+      <div className="flex items-start gap-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg px-3 py-2 text-xs text-amber-800 dark:text-amber-300">
         <Info className="h-4 w-4 text-amber-500 flex-shrink-0 mt-0.5" />
         <div>
           <p className="font-medium">Citation graph unavailable</p>
@@ -272,7 +272,7 @@ export function CitationsChart({ citationsPerYear, citationGraphSource, publicat
           key={tr}
           onClick={() => setTimeRange(tr)}
           className={`px-2 py-1 text-xs rounded-md transition-colors ${
-            timeRange === tr ? 'bg-[#eaf4f4] text-[#2d7d7d] font-medium' : 'text-gray-500 hover:bg-gray-100'
+            timeRange === tr ? 'bg-[#eaf4f4] text-[#2d7d7d] font-medium' : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-slate-700'
           }`}
         >
           {tr === '5y' ? '5Y' : tr === '10y' ? '10Y' : 'All'}
@@ -286,49 +286,49 @@ export function CitationsChart({ citationsPerYear, citationGraphSource, publicat
       {/* Summary stat cards + time range */}
       <div className="flex items-start justify-between">
         <div className="grid grid-cols-4 gap-3 flex-1 mr-4">
-          <div className="bg-[#eaf4f4] rounded-lg p-3">
+          <div className="bg-[#eaf4f4] dark:bg-[#2d7d7d]/15 rounded-lg p-3">
             <div className="flex items-center text-xs text-[#2d7d7d] mb-1">
               <TrendingUp className="h-3.5 w-3.5 mr-1 flex-shrink-0" />
               Avg Growth
             </div>
-            <div className="text-lg font-semibold text-[#1e293b]">
+            <div className="text-lg font-semibold text-[#1e293b] dark:text-gray-100">
               {stats.avgGrowthRate > 0 ? '+' : ''}{stats.avgGrowthRate}%
             </div>
-            <div className="text-[10px] text-[#64748b]">per year ({timeRangeText})</div>
+            <div className="text-[10px] text-[#64748b] dark:text-gray-400">per year ({timeRangeText})</div>
           </div>
-          <div className="bg-[#eaf4f4] rounded-lg p-3">
+          <div className="bg-[#eaf4f4] dark:bg-[#2d7d7d]/15 rounded-lg p-3">
             <div className="flex items-center text-xs text-[#2d7d7d] mb-1">
               <Citation className="h-3.5 w-3.5 mr-1 flex-shrink-0" />
               Avg Citations
             </div>
-            <div className="text-lg font-semibold text-[#1e293b]">
+            <div className="text-lg font-semibold text-[#1e293b] dark:text-gray-100">
               {stats.avgCitations.toLocaleString()}
             </div>
-            <div className="text-[10px] text-[#64748b]">per year ({timeRangeText})</div>
+            <div className="text-[10px] text-[#64748b] dark:text-gray-400">per year ({timeRangeText})</div>
           </div>
-          <div className="bg-[#eaf4f4] rounded-lg p-3">
+          <div className="bg-[#eaf4f4] dark:bg-[#2d7d7d]/15 rounded-lg p-3">
             <div className="flex items-center text-xs text-[#2d7d7d] mb-1">
               <Calendar className="h-3.5 w-3.5 mr-1 flex-shrink-0" />
               Peak Year
             </div>
-            <div className="text-lg font-semibold text-[#1e293b]">{stats.peakYear}</div>
-            <div className="text-[10px] text-[#64748b]">{stats.peakCitations.toLocaleString()} citations</div>
+            <div className="text-lg font-semibold text-[#1e293b] dark:text-gray-100">{stats.peakYear}</div>
+            <div className="text-[10px] text-[#64748b] dark:text-gray-400">{stats.peakCitations.toLocaleString()} citations</div>
           </div>
-          <div className="bg-[#eaf4f4] rounded-lg p-3">
+          <div className="bg-[#eaf4f4] dark:bg-[#2d7d7d]/15 rounded-lg p-3">
             <div className="flex items-center text-xs text-[#2d7d7d] mb-1">
               <Layers className="h-3.5 w-3.5 mr-1 flex-shrink-0" />
               Total
             </div>
-            <div className="text-lg font-semibold text-[#1e293b]">{stats.totalCumulative.toLocaleString()}</div>
-            <div className="text-[10px] text-[#64748b]">cumulative ({timeRangeText})</div>
+            <div className="text-lg font-semibold text-[#1e293b] dark:text-gray-100">{stats.totalCumulative.toLocaleString()}</div>
+            <div className="text-[10px] text-[#64748b] dark:text-gray-400">cumulative ({timeRangeText})</div>
           </div>
         </div>
         {timeRangeButtons}
       </div>
 
       {/* Citations per year bar chart — mirrors Google Scholar */}
-      <div className="bg-white border border-gray-100 rounded-xl p-4">
-        <h4 className="text-sm font-medium text-gray-900 flex items-center mb-3">
+      <div className="bg-white dark:bg-slate-800 border border-gray-100 dark:border-slate-700 rounded-xl p-4">
+        <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center mb-3">
           <BarChart3 className="h-4 w-4 text-[#2d7d7d] mr-2" />
           Citations per Year
         </h4>
@@ -343,7 +343,7 @@ export function CitationsChart({ citationsPerYear, citationGraphSource, publicat
                 const d = payload[0].payload;
                 return (
                   <div className={tooltipStyle}>
-                    <div className="font-medium text-gray-900 mb-1">{d.year}</div>
+                    <div className="font-medium text-gray-900 dark:text-gray-100 mb-1">{d.year}</div>
                     <div className="text-gray-600">Citations: {d.actual.toLocaleString()}</div>
                     {d.yoyGrowth != null && (
                       <div className={d.yoyGrowth >= 0 ? 'text-emerald-600' : 'text-rose-600'}>
@@ -381,8 +381,8 @@ export function CitationsChart({ citationsPerYear, citationGraphSource, publicat
       {/* Row 2: Two charts side by side */}
       <div className="grid gap-6 lg:grid-cols-2">
         {/* Cumulative citations */}
-        <div className="bg-white border border-gray-100 rounded-xl p-4">
-          <h4 className="text-sm font-medium text-gray-900 flex items-center mb-3">
+        <div className="bg-white dark:bg-slate-800 border border-gray-100 dark:border-slate-700 rounded-xl p-4">
+          <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center mb-3">
             <Layers className="h-4 w-4 text-[#2d7d7d] mr-2" />
             Cumulative Citations
           </h4>
@@ -397,7 +397,7 @@ export function CitationsChart({ citationsPerYear, citationGraphSource, publicat
                   const d = payload[0].payload;
                   return (
                     <div className={tooltipStyle}>
-                      <div className="font-medium text-gray-900 mb-1">{d.year}</div>
+                      <div className="font-medium text-gray-900 dark:text-gray-100 mb-1">{d.year}</div>
                       <div className="text-gray-600">Cumulative: {d.cumulative.toLocaleString()}</div>
                       <div className="text-gray-500">This year: +{d.yearly.toLocaleString()}</div>
                     </div>
@@ -416,8 +416,8 @@ export function CitationsChart({ citationsPerYear, citationGraphSource, publicat
         </div>
 
         {/* Citation velocity */}
-        <div className="bg-white border border-gray-100 rounded-xl p-4">
-          <h4 className="text-sm font-medium text-gray-900 flex items-center mb-3">
+        <div className="bg-white dark:bg-slate-800 border border-gray-100 dark:border-slate-700 rounded-xl p-4">
+          <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center mb-3">
             <Activity className="h-4 w-4 text-[#2d7d7d] mr-2" />
             Citation Velocity
           </h4>
@@ -432,7 +432,7 @@ export function CitationsChart({ citationsPerYear, citationGraphSource, publicat
                   const d = payload[0].payload;
                   return (
                     <div className={tooltipStyle}>
-                      <div className="font-medium text-gray-900 mb-1">{d.year}</div>
+                      <div className="font-medium text-gray-900 dark:text-gray-100 mb-1">{d.year}</div>
                       <div className="text-gray-600">Citations: {d.citations.toLocaleString()}</div>
                       <div className="text-gray-500">3-yr avg: {d.movingAvg.toLocaleString()}</div>
                       {d.yoyChange !== 0 && (
@@ -461,8 +461,8 @@ export function CitationsChart({ citationsPerYear, citationGraphSource, publicat
 
       {/* Publication output + h-index trajectory */}
       {productivityData.length > 0 && (
-        <div className="bg-white border border-gray-100 rounded-xl p-4">
-          <h4 className="text-sm font-medium text-gray-900 flex items-center mb-3">
+        <div className="bg-white dark:bg-slate-800 border border-gray-100 dark:border-slate-700 rounded-xl p-4">
+          <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center mb-3">
             <TrendingUp className="h-4 w-4 text-[#2d7d7d] mr-2" />
             Publication Output & h-index Trajectory
           </h4>
@@ -478,7 +478,7 @@ export function CitationsChart({ citationsPerYear, citationGraphSource, publicat
                   const d = payload[0].payload;
                   return (
                     <div className={tooltipStyle}>
-                      <div className="font-medium text-gray-900 mb-1">{d.year}</div>
+                      <div className="font-medium text-gray-900 dark:text-gray-100 mb-1">{d.year}</div>
                       <div className="text-gray-600">Publications: {d.publications}</div>
                       <div className="text-gray-500">Total papers: {d.totalPubs}</div>
                       <div className="text-[#e07a5f]">h-index: {d.hIndex}</div>

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -353,7 +353,7 @@ export function ProfileView({
                 <Heart className="h-4 w-4 text-[#2d7d7d]" />
               </div>
               <div>
-                <p className="text-sm font-semibold text-gray-900">Support open research tools</p>
+                <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Support open research tools</p>
                 <p className="text-xs text-gray-500 mt-0.5 max-w-2xl">
                   Scholar Folio is built for researchers, not ranking systems. If this helped you understand or share your research profile, a small contribution helps cover paid Scholar data access.
                 </p>

--- a/src/components/PublicationsList.tsx
+++ b/src/components/PublicationsList.tsx
@@ -3,11 +3,11 @@ import { ArrowUpDown, BookOpen, Presentation as Citation, Calendar, Award, Star,
 import type { Publication, JournalRanking, OpenAccessStats, OaStatus } from '../types/scholar';
 
 const OA_COLORS: Record<OaStatus, { bg: string; text: string; label: string; tooltip: string }> = {
-  gold: { bg: 'bg-amber-100', text: 'text-amber-800', label: 'Gold OA', tooltip: 'Published in an open access journal' },
-  green: { bg: 'bg-emerald-100', text: 'text-emerald-800', label: 'Green OA', tooltip: 'Available via a repository (e.g. institutional or preprint)' },
-  hybrid: { bg: 'bg-sky-100', text: 'text-sky-800', label: 'Hybrid OA', tooltip: 'Open access in a subscription journal' },
-  bronze: { bg: 'bg-orange-100', text: 'text-orange-800', label: 'Bronze OA', tooltip: 'Free to read on publisher site, but no open license' },
-  closed: { bg: 'bg-gray-100', text: 'text-gray-500', label: 'Closed', tooltip: 'Not freely available' },
+  gold: { bg: 'bg-amber-100 dark:bg-amber-900/40', text: 'text-amber-800 dark:text-amber-300', label: 'Gold OA', tooltip: 'Published in an open access journal' },
+  green: { bg: 'bg-emerald-100 dark:bg-emerald-900/40', text: 'text-emerald-800 dark:text-emerald-300', label: 'Green OA', tooltip: 'Available via a repository (e.g. institutional or preprint)' },
+  hybrid: { bg: 'bg-sky-100 dark:bg-sky-900/40', text: 'text-sky-800 dark:text-sky-300', label: 'Hybrid OA', tooltip: 'Open access in a subscription journal' },
+  bronze: { bg: 'bg-orange-100 dark:bg-orange-900/40', text: 'text-orange-800 dark:text-orange-300', label: 'Bronze OA', tooltip: 'Free to read on publisher site, but no open license' },
+  closed: { bg: 'bg-gray-100 dark:bg-slate-700', text: 'text-gray-500 dark:text-gray-400', label: 'Closed', tooltip: 'Not freely available' },
 };
 
 function OaBadge({ status, oaUrl }: { status: OaStatus; oaUrl?: string }) {
@@ -42,31 +42,31 @@ function JournalRankingBadge({ ranking }: { ranking: JournalRanking }) {
   return (
     <div className="flex flex-wrap gap-1.5">
       {ranking.ft50 && (
-        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-800">
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300">
           <Award className="h-3 w-3 mr-0.5" />
           FT50
         </span>
       )}
       {ranking.abs && (
-        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#eaf4f4] text-[#2d7d7d]">
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-[#eaf4f4] dark:bg-[#2d7d7d]/20 text-[#2d7d7d] dark:text-[#5bbdbd]">
           <Star className="h-3 w-3 mr-0.5" />
           ABS {ranking.abs}
         </span>
       )}
       {ranking.sjr && (
-        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-teal-100 text-teal-800">
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-teal-100 dark:bg-teal-900/40 text-teal-800 dark:text-teal-300">
           <TrendingUp className="h-3 w-3 mr-0.5" />
           SJR {ranking.sjr}
         </span>
       )}
       {ranking.abdc && (
-        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-100 text-purple-800">
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-100 dark:bg-purple-900/40 text-purple-800 dark:text-purple-300">
           <Star className="h-3 w-3 mr-0.5" />
           ABDC {ranking.abdc}
         </span>
       )}
       {ranking.jcr && (
-        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-100 text-indigo-800">
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-100 dark:bg-indigo-900/40 text-indigo-800 dark:text-indigo-300">
           <TrendingUp className="h-3 w-3 mr-0.5" />
           IF {ranking.jcr}
         </span>
@@ -97,17 +97,17 @@ export function PublicationsList({ publications, openAccess }: PublicationsListP
 
   if (!publications.length) {
     return (
-      <div className="bg-white rounded-lg p-6 text-center">
-        <BookOpen className="h-8 w-8 text-gray-400 mx-auto mb-2" />
-        <p className="text-gray-600">No publications found</p>
+      <div className="bg-white dark:bg-slate-800 rounded-lg p-6 text-center">
+        <BookOpen className="h-8 w-8 text-gray-400 dark:text-gray-500 mx-auto mb-2" />
+        <p className="text-gray-600 dark:text-gray-400">No publications found</p>
       </div>
     );
   }
 
   return (
-    <div className="bg-white rounded-lg p-6">
+    <div className="bg-white dark:bg-slate-800 rounded-lg p-6">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-lg font-semibold text-gray-900 flex items-center">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 flex items-center">
           <BookOpen className="h-5 w-5 text-[#2d7d7d] mr-2" />
           Publications ({publications.length})
         </h3>
@@ -118,7 +118,7 @@ export function PublicationsList({ publications, openAccess }: PublicationsListP
             className={`text-xs px-2 py-1 rounded ${
               sortField === 'citations'
                 ? 'bg-[#eaf4f4] text-[#2d7d7d]'
-                : 'text-gray-600 hover:bg-gray-100'
+                : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-slate-700'
             }`}
           >
             Citations
@@ -129,7 +129,7 @@ export function PublicationsList({ publications, openAccess }: PublicationsListP
             className={`text-xs px-2 py-1 rounded ${
               sortField === 'year'
                 ? 'bg-[#eaf4f4] text-[#2d7d7d]'
-                : 'text-gray-600 hover:bg-gray-100'
+                : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-slate-700'
             }`}
           >
             Year
@@ -140,7 +140,7 @@ export function PublicationsList({ publications, openAccess }: PublicationsListP
             className={`text-xs px-2 py-1 rounded ${
               sortField === 'title'
                 ? 'bg-[#eaf4f4] text-[#2d7d7d]'
-                : 'text-gray-600 hover:bg-gray-100'
+                : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-slate-700'
             }`}
           >
             Title
@@ -154,27 +154,27 @@ export function PublicationsList({ publications, openAccess }: PublicationsListP
           const normalizedTitle = pub.title.toLowerCase().replace(/[^a-z0-9]/g, '');
           const pubOaStatus = openAccess?.publicationOa?.[normalizedTitle];
           return (
-          <div key={index} className="border-b border-gray-100 last:border-0 pb-4 last:pb-0">
+          <div key={index} className="border-b border-gray-100 dark:border-slate-700 last:border-0 pb-4 last:pb-0">
             <a
               href={pub.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-start justify-between gap-4 hover:bg-gray-50 rounded p-2 -mx-2 transition-colors"
+              className="flex items-start justify-between gap-4 hover:bg-gray-50 dark:hover:bg-slate-700/50 rounded p-2 -mx-2 transition-colors"
             >
               <div className="flex-1 min-w-0">
-                <h4 className="text-sm font-medium text-gray-900 hover:text-[#2d7d7d] mb-1">
+                <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-[#2d7d7d] mb-1">
                   {pub.title}
                 </h4>
-                <p className="text-xs text-gray-600 mb-2">
+                <p className="text-xs text-gray-600 dark:text-gray-400 mb-2">
                   {pub.authors.join(', ')}
                 </p>
-                <div className="flex flex-wrap items-center gap-4 text-xs text-gray-500">
+                <div className="flex flex-wrap items-center gap-4 text-xs text-gray-500 dark:text-gray-400">
                   <span className="flex items-center">
                     <Calendar className="h-3 w-3 mr-1" />
                     {pub.year}
                   </span>
                   {pub.venue && (
-                    <span className="text-gray-400">{pub.venue}</span>
+                    <span className="text-gray-400 dark:text-gray-500">{pub.venue}</span>
                   )}
                 </div>
                 {(pub.journalRanking || pubOaStatus) && (
@@ -186,7 +186,7 @@ export function PublicationsList({ publications, openAccess }: PublicationsListP
               </div>
               <div className="flex flex-col items-center shrink-0 min-w-[60px]">
                 <span className="text-lg font-bold text-[#2d7d7d]">{pub.citations.toLocaleString()}</span>
-                <span className="text-[10px] text-gray-400 uppercase tracking-wide">citations</span>
+                <span className="text-[10px] text-gray-400 dark:text-gray-500 uppercase tracking-wide">citations</span>
               </div>
             </a>
           </div>

--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -975,13 +975,13 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
   return (
     <div>
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-semibold text-gray-900 flex items-center">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 flex items-center">
           <FileText className="h-4 w-4 text-[#2d7d7d] mr-2" />
           Research Profile
         </h3>
         <button
           onClick={() => setShowReport(!showReport)}
-          className="inline-flex items-center gap-1 text-[10px] text-gray-400 hover:text-gray-600 transition-colors"
+          className="inline-flex items-center gap-1 text-[10px] text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
           title="Report an error in this profile"
         >
           <Flag className="h-3 w-3" />
@@ -990,7 +990,7 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
       </div>
 
       {showReport && (
-        <div className="mb-4 bg-gray-50 rounded-lg p-4 border border-gray-200">
+        <div className="mb-4 bg-gray-50 dark:bg-slate-800 rounded-lg p-4 border border-gray-200 dark:border-slate-700">
           {reportStatus === 'sent' ? (
             <div className="flex items-center gap-2 text-sm text-emerald-600">
               <Check className="h-4 w-4" />
@@ -998,7 +998,7 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
             </div>
           ) : (
             <>
-              <p className="text-xs text-gray-500 mb-2">
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
                 Spotted something wrong? Let us know and we'll fix it.
               </p>
               <textarea
@@ -1006,7 +1006,7 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
                 onChange={e => setReportMsg(e.target.value)}
                 placeholder="Describe the error (e.g., 'Wrong affiliation', 'Missing publications'...)"
                 rows={2}
-                className="w-full px-3 py-2 text-sm rounded-lg border border-gray-200 focus:border-[#2d7d7d] focus:ring-1 focus:ring-[#2d7d7d] outline-none resize-none mb-2"
+                className="w-full px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-gray-100 focus:border-[#2d7d7d] focus:ring-1 focus:ring-[#2d7d7d] outline-none resize-none mb-2"
                 maxLength={1000}
               />
               <input
@@ -1014,7 +1014,7 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
                 value={reportEmail}
                 onChange={e => setReportEmail(e.target.value)}
                 placeholder="Your email (optional, for follow-up)"
-                className="w-full px-3 py-2 text-sm rounded-lg border border-gray-200 focus:border-[#2d7d7d] focus:ring-1 focus:ring-[#2d7d7d] outline-none mb-2"
+                className="w-full px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-gray-100 focus:border-[#2d7d7d] focus:ring-1 focus:ring-[#2d7d7d] outline-none mb-2"
               />
               <div className="flex items-center gap-2">
                 <button
@@ -1028,7 +1028,7 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
                 </button>
                 <button
                   onClick={() => { setShowReport(false); setReportMsg(''); setReportEmail(''); }}
-                  className="px-3 py-1.5 text-xs text-gray-500 hover:text-gray-700 transition-colors"
+                  className="px-3 py-1.5 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
                 >
                   Cancel
                 </button>
@@ -1166,7 +1166,7 @@ function NarrativeBody({
   return (
     <div
       ref={containerRef}
-      className="space-y-2 text-sm text-gray-600 leading-relaxed"
+      className="space-y-2 text-sm text-gray-600 dark:text-gray-300 leading-relaxed"
       onClick={isAnimating ? skipAnimation : undefined}
       style={isAnimating ? { cursor: 'pointer' } : undefined}
     >
@@ -1175,7 +1175,7 @@ function NarrativeBody({
         <span className="inline-block w-0.5 h-4 bg-[#2d7d7d] animate-pulse align-text-bottom ml-0.5" />
       )}
       {isAnimating && (
-        <p className="text-[10px] text-gray-400 mt-2 italic">Click anywhere to skip animation</p>
+        <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-2 italic">Click anywhere to skip animation</p>
       )}
     </div>
   );

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,69 @@
+import React, { useState, useEffect } from 'react';
+import { Sun, Moon, Monitor } from 'lucide-react';
+
+type Theme = 'light' | 'dark' | 'system';
+
+function getSystemTheme(): 'light' | 'dark' {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyTheme(theme: Theme) {
+  const resolved = theme === 'system' ? getSystemTheme() : theme;
+  document.documentElement.classList.toggle('dark', resolved === 'dark');
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const saved = localStorage.getItem('sf_theme') as Theme | null;
+    return saved && ['light', 'dark', 'system'].includes(saved) ? saved : 'light';
+  });
+
+  useEffect(() => {
+    applyTheme(theme);
+    localStorage.setItem('sf_theme', theme);
+  }, [theme]);
+
+  // Listen for system preference changes when in system mode
+  useEffect(() => {
+    if (theme !== 'system') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => applyTheme('system');
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [theme]);
+
+  const options: { value: Theme; icon: typeof Sun; label: string }[] = [
+    { value: 'light', icon: Sun, label: 'Light' },
+    { value: 'dark', icon: Moon, label: 'Dark' },
+    { value: 'system', icon: Monitor, label: 'System' },
+  ];
+
+  return (
+    <div
+      className="inline-flex items-center rounded-lg bg-gray-100 dark:bg-slate-800 p-0.5 gap-0.5"
+      role="radiogroup"
+      aria-label="Theme"
+    >
+      {options.map(({ value, icon: Icon, label }) => {
+        const active = theme === value;
+        return (
+          <button
+            key={value}
+            role="radio"
+            aria-checked={active}
+            aria-label={label}
+            title={label}
+            onClick={() => setTheme(value)}
+            className={`relative p-1.5 rounded-md transition-all duration-200 ${
+              active
+                ? 'bg-white dark:bg-slate-700 text-gray-900 dark:text-gray-100 shadow-sm'
+                : 'text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300'
+            }`}
+          >
+            <Icon className="h-3.5 w-3.5" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **New ThemeToggle**: tabs-style toggle with Light/Dark/System options (Sun/Moon/Monitor icons). System mode follows OS preference with live media query listener.
- **Dark mode fixes across all profile components**:
  - ResearcherNarrative: body text, heading, report form, inputs, skip animation text
  - PublicationsList: container, headings, sort buttons, publication items, all OA/journal ranking badges
  - CitationsChart: stat cards, chart containers, headings, tooltips, time range buttons, empty state
  - CitationNetwork: container, tooltips, guide section, stat labels, buttons, dividers
  - ProfileView: support heading

## Test plan
- [ ] Toggle between light/dark/system — all 3 work correctly
- [ ] System mode follows OS preference changes in real time
- [ ] Narrative text is readable in dark mode
- [ ] Publications list: titles, authors, badges all visible
- [ ] Charts: stat cards, headings, tooltips readable
- [ ] Co-author network: container, buttons, guide all themed
- [ ] Build passes