### PR TITLE
Add CSP and harden security headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,7 +1,8 @@
 /*
-  X-Frame-Options: SAMEORIGIN
+  X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   X-Robots-Tag: noai, noimageai
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.openalex.org https://pub.orcid.org https://api.crossref.org https://api.semanticscholar.org https://icite.od.nih.gov; font-src 'self'


### PR DESCRIPTION
## Summary
- Updates `public/_headers` with a full Content-Security-Policy
- Changes X-Frame-Options from SAMEORIGIN to DENY
- Normalises HSTS max-age to 31536000 (removes preload for now)
- CSP `connect-src` scoped to Supabase, OpenAlex, ORCID, Crossref, Semantic Scholar, iCite

## Test plan
- [x] `npm run build` passes