### PR TITLE
P-index review tabs, feedback copy, and monthly free credit

### DIFF
--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -86,7 +86,7 @@ export function FeedbackModal({ mode, onClose, onSuccess, profileViewed, isFirst
     }
   };
 
-  const headerTitle = mode === 'prompt' ? "How's your experience?" : 'Share Feedback';
+  const headerTitle = mode === 'prompt' ? 'Help us improve' : 'Share Feedback';
   const buttonLabel = successMessage
     ? successMessage
     : submitting
@@ -120,7 +120,7 @@ export function FeedbackModal({ mode, onClose, onSuccess, profileViewed, isFirst
           <h2 id="feedback-modal-title" className="text-lg font-bold pr-8">{headerTitle}</h2>
           {mode === 'prompt' && (
             <p className="text-sm text-white/80 mt-1">
-              Earn {creditsAmount} credits for sharing a quick thought.
+              Report a bug or request a feature — earn {creditsAmount} credits.
             </p>
           )}
         </div>
@@ -161,13 +161,13 @@ export function FeedbackModal({ mode, onClose, onSuccess, profileViewed, isFirst
           {/* Textarea */}
           <div>
             <label htmlFor="feedback-comment" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              {mode === 'prompt' ? 'Your feedback' : 'Any additional thoughts? (optional)'}
+              {mode === 'prompt' ? 'What can we improve?' : 'What can we improve? (optional)'}
             </label>
             <textarea
               id="feedback-comment"
               value={comment}
               onChange={e => setComment(e.target.value)}
-              placeholder={mode === 'prompt' ? 'What do you think of Scholar Folio so far?' : 'Tell us what you think...'}
+              placeholder="Found a bug? Missing a feature? Let us know what's broken or what you'd like to see."
               rows={3}
               className="w-full px-3 py-2.5 text-sm text-gray-900 dark:text-gray-100 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 focus:border-[#2d7d7d] focus:ring-1 focus:ring-[#2d7d7d] outline-none transition-colors resize-none"
               maxLength={1000}

--- a/src/components/PIndexSection.tsx
+++ b/src/components/PIndexSection.tsx
@@ -44,6 +44,7 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
   const [errorMsg, setErrorMsg] = useState('');
   const [showDetails, setShowDetails] = useState(false);
   const [matchStatuses, setMatchStatuses] = useState<Map<string, MatchStatus>>(new Map());
+  const [reviewTab, setReviewTab] = useState<'review' | 'confirmed'>('review');
 
   const [firstName, setFirstName] = useState(() => {
     const parts = authorName.trim().split(/\s+/);
@@ -98,6 +99,24 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
       return b.year - a.year || b.citations - a.citations;
     });
   }, [allWorks, matchStatuses]);
+
+  const filteredWorks = useMemo(() => {
+    if (matchStatuses.size === 0) return sortedWorks;
+    if (reviewTab === 'confirmed') {
+      return sortedWorks.filter(w => matchStatuses.get(w.id) === 'confirmed');
+    }
+    return sortedWorks.filter(w => matchStatuses.get(w.id) !== 'confirmed');
+  }, [sortedWorks, matchStatuses, reviewTab]);
+
+  const reviewTabCounts = useMemo(() => {
+    if (matchStatuses.size === 0) return null;
+    let needsReview = 0, confirmed = 0;
+    for (const status of matchStatuses.values()) {
+      if (status === 'confirmed') confirmed++;
+      else needsReview++;
+    }
+    return { needsReview, confirmed };
+  }, [matchStatuses]);
 
   const handleSearch = useCallback(async () => {
     if (!firstName.trim() || !lastName.trim()) return;
@@ -231,6 +250,7 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
     setAllWorks([]);
     setExcludedIds(new Set());
     setMatchStatuses(new Map());
+    setReviewTab('review');
     setErrorMsg('');
     setProgress({ pct: 0, status: '' });
     oaRateLimiter.clear();
@@ -383,13 +403,40 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
             </div>
           </div>
 
-          {matchStatuses.size > 0 ? (
-            <div className="flex items-start gap-2 bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800 rounded-lg px-3 py-2 mb-3">
-              <CheckCircle className="h-3.5 w-3.5 text-green-500 mt-0.5 flex-shrink-0" />
-              <p className="text-[11px] text-green-700 dark:text-green-300">
-                Items needing your review appear first. Confirmed matches (green) are at the bottom. Unmatched items are unchecked — review and include any that are yours.
-              </p>
-            </div>
+          {matchStatuses.size > 0 && reviewTabCounts ? (
+            <>
+              <div className="flex gap-1 mb-3 border-b border-gray-200 dark:border-slate-700">
+                <button
+                  onClick={() => setReviewTab('review')}
+                  className={`px-3 py-1.5 text-[11px] font-medium border-b-2 transition-colors ${
+                    reviewTab === 'review'
+                      ? 'border-violet-500 text-violet-700 dark:text-violet-300'
+                      : 'border-transparent text-gray-400 hover:text-gray-600 dark:hover:text-gray-300'
+                  }`}
+                >
+                  Needs Review ({reviewTabCounts.needsReview})
+                </button>
+                <button
+                  onClick={() => setReviewTab('confirmed')}
+                  className={`px-3 py-1.5 text-[11px] font-medium border-b-2 transition-colors ${
+                    reviewTab === 'confirmed'
+                      ? 'border-green-500 text-green-700 dark:text-green-300'
+                      : 'border-transparent text-gray-400 hover:text-gray-600 dark:hover:text-gray-300'
+                  }`}
+                >
+                  Confirmed ({reviewTabCounts.confirmed})
+                </button>
+              </div>
+              {reviewTab === 'review' ? (
+                <p className="text-[11px] text-amber-600 dark:text-amber-400 mb-2">
+                  Check any publications below that are yours. Unchecked items will be excluded from the p-index.
+                </p>
+              ) : (
+                <p className="text-[11px] text-green-600 dark:text-green-400 mb-2">
+                  These publications matched your Google Scholar profile and are included automatically.
+                </p>
+              )}
+            </>
           ) : (
             <div className="flex items-start gap-2 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg px-3 py-2 mb-3">
               <AlertTriangle className="h-3.5 w-3.5 text-amber-500 mt-0.5 flex-shrink-0" />
@@ -402,7 +449,7 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
           )}
 
           <div className="max-h-72 overflow-y-auto border border-gray-100 dark:border-slate-700 rounded-lg divide-y divide-gray-50 dark:divide-slate-700/50">
-            {sortedWorks.map(work => {
+            {filteredWorks.map(work => {
               const excluded = excludedIds.has(work.id);
               const matchStatus = matchStatuses.get(work.id);
               return (

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -27,6 +27,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const dismissWelcome = () => setShowWelcome(false);
 
   const fetchCredits = async (userId: string) => {
+    // Try to claim a free monthly credit if eligible (0 credits, >30 days since last grant)
+    await supabase.rpc('claim_monthly_credit', { p_user_id: userId }).catch(() => {});
+
     const { data, error } = await supabase
       .from('user_credits')
       .select('credits_remaining')


### PR DESCRIPTION
## Summary
- Split p-index publication review into two tabs: "Needs Review" (possible + unmatched) and "Confirmed" — reduces scrolling for users with long publication lists
- Update feedback modal to specifically ask for bug reports and feature requests
- Add monthly free credit system: users at 0 credits receive 1 free credit every 30 days on login via `claim_monthly_credit` RPC

## Test plan
- [ ] P-index: verify tabs show correct counts and filter correctly
- [ ] Feedback modal: verify updated copy appears for both prompt and button modes
- [ ] Monthly credit: set a test user to 0 credits, verify they get 1 credit on next login

🤖 Generated with [Claude Code](https://claude.com/claude-code)