### PR TITLE
Fix dark mode contrast on profile view

### DIFF
--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -251,7 +251,7 @@ export function ProfileView({
                 <div className="flex items-center gap-2">
                   <button
                     onClick={handleShare}
-                    className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] hover:text-[#1a5c5c] bg-[#eaf4f4] hover:bg-[#d5ecec] px-2.5 py-1 rounded-full transition-colors"
+                    className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] dark:text-[#5bbdbd] hover:text-[#1a5c5c] bg-[#eaf4f4] dark:bg-[#2d7d7d]/20 hover:bg-[#d5ecec] dark:hover:bg-[#2d7d7d]/30 px-2.5 py-1 rounded-full transition-colors"
                   >
                     {copied ? <Check className="h-3 w-3" /> : <Share2 className="h-3 w-3" />}
                     {copied ? 'Link copied!' : 'Share profile'}
@@ -259,7 +259,7 @@ export function ProfileView({
                   {scholarId && (
                     <button
                       onClick={() => setShowEmbed(true)}
-                      className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] hover:text-[#1a5c5c] bg-[#eaf4f4] hover:bg-[#d5ecec] px-2.5 py-1 rounded-full transition-colors"
+                      className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] dark:text-[#5bbdbd] hover:text-[#1a5c5c] bg-[#eaf4f4] dark:bg-[#2d7d7d]/20 hover:bg-[#d5ecec] dark:hover:bg-[#2d7d7d]/30 px-2.5 py-1 rounded-full transition-colors"
                     >
                       <Code className="h-3 w-3" />
                       Embed
@@ -280,13 +280,13 @@ export function ProfileView({
                       }
                     }}
                     disabled={exportingPdf}
-                    className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] hover:text-[#1a5c5c] bg-[#eaf4f4] hover:bg-[#d5ecec] px-2.5 py-1 rounded-full transition-colors disabled:opacity-50"
+                    className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] dark:text-[#5bbdbd] hover:text-[#1a5c5c] bg-[#eaf4f4] dark:bg-[#2d7d7d]/20 hover:bg-[#d5ecec] dark:hover:bg-[#2d7d7d]/30 px-2.5 py-1 rounded-full transition-colors disabled:opacity-50"
                   >
                     <Download className="h-3 w-3" />
                     {exportingPdf ? 'Exporting...' : 'PDF'}
                   </button>
                   {claimedSlug ? (
-                    <span className="inline-flex items-center gap-1.5 text-xs text-emerald-700 bg-emerald-50 px-2.5 py-1 rounded-full font-medium">
+                    <span className="inline-flex items-center gap-1.5 text-xs text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 px-2.5 py-1 rounded-full font-medium">
                       <BadgeCheck className="h-3.5 w-3.5" />
                       {claimedByCurrentUser ? (
                         <a href={`/${claimedSlug}`} className="hover:underline">scholarfolio.org/{claimedSlug}</a>
@@ -297,7 +297,7 @@ export function ProfileView({
                   ) : user && scholarId ? (
                     <button
                       onClick={() => setShowClaimModal(true)}
-                      className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] hover:text-[#1a5c5c] bg-[#eaf4f4] hover:bg-[#d5ecec] px-2.5 py-1 rounded-full transition-colors"
+                      className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] dark:text-[#5bbdbd] hover:text-[#1a5c5c] bg-[#eaf4f4] dark:bg-[#2d7d7d]/20 hover:bg-[#d5ecec] dark:hover:bg-[#2d7d7d]/30 px-2.5 py-1 rounded-full transition-colors"
                     >
                       <Link className="h-3 w-3" />
                       Claim profile
@@ -334,7 +334,7 @@ export function ProfileView({
               ].map(({ value, label }) => (
                 <div key={label} className="text-center">
                   <div className="text-2xl font-bold gradient-text">{value}</div>
-                  <div className="text-xs text-gray-400 font-medium mt-0.5">{label}</div>
+                  <div className="text-xs text-gray-400 dark:text-gray-500 font-medium mt-0.5">{label}</div>
                 </div>
               ))}
             </div>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -108,10 +108,10 @@ export function SearchBar({ onSearch, isLoading = false, compact = false, error:
           disabled={isLoading}
           className={`w-full ${
             compact
-              ? 'py-1.5 pl-9 pr-16 text-xs'
-              : 'py-3 pl-12 pr-24 text-sm'
-          } text-gray-700 bg-white border ${
-            error ? 'border-[#64748b] focus:border-[#2d7d7d] focus:ring-[#2d7d7d]/20' : 'border-gray-200 focus:border-[#2d7d7d] focus:ring-[#2d7d7d]/20'
+              ? 'py-1.5 pl-9 pr-24 text-xs'
+              : 'py-3 pl-12 pr-28 text-sm'
+          } text-gray-700 dark:text-gray-200 bg-white dark:bg-slate-800 border ${
+            error ? 'border-[#64748b] focus:border-[#2d7d7d] focus:ring-[#2d7d7d]/20' : 'border-gray-200 dark:border-slate-600 focus:border-[#2d7d7d] focus:ring-[#2d7d7d]/20'
           } rounded-lg focus:outline-none focus:ring-2 transition-all`}
           autoComplete="off"
           spellCheck="false"

--- a/src/components/TopicsList.tsx
+++ b/src/components/TopicsList.tsx
@@ -31,7 +31,7 @@ export function TopicsList({ topics = [], compact = false }: TopicsListProps) {
             href={topic.url}
             target="_blank"
             rel="noopener noreferrer"
-            className={`inline-flex items-center space-x-1 px-1.5 py-0.5 bg-[#eaf4f4] hover:bg-[#d5ecec] text-[#2d7d7d] rounded-full transition-colors ${
+            className={`inline-flex items-center space-x-1 px-1.5 py-0.5 bg-[#eaf4f4] dark:bg-[#2d7d7d]/20 hover:bg-[#d5ecec] dark:hover:bg-[#2d7d7d]/30 text-[#2d7d7d] dark:text-[#5bbdbd] rounded-full transition-colors ${
               compact ? 'text-[10px]' : 'text-xs'
             }`}
             title={topicName}

--- a/src/index.css
+++ b/src/index.css
@@ -268,6 +268,10 @@ body {
     radial-gradient(at 80% 80%, rgba(30, 41, 59, 0.06) 0px, transparent 50%);
 }
 
+.dark .gradient-text {
+  background-image: linear-gradient(135deg, #5bbdbd, #94a3b8);
+}
+
 .dark .skeleton {
   background: linear-gradient(90deg, #1e293b 25%, #334155 50%, #1e293b 75%);
   background-size: 200% 100%;


### PR DESCRIPTION
## Summary
- **Gradient text** (citation numbers): lighten in dark mode so they're readable
- **Search bar**: dark mode input bg/text/border + fix Explore button overlapping input text
- **Topic pills**: dark bg/text variants
- **Action buttons** (Share, Embed, PDF, Claim): dark bg/text variants
- **Verified badge**: dark contrast fix

## Test plan
- [ ] Dark mode: verify citation numbers (4,072 / 24 / 53) are clearly readable
- [ ] Search bar: Explore button doesn't overlap input text
- [ ] Topic tags and action buttons have proper contrast in dark mode