### PR TITLE
Fix credits not loading due to .rpc().catch() TypeError

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -40,7 +40,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const fetchCredits = async (userId: string) => {
     // Fire-and-forget: try to claim a free monthly credit (don't block credit fetch)
-    supabase.rpc('claim_monthly_credit', { p_user_id: userId }).catch(() => {});
+    supabase.rpc('claim_monthly_credit', { p_user_id: userId }).then(() => {}).catch(() => {});
 
     const { data, error } = await supabase
       .from('user_credits')


### PR DESCRIPTION
## Summary
- `supabase.rpc()` returns a `PostgrestFilterBuilder`, not a native Promise
- Calling `.catch()` directly on it throws `TypeError: ut.rpc(...).catch is not a function`
- This crashed `fetchCredits` before the actual credit query could execute
- Fixed by using `.then().catch()` to properly convert to a Promise

## Test plan
- [ ] Log in and verify credits badge appears in header
- [ ] Check console for no more `ut.rpc(...).catch is not a function` error
- [ ] Verify `[ScholarFolio] fetchCredits:` log shows correct data