### PR TITLE
Remove debug logs and DRY up S2 enrichment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -199,6 +199,24 @@ function AppContent() {
   };
   const ANON_FREE_LIMIT = 5;
 
+  /** Re-key S2 enrichment results to PublicationsList normalization and update state */
+  const applyS2Data = (s2Result: Awaited<ReturnType<typeof enrichWithSemanticScholar>>, pubs: Array<{ title: string }>) => {
+    const s2Data: Record<string, { influentialCitationCount: number; tldr?: string; s2CitationCount?: number }> = {};
+    for (const pub of pubs) {
+      const pubKey = pub.title.toLowerCase().replace(/[^a-z0-9]/g, '');
+      const s2Normalized = pub.title.toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+      const paper = s2Result.papers.get(s2Normalized);
+      if (paper) {
+        s2Data[pubKey] = {
+          influentialCitationCount: paper.influentialCitationCount,
+          tldr: paper.tldr?.text,
+          s2CitationCount: paper.citationCount,
+        };
+      }
+    }
+    setData(prev => prev ? { ...prev, s2Data, s2Stats: s2Result.stats } : prev);
+  };
+
   const handleSearch = useCallback(async (url: string, bypassCredits = false, cacheOnly = false) => {
     // Prevent multiple concurrent requests using ref to avoid stale closure
     if (requestInProgressRef.current) {
@@ -279,29 +297,9 @@ function AppContent() {
             }
             enrichWithSemanticScholar(sanitizedData.publications, doiMap)
               .then(s2Result => {
-                console.log(`[S2] Matched ${s2Result.stats.matched}/${s2Result.stats.total} papers, ${s2Result.stats.totalInfluentialCitations} influential citations`);
-                // Re-key using PublicationsList normalization (lowercase, alphanumeric only)
-                const s2Data: Record<string, { influentialCitationCount: number; tldr?: string; s2CitationCount?: number }> = {};
-                for (const pub of sanitizedData.publications) {
-                  const pubKey = pub.title.toLowerCase().replace(/[^a-z0-9]/g, '');
-                  const s2Normalized = pub.title.toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
-                  const paper = s2Result.papers.get(s2Normalized);
-                  if (paper) {
-                    s2Data[pubKey] = {
-                      influentialCitationCount: paper.influentialCitationCount,
-                      tldr: paper.tldr?.text,
-                      s2CitationCount: paper.citationCount,
-                    };
-                  }
-                }
-                setData(prev => prev ? {
-                  ...prev,
-                  s2Data,
-                  s2Stats: s2Result.stats,
-                } : prev);
+                applyS2Data(s2Result, sanitizedData.publications);
               })
               .catch((err) => {
-                console.warn('[S2] Enrichment failed:', err);
                 logCaughtError(err, 's2', 'App', 'enrich-with-dois', { pubCount: sanitizedData.publications.length });
               });
           } else {
@@ -310,28 +308,9 @@ function AppContent() {
             // Still try S2 without DOI map (title search only, capped at 10)
             enrichWithSemanticScholar(sanitizedData.publications)
               .then(s2Result => {
-                console.log(`[S2] Matched ${s2Result.stats.matched}/${s2Result.stats.total} papers (no DOI map)`);
-                const s2Data: Record<string, { influentialCitationCount: number; tldr?: string; s2CitationCount?: number }> = {};
-                for (const pub of sanitizedData.publications) {
-                  const pubKey = pub.title.toLowerCase().replace(/[^a-z0-9]/g, '');
-                  const s2Normalized = pub.title.toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
-                  const paper = s2Result.papers.get(s2Normalized);
-                  if (paper) {
-                    s2Data[pubKey] = {
-                      influentialCitationCount: paper.influentialCitationCount,
-                      tldr: paper.tldr?.text,
-                      s2CitationCount: paper.citationCount,
-                    };
-                  }
-                }
-                setData(prev => prev ? {
-                  ...prev,
-                  s2Data,
-                  s2Stats: s2Result.stats,
-                } : prev);
+                applyS2Data(s2Result, sanitizedData.publications);
               })
               .catch((err) => {
-                console.warn('[S2] Enrichment failed:', err);
                 logCaughtError(err, 's2', 'App', 'enrich-no-dois', { pubCount: sanitizedData.publications.length });
               });
           }

--- a/src/services/scholar/index.ts
+++ b/src/services/scholar/index.ts
@@ -194,7 +194,6 @@ function normalizeScholarUrl(url: string): string {
     // Create a clean normalized URL with just the user parameter
     const normalizedUrl = `https://scholar.google.com/citations?user=${encodeURIComponent(userId)}`;
     
-    console.log('[ScholarService] Normalized URL:', normalizedUrl);
     return normalizedUrl;
   } catch (e) {
     console.error('[ScholarService] Error normalizing URL:', e);


### PR DESCRIPTION
## Summary
- Remove 4 debug `console.log`/`console.warn` calls from S2 enrichment in App.tsx
- Remove normalized URL debug log from scholar service (leaked user input to console)
- Extract `applyS2Data()` helper to eliminate ~30 lines of duplicated S2 re-keying logic

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Profile search still shows S2 influential citations and TLDR
- [ ] No S2 debug output in browser console