### PR TITLE
Add forgot password flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { AuthButton } from './components/AuthButton';
 import { CreditPacks } from './components/CreditPacks';
 import { SignUpWall } from './components/SignUpWall';
 import { ProfileSkeleton } from './components/ProfileSkeleton';
+import { PasswordResetModal } from './components/PasswordResetModal';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { supabase } from './lib/supabase';
 import { ADMIN_EMAIL } from './lib/constants';
@@ -140,7 +141,7 @@ function AppContent() {
   const [page, setPage] = useState<Page>('home');
   const requestInProgressRef = useRef(false);
   const handleSearchRef = useRef<((url: string, bypassCredits?: boolean, cacheOnly?: boolean) => void) | null>(null);
-  const { user, credits, refreshCredits, showWelcome, dismissWelcome } = useAuth();
+  const { user, credits, refreshCredits, showWelcome, dismissWelcome, showPasswordReset, dismissPasswordReset, updatePassword } = useAuth();
   const isAdmin = user?.email === ADMIN_EMAIL;
 
   // Handle shareable profile URL (?user=AUTHOR_ID) or vanity slug path (e.g. /jonas-heller)
@@ -382,6 +383,7 @@ function AppContent() {
           </button>
         </div>
       )}
+      {showPasswordReset && <PasswordResetModal onSubmit={updatePassword} onClose={dismissPasswordReset} />}
       <div className="flex-1">
         {renderPage()}
       </div>

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { LogIn, User, X, Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { supabase } from '../lib/supabase';
 
 export function AuthButton() {
   const { user, loading, signIn, signUp, signInWithGoogle } = useAuth();
@@ -14,6 +15,8 @@ export function AuthButton() {
   const [showPassword, setShowPassword] = useState(false);
   const [confirmSent, setConfirmSent] = useState(false);
   const [agreedToTerms, setAgreedToTerms] = useState(false);
+  const [resetSent, setResetSent] = useState(false);
+  const [sendingReset, setSendingReset] = useState(false);
 
   if (loading) return null;
 
@@ -55,6 +58,7 @@ export function AuthButton() {
     setPassword('');
     setError(null);
     setConfirmSent(false);
+    setResetSent(false);
     setShowPassword(false);
     setAgreedToTerms(false);
   };
@@ -199,6 +203,41 @@ export function AuthButton() {
                     </button>
                   </div>
                 </div>
+
+                {!isSignUp && !resetSent && (
+                  <div className="text-right -mt-2">
+                    <button
+                      type="button"
+                      disabled={sendingReset}
+                      onClick={async () => {
+                        if (!email.trim()) {
+                          setError('Enter your email address first.');
+                          return;
+                        }
+                        setSendingReset(true);
+                        setError(null);
+                        const { error } = await supabase.auth.resetPasswordForEmail(email, {
+                          redirectTo: window.location.origin,
+                        });
+                        setSendingReset(false);
+                        if (error) {
+                          setError(error.message);
+                        } else {
+                          setResetSent(true);
+                        }
+                      }}
+                      className="text-[10px] text-[#2d7d7d] hover:underline font-medium"
+                    >
+                      {sendingReset ? 'Sending...' : 'Forgot password?'}
+                    </button>
+                  </div>
+                )}
+
+                {resetSent && (
+                  <p className="text-xs text-green-700 bg-green-50 px-3 py-2 rounded-lg">
+                    Password reset link sent to <strong>{email}</strong>. Check your inbox.
+                  </p>
+                )}
 
                 {error && (
                   <p className="text-xs text-red-600 bg-red-50 px-3 py-2 rounded-lg">{error}</p>

--- a/src/components/PasswordResetModal.tsx
+++ b/src/components/PasswordResetModal.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { X, Eye, EyeOff } from 'lucide-react';
+
+interface PasswordResetModalProps {
+  onSubmit: (password: string) => Promise<{ error: string | null }>;
+  onClose: () => void;
+}
+
+export function PasswordResetModal({ onSubmit, onClose }: PasswordResetModalProps) {
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    const { error } = await onSubmit(password);
+    setSubmitting(false);
+    if (error) {
+      setError(error);
+    } else {
+      setSuccess(true);
+      setTimeout(onClose, 2000);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={onClose}>
+      <div className="bg-white rounded-xl shadow-xl max-w-sm w-full p-6" onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-gray-900">Set new password</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {success ? (
+          <p className="text-sm text-green-700 bg-green-50 px-3 py-3 rounded-lg">
+            Password updated successfully!
+          </p>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">New password</label>
+              <div className="relative">
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={e => setPassword(e.target.value)}
+                  required
+                  minLength={6}
+                  autoFocus
+                  className="w-full px-3 py-2 pr-10 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#2d7d7d]/20 focus:border-[#2d7d7d]"
+                  placeholder="Min 6 characters"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-2.5 text-gray-400 hover:text-gray-600"
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+            </div>
+
+            {error && (
+              <p className="text-xs text-red-600 bg-red-50 px-3 py-2 rounded-lg">{error}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full py-2 text-sm font-medium text-white bg-[#2d7d7d] rounded-lg hover:bg-[#1f5c5c] disabled:opacity-50 transition-colors"
+            >
+              {submitting ? 'Updating...' : 'Update password'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,7 +8,10 @@ interface AuthState {
   credits: number | null;
   loading: boolean;
   showWelcome: boolean;
+  showPasswordReset: boolean;
   dismissWelcome: () => void;
+  dismissPasswordReset: () => void;
+  updatePassword: (newPassword: string) => Promise<{ error: string | null }>;
   signIn: (email: string, password: string) => Promise<{ error: string | null }>;
   signUp: (email: string, password: string) => Promise<{ error: string | null }>;
   signInWithGoogle: () => Promise<{ error: string | null }>;
@@ -24,7 +27,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [credits, setCredits] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [showWelcome, setShowWelcome] = useState(false);
+  const [showPasswordReset, setShowPasswordReset] = useState(false);
   const dismissWelcome = () => setShowWelcome(false);
+  const dismissPasswordReset = () => setShowPasswordReset(false);
+
+  const updatePassword = async (newPassword: string) => {
+    const { error } = await supabase.auth.updateUser({ password: newPassword });
+    if (error) return { error: error.message };
+    setShowPasswordReset(false);
+    return { error: null };
+  };
 
   const fetchCredits = async (userId: string) => {
     // Try to claim a free monthly credit if eligible (0 credits, >30 days since last grant)
@@ -63,6 +75,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setUser(session?.user ?? null);
         if (session?.user) {
           fetchCredits(session.user.id);
+          // Show password reset modal when user clicks recovery link
+          if (event === 'PASSWORD_RECOVERY') {
+            setShowPasswordReset(true);
+          }
           // Detect new Google sign-up (user just created, signed in via OAuth)
           if (event === 'SIGNED_IN') {
             const createdAt = new Date(session.user.created_at).getTime();
@@ -114,7 +130,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, session, credits, loading, showWelcome, dismissWelcome, signIn, signUp, signInWithGoogle, signOut, refreshCredits }}>
+    <AuthContext.Provider value={{ user, session, credits, loading, showWelcome, showPasswordReset, dismissWelcome, dismissPasswordReset, updatePassword, signIn, signUp, signInWithGoogle, signOut, refreshCredits }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- Add "Forgot password?" link to sign-in form
- Sends password reset email via Supabase `resetPasswordForEmail`
- Listens for `PASSWORD_RECOVERY` auth event and shows "Set new password" modal
- Full flow: enter email -> click link in email -> set new password on site

## Test plan
- [ ] Sign in form shows "Forgot password?" link
- [ ] Clicking it with an email sends reset email and shows confirmation
- [ ] Clicking reset link in email opens the site with password update modal
- [ ] Setting new password works and modal closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)