### PR TITLE
Show loading animation when clicking co-author link

### DIFF
--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -880,6 +880,18 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
     setSearchingAuthor(authorName);
     // Open window immediately during user click to avoid popup blocker
     const newWindow = window.open('about:blank', '_blank');
+    if (newWindow) {
+      newWindow.document.write(`<!DOCTYPE html><html><head><title>Scholar Folio</title><style>
+        *{margin:0;padding:0;box-sizing:border-box}
+        body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f8fafa;display:flex;align-items:center;justify-content:center;min-height:100vh;color:#334155}
+        .wrap{text-align:center}
+        .spinner{width:36px;height:36px;border:3px solid #e2e8f0;border-top-color:#2d7d7d;border-radius:50%;animation:spin .8s linear infinite;margin:0 auto 16px}
+        @keyframes spin{to{transform:rotate(360deg)}}
+        .title{font-size:14px;font-weight:600;color:#1e293b;margin-bottom:4px}
+        .sub{font-size:13px;color:#64748b}
+      </style></head><body><div class="wrap"><div class="spinner"></div><div class="title">Loading profile</div><div class="sub">${authorName.replace(/'/g, '&#39;')}</div></div></body></html>`);
+      newWindow.document.close();
+    }
     try {
       const results = await scholarService.searchAuthors(authorName);
       if (results.length >= 1 && newWindow) {


### PR DESCRIPTION
## Summary
- Replaced blank page with branded loading screen (spinner + author name) when clicking a co-author link in the narrative
- Uses ScholarFolio teal color scheme

## Test plan
- [ ] Click a co-author name in the research narrative
- [ ] Verify new tab shows spinner with "Loading profile" and author name
- [ ] Verify it navigates to the correct profile once loaded