### PR TITLE
Fix delete modal, full header on About page, debug credits

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -338,7 +338,7 @@ function AppContent() {
       if (!isAdmin) { handleNavigate('home'); return null; }
       return <div className="page-enter"><AdminDashboard onBack={() => handleNavigate('home')} /></div>;
     }
-    if (page === 'about') return <div className="page-enter"><AboutPage onBack={() => handleNavigate('home')} headerControls={authControls} /></div>;
+    if (page === 'about') return <div className="page-enter"><AboutPage onBack={() => handleNavigate('home')} socialLinks={<SocialLinks />} authControls={authControls} /></div>;
     if (page === 'terms') return <div className="page-enter"><TermsPage onBack={() => handleNavigate('home')} /></div>;
     if (page === 'privacy') return <div className="page-enter"><PrivacyPage onBack={() => handleNavigate('home')} /></div>;
     if (page === 'changelog') return <div className="page-enter"><ChangelogPage onBack={() => handleNavigate('home')} /></div>;

--- a/src/components/AboutPage.tsx
+++ b/src/components/AboutPage.tsx
@@ -4,21 +4,23 @@ import { Logo } from './Logo';
 
 interface AboutPageProps {
   onBack: () => void;
-  headerControls?: React.ReactNode;
+  socialLinks?: React.ReactNode;
+  authControls?: React.ReactNode;
 }
 
-export function AboutPage({ onBack, headerControls }: AboutPageProps) {
+export function AboutPage({ onBack, socialLinks, authControls }: AboutPageProps) {
   return (
     <main className="flex-1 mesh-bg min-h-screen">
-      <nav className="border-b border-gray-200/60 bg-white/60 backdrop-blur-lg sticky top-0 z-10">
+      <nav className="border-b border-gray-200/60 bg-white/60 dark:bg-gray-900/60 backdrop-blur-lg sticky top-0 z-10">
         <div className="max-w-6xl mx-auto px-6 h-14 flex items-center">
-          <button onClick={onBack} className="p-1.5 hover:bg-gray-100 rounded-lg transition-colors mr-3">
+          <button onClick={onBack} className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors mr-3">
             <ArrowLeft className="h-4 w-4 text-gray-500" />
           </button>
           <Logo size={28} />
-          <span className="font-semibold text-gray-900 text-sm tracking-tight ml-3">Scholar Folio</span>
-          <div className="ml-auto flex items-center gap-2">
-            {headerControls}
+          <span className="font-semibold text-gray-900 dark:text-gray-100 text-sm tracking-tight ml-3">Scholar Folio</span>
+          <div className="ml-auto flex items-center gap-3">
+            {socialLinks}
+            {authControls}
           </div>
         </div>
       </nav>

--- a/src/components/AuthHeaderControls.tsx
+++ b/src/components/AuthHeaderControls.tsx
@@ -203,8 +203,8 @@ export function AuthHeaderControls({ onBuyCredits, onAdmin, anonSearchesUsed = 0
       </DropdownMenu.Root>
 
       {showDeleteConfirm && (
-        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={() => { if (!deleting) { setShowDeleteConfirm(false); setDeleteError(null); setDeleteConfirmText(''); } }}>
-          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl border border-gray-200 dark:border-gray-700 p-6 max-w-sm mx-4 w-full" onClick={e => e.stopPropagation()}>
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center overflow-y-auto p-4 bg-black/50 backdrop-blur-sm" onClick={() => { if (!deleting) { setShowDeleteConfirm(false); setDeleteError(null); setDeleteConfirmText(''); } }}>
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-2xl border border-gray-200 dark:border-gray-700 p-6 max-w-sm w-full m-auto" onClick={e => e.stopPropagation()}>
             <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-2">Delete your account?</h3>
             <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
               This will permanently delete your account, credits, and all associated data. This action cannot be undone.

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -48,6 +48,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       .eq('user_id', userId)
       .maybeSingle();
 
+    console.log('[ScholarFolio] fetchCredits:', { userId, data, error });
+
     if (!error && data) {
       setCredits(data.credits_remaining);
     } else {


### PR DESCRIPTION
## Summary
- Fixed delete modal centering (was cut off at top) with overflow-y-auto and m-auto
- About page now shows the full header: dark mode toggle, LinkedIn/GitHub links, credits badge, user dropdown
- Added console.log to fetchCredits to debug why credits don't display for some accounts

## Test plan
- [ ] Delete modal is properly centered on screen
- [ ] About page shows full header with all controls
- [ ] Check browser console for `[ScholarFolio] fetchCredits:` log to debug credits