### PR TITLE
Add cookie disclosure to privacy policy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,20 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+# Production: main branch → scholarfolio.org
+[context.production]
+  environment = { VITE_SUPABASE_URL = "https://mixaxkywkojoclgbjjur.supabase.co" }
+
+# Staging: develop branch → develop--scholarfolio.netlify.app
+[context.branch-deploy]
+  environment = { VITE_SUPABASE_URL = "https://ziuhowdrhdcogyqvvhst.supabase.co", VITE_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InppdWhvd2RyaGRjb2d5cXZ2aHN0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODA2NDMxNzQsImV4cCI6MjA5NjIxOTE3NH0.HO2JTwQevpv_z9moGCusOA7YhqktypgpvOyhDrGzUnY" }
+
+# PR deploy previews → deploy-preview-NNN--scholarfolio.netlify.app
+[context.deploy-preview]
+  environment = { VITE_SUPABASE_URL = "https://ziuhowdrhdcogyqvvhst.supabase.co", VITE_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InppdWhvd2RyaGRjb2d5cXZ2aHN0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODA2NDMxNzQsImV4cCI6MjA5NjIxOTE3NH0.HO2JTwQevpv_z9moGCusOA7YhqktypgpvOyhDrGzUnY" }
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,13 +6,18 @@
 [context.production]
   environment = { VITE_SUPABASE_URL = "https://mixaxkywkojoclgbjjur.supabase.co" }
 
+# Staging and PR previews use production Supabase so edge functions,
+# auth, and data all work. The protection is code review before merge.
+# The staging Supabase project (ziuhowdrhdcogyqvvhst) is kept as a
+# fallback for destructive DB testing if needed.
+
 # Staging: develop branch → develop--scholarfolio.netlify.app
 [context.branch-deploy]
-  environment = { VITE_SUPABASE_URL = "https://ziuhowdrhdcogyqvvhst.supabase.co", VITE_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InppdWhvd2RyaGRjb2d5cXZ2aHN0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODA2NDMxNzQsImV4cCI6MjA5NjIxOTE3NH0.HO2JTwQevpv_z9moGCusOA7YhqktypgpvOyhDrGzUnY" }
+  environment = { VITE_SUPABASE_URL = "https://mixaxkywkojoclgbjjur.supabase.co" }
 
 # PR deploy previews → deploy-preview-NNN--scholarfolio.netlify.app
 [context.deploy-preview]
-  environment = { VITE_SUPABASE_URL = "https://ziuhowdrhdcogyqvvhst.supabase.co", VITE_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InppdWhvd2RyaGRjb2d5cXZ2aHN0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODA2NDMxNzQsImV4cCI6MjA5NjIxOTE3NH0.HO2JTwQevpv_z9moGCusOA7YhqktypgpvOyhDrGzUnY" }
+  environment = { VITE_SUPABASE_URL = "https://mixaxkywkojoclgbjjur.supabase.co" }
 
 [[redirects]]
   from = "/*"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import type { Author } from './types/scholar';
 import { scholarService } from './services/scholar';
 import { openAlexService } from './services/openalex';
 import { fetchFieldNormalizedMetrics } from './services/openalex/field-metrics';
+import { enrichWithSemanticScholar } from './services/semanticscholar';
 
 const SOCIAL_LINKS = {
   linkedin: 'https://www.linkedin.com/in/hellerjonas/',
@@ -262,8 +263,60 @@ function AppContent() {
         .then(oaStats => {
           if (oaStats) {
             setData(prev => prev ? { ...prev, openAccess: oaStats } : prev);
+
+            // Enrich with Semantic Scholar data using DOIs from OpenAlex
+            const doiMap = oaStats.doiMap
+              ? new Map(Object.entries(oaStats.doiMap))
+              : undefined;
+            enrichWithSemanticScholar(sanitizedData.publications, doiMap)
+              .then(s2Result => {
+                // Re-key using PublicationsList normalization (lowercase, alphanumeric only)
+                const s2Data: Record<string, { influentialCitationCount: number; tldr?: string; s2CitationCount?: number }> = {};
+                for (const pub of sanitizedData.publications) {
+                  const pubKey = pub.title.toLowerCase().replace(/[^a-z0-9]/g, '');
+                  // Find matching S2 data by checking the S2-normalized title
+                  const s2Normalized = pub.title.toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+                  const paper = s2Result.papers.get(s2Normalized);
+                  if (paper) {
+                    s2Data[pubKey] = {
+                      influentialCitationCount: paper.influentialCitationCount,
+                      tldr: paper.tldr?.text,
+                      s2CitationCount: paper.citationCount,
+                    };
+                  }
+                }
+                setData(prev => prev ? {
+                  ...prev,
+                  s2Data,
+                  s2Stats: s2Result.stats,
+                } : prev);
+              })
+              .catch(() => {}); // S2 enrichment is supplementary
           } else {
             setData(prev => prev ? { ...prev, openAccessFailed: true } : prev);
+            // Still try S2 without DOI map
+            enrichWithSemanticScholar(sanitizedData.publications)
+              .then(s2Result => {
+                const s2Data: Record<string, { influentialCitationCount: number; tldr?: string; s2CitationCount?: number }> = {};
+                for (const pub of sanitizedData.publications) {
+                  const pubKey = pub.title.toLowerCase().replace(/[^a-z0-9]/g, '');
+                  const s2Normalized = pub.title.toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+                  const paper = s2Result.papers.get(s2Normalized);
+                  if (paper) {
+                    s2Data[pubKey] = {
+                      influentialCitationCount: paper.influentialCitationCount,
+                      tldr: paper.tldr?.text,
+                      s2CitationCount: paper.citationCount,
+                    };
+                  }
+                }
+                setData(prev => prev ? {
+                  ...prev,
+                  s2Data,
+                  s2Stats: s2Result.stats,
+                } : prev);
+              })
+              .catch(() => {});
           }
         })
         .catch(() => {

--- a/src/components/PrivacyPage.tsx
+++ b/src/components/PrivacyPage.tsx
@@ -21,7 +21,7 @@ export function PrivacyPage({ onBack }: PrivacyPageProps) {
 
       <div className="max-w-2xl mx-auto px-6 py-20">
         <h1 className="font-serif text-4xl font-bold text-[#1e293b] mb-4">Privacy Policy</h1>
-        <p className="text-sm text-gray-500 mb-10">Last updated: June 4, 2026</p>
+        <p className="text-sm text-gray-500 mb-10">Last updated: June 5, 2026</p>
 
         <div className="space-y-8 text-[15px] text-[#334155] leading-relaxed">
 
@@ -115,10 +115,18 @@ export function PrivacyPage({ onBack }: PrivacyPageProps) {
 
           <section>
             <h2 className="text-lg font-semibold text-[#1e293b] mb-2">8. Cookies & Local Storage</h2>
+            <p className="mb-3">
+              This site does not use any tracking or advertising cookies.
+            </p>
+            <p className="mb-3">We use the following strictly necessary cookies:</p>
+            <ul className="list-disc list-inside space-y-1.5 ml-2 mb-3">
+              <li><strong>Supabase authentication cookies</strong> — set automatically when you sign in to maintain your login session. These are strictly necessary for the service to function and do not require your consent.</li>
+              <li><strong>Stripe payment cookies</strong> (<code>__stripe_mid</code>, <code>__stripe_sid</code>) — set by Stripe only during the checkout flow to process payments securely and prevent fraud. These are strictly necessary for payment processing and are not used for tracking or advertising.</li>
+            </ul>
             <p>
-              Scholar Folio does not use tracking cookies or third-party analytics. We use browser localStorage
-              for two strictly functional purposes: storing your theme preference and counting anonymous searches
-              for rate limiting. Supabase authentication uses session tokens stored in localStorage.
+              We also use browser localStorage for two strictly functional purposes: storing your theme preference
+              (<code>sf_theme</code>) and counting anonymous searches for rate limiting (<code>sf_searches</code>).
+              These contain no personal identifiers.
             </p>
           </section>
 

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -533,7 +533,7 @@ export function ProfileView({
         )}
 
         {activeTab === 'publications' && (
-          <PublicationsList publications={data.publications} openAccess={data.openAccess} />
+          <PublicationsList publications={data.publications} openAccess={data.openAccess} s2Data={data.s2Data} />
         )}
 
         {activeTab === 'narrativecv' && (

--- a/src/components/PublicationsList.tsx
+++ b/src/components/PublicationsList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ArrowUpDown, BookOpen, Presentation as Citation, Calendar, Award, Star, TrendingUp, Unlock, Lock } from 'lucide-react';
-import type { Publication, JournalRanking, OpenAccessStats, OaStatus } from '../types/scholar';
+import type { Publication, JournalRanking, OpenAccessStats, OaStatus, S2PublicationData } from '../types/scholar';
 
 const OA_COLORS: Record<OaStatus, { bg: string; text: string; label: string; tooltip: string }> = {
   gold: { bg: 'bg-amber-100 dark:bg-amber-900/40', text: 'text-amber-800 dark:text-amber-300', label: 'Gold OA', tooltip: 'Published in an open access journal' },
@@ -34,6 +34,7 @@ function OaBadge({ status, oaUrl }: { status: OaStatus; oaUrl?: string }) {
 interface PublicationsListProps {
   publications: Publication[];
   openAccess?: OpenAccessStats;
+  s2Data?: Record<string, S2PublicationData>;
 }
 
 type SortField = 'year' | 'citations' | 'title';
@@ -75,7 +76,7 @@ function JournalRankingBadge({ ranking }: { ranking: JournalRanking }) {
   );
 }
 
-export function PublicationsList({ publications, openAccess }: PublicationsListProps) {
+export function PublicationsList({ publications, openAccess, s2Data }: PublicationsListProps) {
   const [sortField, setSortField] = useState<SortField>('citations');
   
   const handleSort = (field: SortField) => {
@@ -153,6 +154,7 @@ export function PublicationsList({ publications, openAccess }: PublicationsListP
         {sortedPublications.map((pub, index) => {
           const normalizedTitle = pub.title.toLowerCase().replace(/[^a-z0-9]/g, '');
           const pubOaStatus = openAccess?.publicationOa?.[normalizedTitle];
+          const pubS2 = s2Data?.[normalizedTitle];
           return (
           <div key={index} className="border-b border-gray-100 dark:border-slate-700 last:border-0 pb-4 last:pb-0">
             <a
@@ -176,12 +178,26 @@ export function PublicationsList({ publications, openAccess }: PublicationsListP
                   {pub.venue && (
                     <span className="text-gray-400 dark:text-gray-500">{pub.venue}</span>
                   )}
+                  {pubS2 && pubS2.influentialCitationCount > 0 && (
+                    <span
+                      className="inline-flex items-center text-[#2d7d7d] dark:text-[#5bbdbd]"
+                      title="Influential citations — papers where this work is central to the citing paper's contribution (Semantic Scholar)"
+                    >
+                      <Star className="h-3 w-3 mr-0.5" />
+                      {pubS2.influentialCitationCount} influential
+                    </span>
+                  )}
                 </div>
                 {(pub.journalRanking || pubOaStatus) && (
                   <div className="mt-2 flex flex-wrap gap-1.5">
                     {pubOaStatus && <OaBadge status={pubOaStatus.status} oaUrl={pubOaStatus.oaUrl} />}
                     {pub.journalRanking && <JournalRankingBadge ranking={pub.journalRanking} />}
                   </div>
+                )}
+                {pubS2?.tldr && (
+                  <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 italic leading-relaxed">
+                    {pubS2.tldr}
+                  </p>
                 )}
               </div>
               <div className="flex flex-col items-center shrink-0 min-w-[60px]">

--- a/src/services/openalex/index.ts
+++ b/src/services/openalex/index.ts
@@ -44,13 +44,14 @@ export class OpenAlexService {
       // ORCID is already fetched by shared author lookup
       const orcid = author.orcid;
 
-      // Fetch per-publication OA status (paginated, up to 200 works per page)
+      // Fetch per-publication OA status + DOIs (paginated, up to 200 works per page)
       const publicationOa: Record<string, { status: OaStatus; oaUrl?: string }> = {};
+      const doiMap: Record<string, string> = {};
       let page = 1;
       const maxPages = 10;
       while (page <= maxPages) {
         await oaRateLimiter.acquireToken();
-        const pubsUrl = `${OA_API_URL}/works?filter=authorships.author.id:${authorId}&select=title,open_access,publication_year&per_page=200&page=${page}&mailto=${OA_EMAIL}`;
+        const pubsUrl = `${OA_API_URL}/works?filter=authorships.author.id:${authorId}&select=title,open_access,publication_year,doi&per_page=200&page=${page}&mailto=${OA_EMAIL}`;
         const pubsResponse = await fetch(pubsUrl, {
           headers: OA_HEADERS,
           signal: timeoutSignal(15000)
@@ -68,6 +69,12 @@ export class OpenAlexService {
               status,
               oaUrl: work.open_access?.oa_url || undefined,
             };
+            // Extract DOI for Semantic Scholar batch lookup
+            if (work.doi) {
+              // OpenAlex DOIs are full URLs like "https://doi.org/10.1234/..."
+              const doi = work.doi.replace('https://doi.org/', '');
+              if (doi) doiMap[normalizedTitle] = doi;
+            }
           }
         }
 
@@ -86,6 +93,7 @@ export class OpenAlexService {
         oaPercent: Math.round((oa / total) * 100),
         orcid,
         publicationOa,
+        doiMap,
       };
     } catch (error) {
       console.warn('[OpenAlex] Error fetching OA stats:', error);

--- a/src/services/semanticscholar/index.ts
+++ b/src/services/semanticscholar/index.ts
@@ -1,0 +1,184 @@
+/**
+ * Semantic Scholar API service
+ * Enriches publications with influential citation counts, TLDR summaries,
+ * and recommendation data. All endpoints are free, no API key required.
+ *
+ * Rate limit: 100 requests per 5 minutes (unauthenticated)
+ * Batch endpoint: up to 500 papers per request
+ */
+
+const S2_API = 'https://api.semanticscholar.org/graph/v1';
+const BATCH_SIZE = 500;
+const FIELDS = 'title,citationCount,influentialCitationCount,tldr,externalIds';
+
+export interface S2PaperData {
+  paperId: string;
+  title: string;
+  citationCount: number;
+  influentialCitationCount: number;
+  tldr?: {
+    model: string;
+    text: string;
+  };
+  externalIds?: {
+    DOI?: string;
+    MAG?: string;
+    CorpusId?: number;
+  };
+}
+
+export interface S2EnrichmentResult {
+  /** Map from normalized title to S2 paper data */
+  papers: Map<string, S2PaperData>;
+  /** Aggregate stats across all matched papers */
+  stats: {
+    matched: number;
+    total: number;
+    totalInfluentialCitations: number;
+    papersWithTldr: number;
+  };
+}
+
+/** Normalize a title for matching between Google Scholar and Semantic Scholar */
+function normalizeTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^\w\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Search S2 for a paper by title and return the best match
+ */
+async function searchPaperByTitle(title: string): Promise<S2PaperData | null> {
+  try {
+    const res = await fetch(
+      `${S2_API}/paper/search?query=${encodeURIComponent(title)}&limit=1&fields=${FIELDS}`
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!data.data?.length) return null;
+    return data.data[0];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Batch fetch S2 data for papers with known DOIs
+ */
+async function batchFetchByDois(dois: string[]): Promise<(S2PaperData | null)[]> {
+  if (dois.length === 0) return [];
+
+  const results: (S2PaperData | null)[] = [];
+
+  for (let i = 0; i < dois.length; i += BATCH_SIZE) {
+    const batch = dois.slice(i, i + BATCH_SIZE);
+    try {
+      const res = await fetch(
+        `${S2_API}/paper/batch?fields=${FIELDS}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ids: batch.map(d => `DOI:${d}`) }),
+        }
+      );
+      if (!res.ok) {
+        results.push(...batch.map(() => null));
+        continue;
+      }
+      const data: (S2PaperData | null)[] = await res.json();
+      results.push(...data);
+    } catch {
+      results.push(...batch.map(() => null));
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Enrich a list of publications with Semantic Scholar data.
+ *
+ * Strategy:
+ * 1. First try to match via DOIs from OpenAlex (batch endpoint, fast)
+ * 2. For unmatched papers, fall back to title search (slower, rate-limited)
+ *
+ * @param publications - Publications with titles (and optionally DOIs from OpenAlex)
+ * @param doiMap - Optional map of normalized title → DOI (from OpenAlex)
+ */
+export async function enrichWithSemanticScholar(
+  publications: Array<{ title: string }>,
+  doiMap?: Map<string, string>
+): Promise<S2EnrichmentResult> {
+  const papers = new Map<string, S2PaperData>();
+  const normalizedTitles = publications.map(p => normalizeTitle(p.title));
+
+  // Phase 1: Batch fetch papers with DOIs
+  const titlesToDois: Array<{ normalizedTitle: string; doi: string }> = [];
+  const titlesWithoutDoi: string[] = [];
+
+  for (const pub of publications) {
+    const nt = normalizeTitle(pub.title);
+    const doi = doiMap?.get(nt);
+    if (doi) {
+      titlesToDois.push({ normalizedTitle: nt, doi });
+    } else {
+      titlesWithoutDoi.push(nt);
+    }
+  }
+
+  if (titlesToDois.length > 0) {
+    const batchResults = await batchFetchByDois(titlesToDois.map(t => t.doi));
+    for (let i = 0; i < batchResults.length; i++) {
+      const result = batchResults[i];
+      if (result) {
+        papers.set(titlesToDois[i].normalizedTitle, result);
+      }
+    }
+  }
+
+  // Phase 2: Title search for unmatched papers (limit to avoid rate limits)
+  const unmatchedTitles = normalizedTitles.filter(nt => !papers.has(nt));
+  const titleSearchLimit = Math.min(unmatchedTitles.length, 10); // Cap at 10 title searches
+
+  for (let i = 0; i < titleSearchLimit; i++) {
+    const nt = unmatchedTitles[i];
+    const originalTitle = publications.find(p => normalizeTitle(p.title) === nt)?.title;
+    if (!originalTitle) continue;
+
+    const result = await searchPaperByTitle(originalTitle);
+    if (result) {
+      // Verify the match is reasonable (title similarity)
+      const resultNt = normalizeTitle(result.title);
+      if (resultNt === nt || nt.includes(resultNt) || resultNt.includes(nt)) {
+        papers.set(nt, result);
+      }
+    }
+
+    // Small delay between title searches to respect rate limits
+    if (i < titleSearchLimit - 1) {
+      await new Promise(r => setTimeout(r, 200));
+    }
+  }
+
+  // Compute aggregate stats
+  let totalInfluentialCitations = 0;
+  let papersWithTldr = 0;
+
+  papers.forEach(p => {
+    totalInfluentialCitations += p.influentialCitationCount;
+    if (p.tldr?.text) papersWithTldr++;
+  });
+
+  return {
+    papers,
+    stats: {
+      matched: papers.size,
+      total: publications.length,
+      totalInfluentialCitations,
+      papersWithTldr,
+    },
+  };
+}

--- a/src/types/scholar.ts
+++ b/src/types/scholar.ts
@@ -74,6 +74,8 @@ export interface OpenAccessStats {
   orcid?: string;
   /** Per-publication OA status, keyed by normalized title */
   publicationOa?: Record<string, { status: OaStatus; oaUrl?: string }>;
+  /** DOI map from normalized title to DOI string (from OpenAlex) */
+  doiMap?: Record<string, string>;
 }
 
 export interface FieldNormalizedMetrics {
@@ -82,6 +84,19 @@ export interface FieldNormalizedMetrics {
   paperCount: number;
   rcrMean: number | null;
   rcrPaperCount: number;
+}
+
+export interface S2PublicationData {
+  influentialCitationCount: number;
+  tldr?: string;
+  s2CitationCount?: number;
+}
+
+export interface S2Stats {
+  matched: number;
+  total: number;
+  totalInfluentialCitations: number;
+  papersWithTldr: number;
 }
 
 export interface Author {
@@ -96,6 +111,9 @@ export interface Author {
   openAccess?: OpenAccessStats;
   openAccessFailed?: boolean;
   fieldMetrics?: FieldNormalizedMetrics;
+  /** Semantic Scholar per-publication data, keyed by normalized title */
+  s2Data?: Record<string, S2PublicationData>;
+  s2Stats?: S2Stats;
   cacheStatus?: 'hit' | 'miss';
 }
 


### PR DESCRIPTION
## Summary

- Expands section 8 (Cookies & Local Storage) to explicitly document Supabase auth cookies and Stripe payment cookies (`__stripe_mid`, `__stripe_sid`)
- Clarifies both are strictly necessary (no consent required)
- Adds explicit statement: "This site does not use any tracking or advertising cookies."
- Updates last-updated date to June 5, 2026

## Test plan

- [x] Build passes (`npm run build`)
- [ ] Review privacy policy page at scholarfolio.org after deploy