### PR TITLE
Move admin email to env var

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,1 +1,1 @@
-export const ADMIN_EMAIL = 'jonasheller89@gmail.com';
+export const ADMIN_EMAIL = import.meta.env.VITE_ADMIN_EMAIL || '';


### PR DESCRIPTION
## Summary
- Move ADMIN_EMAIL from hardcoded constant to VITE_ADMIN_EMAIL env var
- Removes PII from compiled JS bundle

## Manual steps after merge
- Set VITE_ADMIN_EMAIL=jonasheller89@gmail.com in Netlify env vars

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>