### PR TITLE
Add feedback-for-credits system

### DIFF
--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { ArrowLeft, BarChart3, Users, CreditCard, Search, TrendingUp, UserPlus, Eye, Flag, ExternalLink, AlertTriangle } from 'lucide-react';
+import { ArrowLeft, BarChart3, Users, CreditCard, Search, TrendingUp, UserPlus, Eye, Flag, ExternalLink, AlertTriangle, MessageSquare } from 'lucide-react';
 import { Logo } from './Logo';
 import { useAuth } from '../contexts/AuthContext';
 import { supabase } from '../lib/supabase';
@@ -18,6 +18,7 @@ interface RawData {
   users: Array<{ user_id: string; credits_remaining: number; total_purchased: number; created_at: string }>;
   purchases: Array<{ pack: string; amount_cents: number; credits: number; created_at: string }>;
   dailyStats: Array<{ day: string; total_searches: number; auth_searches: number; anon_searches: number; unique_profiles: number }>;
+  feedback: Array<{ id: string; rating: number | null; comment: string | null; credits_granted: number; source: string; profile_viewed: string | null; created_at: string }>;
 }
 
 function getPeriodStart(period: Period): Date | null {
@@ -86,12 +87,13 @@ export function AdminDashboard({ onBack }: AdminDashboardProps) {
           return allLogs;
         }
 
-        const [searchesData, usersRes, purchasesRes, reportsRes, dailyStatsRes] = await Promise.all([
+        const [searchesData, usersRes, purchasesRes, reportsRes, dailyStatsRes, feedbackRes] = await Promise.all([
           fetchAllLogs(),
           supabase.from('user_credits').select('user_id,credits_remaining,total_purchased,created_at'),
           supabase.from('credit_purchases').select('pack,amount_cents,credits,created_at').order('created_at', { ascending: false }),
           supabase.from('profile_reports').select('*').order('created_at', { ascending: false }).limit(100),
           supabase.from('daily_search_stats').select('*').order('day', { ascending: true }),
+          supabase.from('feedback').select('id,rating,comment,credits_granted,source,profile_viewed,created_at').order('created_at', { ascending: false }).limit(200),
         ]);
 
         if (usersRes.error) throw usersRes.error;
@@ -102,6 +104,7 @@ export function AdminDashboard({ onBack }: AdminDashboardProps) {
           users: usersRes.data || [],
           purchases: purchasesRes.data || [],
           dailyStats: dailyStatsRes.data || [],
+          feedback: feedbackRes.data || [],
         });
         if (reportsRes.data) setReports(reportsRes.data);
       } catch (err) {
@@ -389,6 +392,51 @@ export function AdminDashboard({ onBack }: AdminDashboardProps) {
                       </button>
                     </div>
                   )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* User Feedback */}
+        {rawData && rawData.feedback.length > 0 && (
+          <div className="mt-8 bg-white rounded-2xl border border-gray-100 shadow-card p-5">
+            <h3 className="text-sm font-semibold text-gray-900 flex items-center gap-2 mb-4">
+              <MessageSquare className="h-4 w-4 text-[#2d7d7d]" />
+              User Feedback ({rawData.feedback.length})
+            </h3>
+            <div className="space-y-3">
+              {rawData.feedback.map(fb => (
+                <div key={fb.id} className="border border-gray-100 rounded-xl p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      {fb.rating && (
+                        <p className="text-sm mb-1">
+                          {'★'.repeat(fb.rating)}{'☆'.repeat(5 - fb.rating)}
+                        </p>
+                      )}
+                      {fb.comment && (
+                        <p className="text-sm text-gray-700">{fb.comment}</p>
+                      )}
+                      <div className="flex items-center gap-3 mt-2 text-xs text-gray-400">
+                        <span>{new Date(fb.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</span>
+                        <span className="px-1.5 py-0.5 rounded bg-gray-100 text-gray-500">{fb.source}</span>
+                        {fb.credits_granted > 0 && (
+                          <span className="text-emerald-600">+{fb.credits_granted} credits</span>
+                        )}
+                        {fb.profile_viewed && (
+                          <a
+                            href={`?user=${fb.profile_viewed}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-[#2d7d7d] hover:underline"
+                          >
+                            {fb.profile_viewed}
+                          </a>
+                        )}
+                      </div>
+                    </div>
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -1,0 +1,205 @@
+import { useState, useEffect, useRef } from 'react';
+import { X, Loader2 } from 'lucide-react';
+import { supabase } from '../lib/supabase';
+
+interface FeedbackModalProps {
+  mode: 'prompt' | 'button';
+  onClose: () => void;
+  onSuccess: (creditsGranted: number) => void;
+  profileViewed: string | null;
+  isFirstFeedback: boolean;
+}
+
+export function FeedbackModal({ mode, onClose, onSuccess, profileViewed, isFirstFeedback }: FeedbackModalProps) {
+  const [rating, setRating] = useState<number>(0);
+  const [hoverRating, setHoverRating] = useState<number>(0);
+  const [comment, setComment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  const creditsAmount = isFirstFeedback ? 5 : 2;
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === overlayRef.current) onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (mode === 'button' && rating === 0) {
+      setError('Please select a star rating.');
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+
+      if (!session) {
+        setError('You must be signed in to submit feedback.');
+        setSubmitting(false);
+        return;
+      }
+
+      const res = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/submit-feedback`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session.access_token}`,
+          },
+          body: JSON.stringify({
+            rating: mode === 'button' ? rating : null,
+            comment: comment.trim() || null,
+            profileViewed,
+            source: mode,
+          }),
+        }
+      );
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error || 'Submission failed. Please try again.');
+      }
+
+      const data = await res.json();
+      const granted: number = data?.credits_granted ?? creditsAmount;
+
+      setSuccessMessage(`Thanks! You earned ${granted} credits.`);
+      setTimeout(() => {
+        onSuccess(granted);
+      }, 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+      setSubmitting(false);
+    }
+  };
+
+  const headerTitle = mode === 'prompt' ? "How's your experience?" : 'Share Feedback';
+  const buttonLabel = successMessage
+    ? successMessage
+    : submitting
+    ? ''
+    : mode === 'prompt'
+    ? `Share feedback — earn ${creditsAmount} credits`
+    : `Submit — earn ${creditsAmount} credits`;
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="feedback-modal-title"
+      onClick={handleOverlayClick}
+    >
+      <div
+        className="bg-white dark:bg-slate-800 rounded-2xl shadow-2xl max-w-md w-full overflow-hidden"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="relative bg-gradient-to-r from-[#2d7d7d] to-[#1a5c5c] px-6 pt-5 pb-5 text-white">
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-4 text-white/70 hover:text-white transition-colors"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+          <h2 id="feedback-modal-title" className="text-lg font-bold pr-8">{headerTitle}</h2>
+          {mode === 'prompt' && (
+            <p className="text-sm text-white/80 mt-1">
+              Earn {creditsAmount} credits for sharing a quick thought.
+            </p>
+          )}
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5 space-y-4">
+          {/* Star rating — button mode only */}
+          {mode === 'button' && (
+            <div>
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                How would you rate Scholar Folio?
+              </p>
+              <div
+                className="flex gap-1"
+                onMouseLeave={() => setHoverRating(0)}
+                role="radiogroup"
+                aria-label="Star rating"
+              >
+                {[1, 2, 3, 4, 5].map(star => (
+                  <button
+                    key={star}
+                    type="button"
+                    role="radio"
+                    aria-checked={rating === star}
+                    aria-label={`${star} star${star !== 1 ? 's' : ''}`}
+                    onClick={() => setRating(star)}
+                    onMouseEnter={() => setHoverRating(star)}
+                    className="text-3xl leading-none transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#2d7d7d] rounded"
+                    style={{ color: star <= (hoverRating || rating) ? '#f59e0b' : '#d1d5db' }}
+                  >
+                    &#9733;
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Textarea */}
+          <div>
+            <label htmlFor="feedback-comment" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              {mode === 'prompt' ? 'Your feedback' : 'Any additional thoughts? (optional)'}
+            </label>
+            <textarea
+              id="feedback-comment"
+              value={comment}
+              onChange={e => setComment(e.target.value)}
+              placeholder={mode === 'prompt' ? 'What do you think of Scholar Folio so far?' : 'Tell us what you think...'}
+              rows={3}
+              className="w-full px-3 py-2.5 text-sm text-gray-900 dark:text-gray-100 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 focus:border-[#2d7d7d] focus:ring-1 focus:ring-[#2d7d7d] outline-none transition-colors resize-none"
+              maxLength={1000}
+            />
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p className="text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 px-3 py-2 rounded-lg">
+              {error}
+            </p>
+          )}
+
+          {/* Submit */}
+          <button
+            onClick={handleSubmit}
+            disabled={submitting || !!successMessage}
+            className="w-full py-2.5 text-sm font-semibold rounded-lg bg-[#2d7d7d] text-white hover:bg-[#1f5c5c] shadow-md shadow-[#2d7d7d]/20 hover:shadow-lg hover:shadow-[#2d7d7d]/30 transition-all disabled:opacity-70 disabled:cursor-not-allowed"
+          >
+            {submitting ? (
+              <span className="inline-flex items-center justify-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Submitting...
+              </span>
+            ) : successMessage ? (
+              successMessage
+            ) : (
+              buttonLabel
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/FeedbackPromptBanner.tsx
+++ b/src/components/FeedbackPromptBanner.tsx
@@ -1,0 +1,33 @@
+import { X } from 'lucide-react';
+
+interface FeedbackPromptBannerProps {
+  onOpenFeedback: () => void;
+  onDismiss: () => void;
+  creditsAmount: number;
+}
+
+export function FeedbackPromptBanner({ onOpenFeedback, onDismiss, creditsAmount }: FeedbackPromptBannerProps) {
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 animate-fade-up">
+      <div className="relative bg-white dark:bg-slate-800 border border-[#2d7d7d]/20 shadow-lg rounded-xl px-5 py-3 max-w-sm w-[calc(100vw-2rem)]">
+        <button
+          onClick={onDismiss}
+          className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+          aria-label="Dismiss"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <p className="text-sm font-medium text-gray-900 dark:text-gray-100 pr-5">
+          Enjoying Scholar Folio?
+        </p>
+        <button
+          onClick={onOpenFeedback}
+          className="text-sm text-[#2d7d7d] dark:text-[#5bbdbd] hover:underline font-medium mt-0.5"
+        >
+          Share quick feedback &rarr; earn {creditsAmount} credits
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock, ExternalLink, Heart, BadgeCheck, Link, Globe, FileText } from 'lucide-react';
+import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock, ExternalLink, Heart, BadgeCheck, Link, Globe, FileText, MessageSquare } from 'lucide-react';
 import { NarrativeCvTab } from './NarrativeCvTab';
 import { EmbedModal } from './EmbedModal';
 import { ClaimProfileModal } from './ClaimProfileModal';
@@ -21,6 +21,9 @@ import type { Author, CoAuthorGeoData } from '../types/scholar';
 import type { PIndexResult } from '../services/openalex/pindex';
 import { fetchCoAuthorGeoData } from '../services/openalex/coauthor-geo';
 import { extractLastName } from '../utils/names';
+import { useFeedback } from '../hooks/useFeedback';
+import { FeedbackModal } from './FeedbackModal';
+import { FeedbackPromptBanner } from './FeedbackPromptBanner';
 import packageJson from '../../package.json';
 
 interface ProfileViewProps {
@@ -58,7 +61,8 @@ export function ProfileView({
   authControls,
   onSupport
 }: ProfileViewProps) {
-  const { user } = useAuth();
+  const { user, refreshCredits } = useAuth();
+  const feedback = useFeedback(user?.id ?? null);
   const [activeTab, setActiveTab] = useState<TabId>('metrics');
   const [imgError, setImgError] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -130,6 +134,11 @@ export function ProfileView({
     };
     checkClaim();
   }, [scholarId, user?.id]);
+
+  // Track profile views for feedback prompt
+  useEffect(() => {
+    if (scholarId) feedback.trackProfileView(scholarId);
+  }, [scholarId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Update document title and OG meta tags for link previews
   useEffect(() => {
@@ -547,6 +556,41 @@ export function ProfileView({
           authorId={scholarId}
           authorName={data.name}
           onClaimed={handleClaimed}
+        />
+      )}
+
+      {/* Feedback prompt banner */}
+      {feedback.showPromptBanner && user && (
+        <FeedbackPromptBanner
+          onOpenFeedback={() => feedback.openModal('prompt')}
+          onDismiss={feedback.dismissBanner}
+          creditsAmount={feedback.hasSubmittedBefore ? 2 : 5}
+        />
+      )}
+
+      {/* Floating feedback button */}
+      {user && !feedback.showPromptBanner && (
+        <button
+          onClick={() => feedback.openModal('button')}
+          className="fixed bottom-6 right-6 z-40 flex items-center gap-2 px-3 py-2 text-xs font-medium text-white bg-[#2d7d7d] hover:bg-[#1f5c5c] rounded-full shadow-lg transition-colors"
+          aria-label="Share feedback"
+        >
+          <MessageSquare className="h-3.5 w-3.5" />
+          Feedback
+        </button>
+      )}
+
+      {/* Feedback modal */}
+      {feedback.showModal && (
+        <FeedbackModal
+          mode={feedback.modalMode}
+          onClose={feedback.closeModal}
+          onSuccess={(credits) => {
+            feedback.onSubmitSuccess(credits);
+            refreshCredits();
+          }}
+          profileViewed={scholarId}
+          isFirstFeedback={!feedback.hasSubmittedBefore}
         />
       )}
     </div>

--- a/src/hooks/useFeedback.ts
+++ b/src/hooks/useFeedback.ts
@@ -1,0 +1,81 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabase';
+
+const SESSION_KEY_VIEWS = 'sf_profile_views';
+const SESSION_KEY_DISMISSED = 'sf_feedback_dismissed';
+
+export function useFeedback(userId: string | null) {
+  const [hasSubmittedBefore, setHasSubmittedBefore] = useState<boolean | null>(null);
+  const [showPromptBanner, setShowPromptBanner] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [modalMode, setModalMode] = useState<'prompt' | 'button'>('button');
+
+  // On mount: check if this user has already submitted feedback
+  useEffect(() => {
+    if (!userId) {
+      setHasSubmittedBefore(null);
+      return;
+    }
+
+    supabase
+      .from('feedback')
+      .select('id')
+      .eq('user_id', userId)
+      .limit(1)
+      .then(({ data }) => {
+        setHasSubmittedBefore(data !== null && data.length > 0);
+      });
+  }, [userId]);
+
+  // Track a profile view by scholar ID, show banner after 2+ unique views
+  const trackProfileView = useCallback((scholarId: string) => {
+    if (!userId || !scholarId) return;
+    if (hasSubmittedBefore) return;
+    if (sessionStorage.getItem(SESSION_KEY_DISMISSED)) return;
+
+    const raw = sessionStorage.getItem(SESSION_KEY_VIEWS);
+    const viewed: string[] = raw ? JSON.parse(raw) : [];
+
+    if (!viewed.includes(scholarId)) {
+      const updated = [...viewed, scholarId];
+      sessionStorage.setItem(SESSION_KEY_VIEWS, JSON.stringify(updated));
+
+      if (updated.length >= 2) {
+        setShowPromptBanner(true);
+      }
+    }
+  }, [userId, hasSubmittedBefore]);
+
+  const dismissBanner = useCallback(() => {
+    setShowPromptBanner(false);
+    sessionStorage.setItem(SESSION_KEY_DISMISSED, '1');
+  }, []);
+
+  const openModal = useCallback((mode: 'prompt' | 'button') => {
+    setModalMode(mode);
+    setShowModal(true);
+    setShowPromptBanner(false);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    setShowModal(false);
+  }, []);
+
+  const onSubmitSuccess = useCallback((_credits: number) => {
+    setHasSubmittedBefore(true);
+    setShowPromptBanner(false);
+    setShowModal(false);
+  }, []);
+
+  return {
+    hasSubmittedBefore,
+    showPromptBanner,
+    showModal,
+    modalMode,
+    trackProfileView,
+    dismissBanner,
+    openModal,
+    closeModal,
+    onSubmitSuccess,
+  };
+}

--- a/supabase/functions/submit-feedback/index.ts
+++ b/supabase/functions/submit-feedback/index.ts
@@ -1,0 +1,157 @@
+import { createClient } from "npm:@supabase/supabase-js@2.39.3";
+
+const ALLOWED_ORIGINS = [
+  'https://scholarfolio.org',
+  'https://www.scholarfolio.org',
+  'https://scholarfolio.netlify.app',
+  'http://localhost:5173',
+];
+
+function getCorsHeaders(req: Request) {
+  const origin = req.headers.get('Origin') || '';
+  const allowedOrigin = ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0];
+  return {
+    "Access-Control-Allow-Origin": allowedOrigin,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  };
+}
+
+const supabase = createClient(
+  Deno.env.get('SUPABASE_URL') ?? '',
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+);
+
+const FEEDBACK_CREDIT_CAP = 20;
+const FIRST_SUBMISSION_CREDITS = 5;
+const SUBSEQUENT_CREDITS = 2;
+
+Deno.serve(async (req) => {
+  const corsHeaders = getCorsHeaders(req);
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    // Authenticate user
+    const authHeader = req.headers.get('Authorization') || '';
+    const jwt = authHeader.replace('Bearer ', '');
+    const { data: { user }, error: authError } = await supabase.auth.getUser(jwt);
+
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Authentication required' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const userId = user.id;
+    const body = await req.json();
+    const { rating, comment, profileViewed, source } = body;
+
+    // Validate source
+    if (source !== 'prompt' && source !== 'button') {
+      return new Response(
+        JSON.stringify({ error: 'Invalid source. Must be "prompt" or "button".' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Validate rating
+    if (rating !== undefined && rating !== null) {
+      if (!Number.isInteger(rating) || rating < 1 || rating > 5) {
+        return new Response(
+          JSON.stringify({ error: 'Rating must be an integer between 1 and 5.' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+    }
+
+    // Validate comment
+    if (comment !== undefined && comment !== null) {
+      if (typeof comment !== 'string' || comment.length > 2000) {
+        return new Response(
+          JSON.stringify({ error: 'Comment must be a string of at most 2000 characters.' }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+    }
+
+    // Query total credits already granted to this user from feedback
+    const { data: sumData, error: sumError } = await supabase
+      .from('feedback')
+      .select('credits_granted')
+      .eq('user_id', userId);
+
+    if (sumError) {
+      console.error('Error querying feedback credits:', sumError);
+      return new Response(
+        JSON.stringify({ error: 'Failed to process feedback' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const totalCreditsGranted = (sumData ?? []).reduce(
+      (sum: number, row: { credits_granted: number }) => sum + (row.credits_granted ?? 0),
+      0
+    );
+
+    const isFirstSubmission = (sumData ?? []).length === 0;
+
+    // Calculate credits to grant
+    let creditsToGrant: number;
+    if (totalCreditsGranted >= FEEDBACK_CREDIT_CAP) {
+      creditsToGrant = 0;
+    } else {
+      const earned = isFirstSubmission ? FIRST_SUBMISSION_CREDITS : SUBSEQUENT_CREDITS;
+      creditsToGrant = Math.min(earned, FEEDBACK_CREDIT_CAP - totalCreditsGranted);
+    }
+
+    // Insert feedback record
+    const { error: insertError } = await supabase.from('feedback').insert({
+      user_id: userId,
+      rating: rating ?? null,
+      comment: comment ?? null,
+      credits_granted: creditsToGrant,
+      profile_viewed: profileViewed ?? null,
+      source,
+    });
+
+    if (insertError) {
+      console.error('Error inserting feedback:', insertError);
+      return new Response(
+        JSON.stringify({ error: 'Failed to save feedback' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Grant credits if applicable
+    if (creditsToGrant > 0) {
+      const { error: rpcError } = await supabase.rpc('increment_credits', {
+        p_user_id: userId,
+        p_amount: creditsToGrant,
+      });
+
+      if (rpcError) {
+        console.error('Error granting credits:', rpcError);
+        // Feedback is already saved — log the error but don't fail the response
+      }
+    }
+
+    const message = creditsToGrant > 0
+      ? `Thank you for your feedback! You've earned ${creditsToGrant} credit${creditsToGrant !== 1 ? 's' : ''}.`
+      : 'Thank you for your feedback!';
+
+    return new Response(
+      JSON.stringify({ credits_granted: creditsToGrant, message }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('Submit feedback error:', error);
+    return new Response(
+      JSON.stringify({ error: 'Failed to submit feedback' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- **Floating feedback button** on profile view for signed-in users
- **Prompt banner** appears after 2nd unique profile view: "Share feedback → earn 5 credits"
- **Feedback modal**: star rating + comment (button mode), or text-only (prompt mode)
- **Edge function** (`submit-feedback`): validates input, saves to `feedback` table, grants credits (5 first, 2 subsequent, 20 cap)
- **Admin dashboard**: read-only feedback section showing ratings, comments, credits granted

## Credit logic
| Submission | Credits |
|---|---|
| First ever | 5 |
| Subsequent | 2 |
| After 20 total | 0 (feedback still saved) |

## Test plan
- [ ] Load 2+ profiles while signed in → banner appears
- [ ] Click banner → prompt modal opens, submit → credits granted
- [ ] Click floating button → star rating modal, submit → credits granted
- [ ] Check admin dashboard → feedback entries visible
- [ ] Unauthenticated submit → 401