### PR TITLE
Make credits more visible and add auth to About page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -338,7 +338,7 @@ function AppContent() {
       if (!isAdmin) { handleNavigate('home'); return null; }
       return <div className="page-enter"><AdminDashboard onBack={() => handleNavigate('home')} /></div>;
     }
-    if (page === 'about') return <div className="page-enter"><AboutPage onBack={() => handleNavigate('home')} /></div>;
+    if (page === 'about') return <div className="page-enter"><AboutPage onBack={() => handleNavigate('home')} headerControls={authControls} /></div>;
     if (page === 'terms') return <div className="page-enter"><TermsPage onBack={() => handleNavigate('home')} /></div>;
     if (page === 'privacy') return <div className="page-enter"><PrivacyPage onBack={() => handleNavigate('home')} /></div>;
     if (page === 'changelog') return <div className="page-enter"><ChangelogPage onBack={() => handleNavigate('home')} /></div>;

--- a/src/components/AboutPage.tsx
+++ b/src/components/AboutPage.tsx
@@ -4,9 +4,10 @@ import { Logo } from './Logo';
 
 interface AboutPageProps {
   onBack: () => void;
+  headerControls?: React.ReactNode;
 }
 
-export function AboutPage({ onBack }: AboutPageProps) {
+export function AboutPage({ onBack, headerControls }: AboutPageProps) {
   return (
     <main className="flex-1 mesh-bg min-h-screen">
       <nav className="border-b border-gray-200/60 bg-white/60 backdrop-blur-lg sticky top-0 z-10">
@@ -16,6 +17,9 @@ export function AboutPage({ onBack }: AboutPageProps) {
           </button>
           <Logo size={28} />
           <span className="font-semibold text-gray-900 text-sm tracking-tight ml-3">Scholar Folio</span>
+          <div className="ml-auto flex items-center gap-2">
+            {headerControls}
+          </div>
         </div>
       </nav>
 

--- a/src/components/AuthHeaderControls.tsx
+++ b/src/components/AuthHeaderControls.tsx
@@ -102,17 +102,17 @@ export function AuthHeaderControls({ onBuyCredits, onAdmin, anonSearchesUsed = 0
       {credits !== null && (
         <button
           onClick={onBuyCredits}
-          className={`flex items-center gap-1 px-2 py-1 text-[10px] rounded-md transition-colors whitespace-nowrap ${
+          className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-colors whitespace-nowrap ${
             credits <= 2 && credits > 0
               ? 'text-amber-700 bg-amber-50 border border-amber-200 hover:bg-amber-100'
               : credits <= 0
                 ? 'text-red-700 bg-red-50 border border-red-200 hover:bg-red-100'
-                : 'text-gray-600 bg-gray-50 border border-gray-200 hover:bg-gray-100'
+                : 'text-[#2d7d7d] bg-[#eaf4f4] border border-[#2d7d7d]/20 hover:bg-[#d5ebeb]'
           }`}
           title="Buy more searches"
         >
-          <Coins className="h-3 w-3" />
-          {credits} credits
+          <Coins className="h-3.5 w-3.5" />
+          {credits} credit{credits !== 1 ? 's' : ''}
         </button>
       )}
 


### PR DESCRIPTION
## Summary
- Credits badge is now larger with brand teal colors instead of tiny gray text
- Auth controls (credits badge + user dropdown) now appear on the About page header
- Credits text properly pluralizes ("1 credit" vs "10 credits")

## Test plan
- [ ] Verify credits badge is prominently visible in header when logged in
- [ ] Verify About page shows auth controls in the top-right
- [ ] Verify color states: teal (normal), amber (low), red (zero)