### PR TITLE
Log p-index OpenAlex lookups for debugging

### DIFF
--- a/src/components/PIndexSection.tsx
+++ b/src/components/PIndexSection.tsx
@@ -3,6 +3,7 @@ import { Search, Loader2, CheckCircle, AlertTriangle, ChevronDown, ChevronUp, In
 import { oaFetchJson, OA_API_URL, OA_EMAIL } from '../services/openalex/author-lookup';
 import { fetchPIndexWorks, computePIndexFromWorks, type PIndexWork, type PIndexResult } from '../services/openalex/pindex';
 import { MetricsCard } from './MetricsCard';
+import { supabase } from '../lib/supabase';
 
 interface OpenAlexSearchResult {
   id: string;
@@ -108,6 +109,15 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
     const data = await oaFetchJson<{ results: OpenAlexSearchResult[] }>(
       `${OA_API_URL}/authors?search=${encodeURIComponent(query)}&per_page=10&select=id,display_name,works_count,cited_by_count,last_known_institutions&mailto=${OA_EMAIL}`
     );
+
+    // Log p-index lookup for debugging (no IP — client-side insert)
+    try {
+      await supabase.from('request_logs').insert({
+        source: 'pindex',
+        author_id: query,
+        origin: window.location.href,
+      });
+    } catch (_) {}
 
     if (!data?.results?.length) {
       setErrorMsg('No authors found in OpenAlex. Try adjusting the name.');


### PR DESCRIPTION
## Summary
- Logs p-index searches to `request_logs` with `source='pindex'` and the searched name as `author_id`
- Client-side insert (no IP stored) — covered under existing legitimate interest basis
- Helps debug "no author found" reports from users

## Test plan
- [ ] Click "Find Author in OpenAlex" → check `request_logs` for new `pindex` entry