### PR TITLE
Fix remaining dark mode gaps

### DIFF
--- a/src/components/CitationNetwork.tsx
+++ b/src/components/CitationNetwork.tsx
@@ -866,25 +866,25 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
 
       {/* Network Insights */}
       {insights && (
-        <div className="mt-6 border-t border-gray-100 pt-6">
-          <h4 className="text-sm font-semibold text-[#1e293b] mb-4 flex items-center gap-2">
+        <div className="mt-6 border-t border-gray-100 dark:border-slate-700 pt-6">
+          <h4 className="text-sm font-semibold text-[#1e293b] dark:text-gray-100 mb-4 flex items-center gap-2">
             <Sparkles className="h-4 w-4 text-[#2d7d7d]" />
             Collaboration Insights
           </h4>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
-            <div className="bg-[#eaf4f4]/50 rounded-lg p-3">
+            <div className="bg-[#eaf4f4]/50 dark:bg-slate-700/30 rounded-lg p-3">
               <p className="text-2xl font-bold text-[#2d7d7d]">{insights.totalCoAuthors}</p>
               <p className="text-xs text-gray-500 dark:text-gray-400">Unique co-authors</p>
             </div>
-            <div className="bg-[#eaf4f4]/50 rounded-lg p-3">
+            <div className="bg-[#eaf4f4]/50 dark:bg-slate-700/30 rounded-lg p-3">
               <p className="text-2xl font-bold text-[#2d7d7d]">{insights.avgAuthors}</p>
               <p className="text-xs text-gray-500 dark:text-gray-400">Avg. authors per paper</p>
             </div>
-            <div className="bg-[#eaf4f4]/50 rounded-lg p-3">
+            <div className="bg-[#eaf4f4]/50 dark:bg-slate-700/30 rounded-lg p-3">
               <p className="text-2xl font-bold text-[#2d7d7d]">{insights.collabPapers}</p>
               <p className="text-xs text-gray-500 dark:text-gray-400">Collaborative papers</p>
             </div>
-            <div className="bg-[#eaf4f4]/50 rounded-lg p-3">
+            <div className="bg-[#eaf4f4]/50 dark:bg-slate-700/30 rounded-lg p-3">
               <p className="text-2xl font-bold text-[#2d7d7d]">{insights.soloPapers}</p>
               <p className="text-xs text-gray-500 dark:text-gray-400">Solo papers ({insights.soloPercent}%)</p>
             </div>

--- a/src/components/MetricsCard.tsx
+++ b/src/components/MetricsCard.tsx
@@ -233,7 +233,7 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
           <p className="text-[11px] font-medium text-gray-400 dark:text-gray-500 leading-none">{title}</p>
           <p className="text-sm font-bold text-gray-900 dark:text-gray-100 mt-1.5 truncate">{display}</p>
           {subtitle && (
-            <p className="text-[10px] text-gray-400 leading-tight mt-0.5 truncate">{subtitle}</p>
+            <p className="text-[10px] text-gray-400 dark:text-gray-500 leading-tight mt-0.5 truncate">{subtitle}</p>
           )}
         </div>
       </div>

--- a/src/components/NarrativeCvTab.tsx
+++ b/src/components/NarrativeCvTab.tsx
@@ -25,7 +25,7 @@ const formats: Array<{
     description: 'Narrative academic profile + max 10 key outputs. NWO explicitly bans Journal Impact Factors and h-indices — the export strips these automatically.',
     grants: 'Veni, Vidi, Vici, Rubicon, and all other NWO programmes',
     metrics: 'No h-index, no JIF, no citation counts',
-    color: 'border-orange-200 bg-orange-50/50',
+    color: 'border-orange-200 bg-orange-50/50 dark:border-orange-800 dark:bg-orange-950/30',
   },
   {
     id: 'erc',
@@ -34,7 +34,7 @@ const formats: Array<{
     description: 'Structured CV (4-page target) with 6 sections covering personal info, education, positions, achievements, publications, and a narrative track record. Journal Impact Factors are discouraged, but citation counts are acceptable as evidence.',
     grants: 'Starting Grant, Consolidator Grant, Advanced Grant',
     metrics: 'No JIF; citation counts allowed',
-    color: 'border-blue-200 bg-blue-50/50',
+    color: 'border-blue-200 bg-blue-50/50 dark:border-blue-800 dark:bg-blue-950/30',
   },
   {
     id: 'msca',
@@ -43,7 +43,7 @@ const formats: Array<{
     description: 'Part B2 researcher CV for MSCA Postdoctoral Fellowship applications. Focuses on research experience, publications, international mobility, and transferable skills. No strict page limit but should be concise.',
     grants: 'MSCA Postdoctoral Fellowships (European & Global)',
     metrics: 'Citation counts allowed; focus on quality over quantity',
-    color: 'border-purple-200 bg-purple-50/50',
+    color: 'border-purple-200 bg-purple-50/50 dark:border-purple-800 dark:bg-purple-950/30',
   },
 ];
 

--- a/src/components/PIndexSection.tsx
+++ b/src/components/PIndexSection.tsx
@@ -298,7 +298,7 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
 
       {/* Step 2: Searching */}
       {step === 'searching' && (
-        <div className="flex items-center gap-2 text-xs text-gray-500 py-4">
+        <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 py-4">
           <Loader2 className="h-4 w-4 animate-spin text-violet-500" />
           Searching OpenAlex…
         </div>
@@ -335,7 +335,7 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
 
       {/* Step 3b: Loading publications */}
       {step === 'loading-works' && (
-        <div className="flex items-center gap-2 text-xs text-gray-500 py-4">
+        <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400 py-4">
           <Loader2 className="h-4 w-4 animate-spin text-violet-500" />
           Loading publications for {selectedAuthor?.display_name}…
         </div>

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -185,15 +185,15 @@ export function ProfileView({
           <div className="flex items-center gap-4">
             <button
               onClick={onReset}
-              className="p-1.5 hover:bg-gray-100 rounded-lg transition-colors"
+              className="p-1.5 hover:bg-gray-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
               aria-label="Go back"
             >
-              <ArrowLeft className="h-4 w-4 text-gray-500" />
+              <ArrowLeft className="h-4 w-4 text-gray-500 dark:text-gray-400" />
             </button>
 
             <div className="flex items-center gap-2">
               <Logo size={24} />
-              <span className="font-semibold text-sm text-gray-900 hidden sm:inline">Scholar Folio</span>
+              <span className="font-semibold text-sm text-gray-900 dark:text-gray-100 hidden sm:inline">Scholar Folio</span>
               <span className="text-[10px] font-medium text-primary-start bg-primary-start/8 px-1.5 py-0.5 rounded hidden sm:inline">
                 v{packageJson.version.replace('-beta', '')} <span className="text-[8px] opacity-60">beta</span>
               </span>
@@ -232,7 +232,7 @@ export function ProfileView({
                 </div>
               )}
               <div className="min-w-0">
-                <h2 className="text-xl font-bold text-gray-900 mb-1 truncate">
+                <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-1 truncate">
                   {profileUrl ? (
                     <a
                       href={profileUrl}
@@ -247,7 +247,7 @@ export function ProfileView({
                     data.name
                   )}
                 </h2>
-                <p className="text-sm text-gray-500 mb-2">{data.affiliation}</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">{data.affiliation}</p>
                 <div className="flex items-center gap-2">
                   <button
                     onClick={handleShare}
@@ -341,20 +341,20 @@ export function ProfileView({
           </div>
 
           {/* Researcher Narrative */}
-          <div className="mt-5 pt-5 border-t border-gray-100">
+          <div className="mt-5 pt-5 border-t border-gray-100 dark:border-slate-700">
             <ResearcherNarrative data={data} geoData={prefetchedGeo} onSearch={onSearch} pIndexResult={pIndexResult} />
           </div>
         </div>
 
         {onSupport && (
-          <div className="bg-white rounded-xl border border-[#2d7d7d]/15 shadow-card p-4 mb-6 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+          <div className="bg-white dark:bg-slate-800 rounded-xl border border-[#2d7d7d]/15 shadow-card p-4 mb-6 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
             <div className="flex items-start gap-3">
               <div className="w-9 h-9 rounded-lg bg-[#eaf4f4] flex items-center justify-center flex-shrink-0">
                 <Heart className="h-4 w-4 text-[#2d7d7d]" />
               </div>
               <div>
                 <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Support open research tools</p>
-                <p className="text-xs text-gray-500 mt-0.5 max-w-2xl">
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 max-w-2xl">
                   Scholar Folio is built for researchers, not ranking systems. If this helped you understand or share your research profile, a small contribution helps cover paid Scholar data access.
                 </p>
               </div>
@@ -387,8 +387,8 @@ export function ProfileView({
                 onClick={() => { setActiveTab(tab.id); setTabKey(k => k + 1); }}
                 className={`relative z-10 flex items-center gap-1.5 px-4 py-2 text-xs font-medium rounded-lg transition-colors ${
                   activeTab === tab.id
-                    ? 'text-gray-900'
-                    : 'text-gray-500 hover:text-gray-700'
+                    ? 'text-gray-900 dark:text-gray-100'
+                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
                 }`}
               >
                 <tab.icon className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary
- **ProfileView**: separator border, support banner bg, support body text
- **MetricsCard**: subtitle dark text
- **PIndexSection**: two spinner loading texts
- **NarrativeCvTab**: card color strings (orange/blue/purple) now have dark border + bg variants
- **CitationNetwork**: insight section border, heading, stat boxes

## Test plan
- [ ] Toggle dark mode and verify all profile components render with proper contrast
- [ ] Check NarrativeCvTab cards have visible borders in dark mode
- [ ] Verify CitationNetwork insights section is readable in dark mode