### PR TITLE
fix: gate AdminDashboard on isAdmin before mounting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { SignUpWall } from './components/SignUpWall';
 import { ProfileSkeleton } from './components/ProfileSkeleton';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { supabase } from './lib/supabase';
+import { ADMIN_EMAIL } from './lib/constants';
 import type { Author } from './types/scholar';
 import { scholarService } from './services/scholar';
 import { openAlexService } from './services/openalex';
@@ -140,6 +141,7 @@ function AppContent() {
   const requestInProgressRef = useRef(false);
   const handleSearchRef = useRef<((url: string, bypassCredits?: boolean, cacheOnly?: boolean) => void) | null>(null);
   const { user, credits, refreshCredits, showWelcome, dismissWelcome } = useAuth();
+  const isAdmin = user?.email === ADMIN_EMAIL;
 
   // Handle shareable profile URL (?user=AUTHOR_ID) or vanity slug path (e.g. /jonas-heller)
   const [initialUrlHandled, setInitialUrlHandled] = useState(false);
@@ -331,7 +333,10 @@ function AppContent() {
   );
 
   const renderPage = () => {
-    if (page === 'admin') return <div className="page-enter"><AdminDashboard onBack={() => handleNavigate('home')} /></div>;
+    if (page === 'admin') {
+      if (!isAdmin) { handleNavigate('home'); return null; }
+      return <div className="page-enter"><AdminDashboard onBack={() => handleNavigate('home')} /></div>;
+    }
     if (page === 'about') return <div className="page-enter"><AboutPage onBack={() => handleNavigate('home')} /></div>;
     if (page === 'terms') return <div className="page-enter"><TermsPage onBack={() => handleNavigate('home')} /></div>;
     if (page === 'privacy') return <div className="page-enter"><PrivacyPage onBack={() => handleNavigate('home')} /></div>;

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -3,8 +3,7 @@ import { ArrowLeft, BarChart3, Users, CreditCard, Search, TrendingUp, UserPlus, 
 import { Logo } from './Logo';
 import { useAuth } from '../contexts/AuthContext';
 import { supabase } from '../lib/supabase';
-
-const ADMIN_EMAIL = 'jonasheller89@gmail.com';
+import { ADMIN_EMAIL } from '../lib/constants';
 
 type Period = 'day' | 'week' | 'month' | 'all';
 type ChartPeriod = 'week' | 'month' | 'all';

--- a/src/components/AuthHeaderControls.tsx
+++ b/src/components/AuthHeaderControls.tsx
@@ -4,8 +4,7 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { AuthButton } from './AuthButton';
 import { useAuth } from '../contexts/AuthContext';
 import { supabase } from '../lib/supabase';
-
-const ADMIN_EMAIL = 'jonasheller89@gmail.com';
+import { ADMIN_EMAIL } from '../lib/constants';
 
 interface AuthHeaderControlsProps {
   onBuyCredits: () => void;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const ADMIN_EMAIL = 'jonasheller89@gmail.com';


### PR DESCRIPTION
## Summary
- Any visitor navigating to `?page=admin` previously caused `AdminDashboard` to mount and fire multiple Supabase queries regardless of auth state
- `App.tsx` now checks `user?.email === ADMIN_EMAIL` before rendering the component; non-admins are immediately redirected to home and the component never mounts
- `ADMIN_EMAIL` extracted to `src/lib/constants.ts` — removes the duplicate hard-coded string that existed in both `AdminDashboard.tsx` and `AuthHeaderControls.tsx`

## Test plan
- [ ] Visit `/?page=admin` while signed out — should redirect to home, no Supabase queries fired
- [ ] Visit `/?page=admin` while signed in as a non-admin — should redirect to home
- [ ] Visit `/?page=admin` as `jonasheller89@gmail.com` — AdminDashboard loads normally