### PR TITLE
Fix credits not displaying for some users

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -39,8 +39,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   const fetchCredits = async (userId: string) => {
-    // Try to claim a free monthly credit if eligible (0 credits, >30 days since last grant)
-    await supabase.rpc('claim_monthly_credit', { p_user_id: userId }).catch(() => {});
+    // Fire-and-forget: try to claim a free monthly credit (don't block credit fetch)
+    supabase.rpc('claim_monthly_credit', { p_user_id: userId }).catch(() => {});
 
     const { data, error } = await supabase
       .from('user_credits')
@@ -50,6 +50,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     if (!error && data) {
       setCredits(data.credits_remaining);
+    } else {
+      setCredits(0);
     }
   };
 


### PR DESCRIPTION
## Summary
- Made `claim_monthly_credit` RPC fire-and-forget (removed `await`) so it can't block credit fetching
- Added fallback to show 0 credits when query returns no data or errors

## Test plan
- [ ] Log in with j.heller@maastrichtuniversity.nl and verify credits show
- [ ] Verify credits badge appears next to user avatar
- [ ] Verify "X credits remaining" shows in dropdown