### PR TITLE
Fix CSP blocking Google Fonts

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,4 +5,4 @@
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   X-Robots-Tag: noai, noimageai
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.openalex.org https://pub.orcid.org https://api.crossref.org https://api.semanticscholar.org https://icite.od.nih.gov; font-src 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.openalex.org https://pub.orcid.org https://api.crossref.org https://api.semanticscholar.org https://icite.od.nih.gov; font-src 'self' https://fonts.gstatic.com


### PR DESCRIPTION
## Summary
- Added `https://fonts.googleapis.com` to `style-src` directive
- Added `https://fonts.gstatic.com` to `font-src` directive
- Fixes DM Sans and Playfair Display not loading for users with strict CSP enforcement

## Test plan
- [ ] No more CSP font/style errors in browser console
- [ ] Fonts render correctly (DM Sans for body, Playfair Display for headings)