### PR TITLE
Comprehensive error logging and user-facing error codes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,7 +176,8 @@ function AppContent() {
             const scholarUrl = `https://scholar.google.com/citations?user=${encodeURIComponent(claim.author_id)}`;
             handleSearchRef.current(scholarUrl, true, true);
           }
-        });
+        })
+        .catch((err: unknown) => logCaughtError(err, 'navigation', 'App', 'load-vanity-slug', { pathSlug }));
     }
   }, [initialUrlHandled]);
 

--- a/src/components/ClaimProfileModal.tsx
+++ b/src/components/ClaimProfileModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { X, Link, Check, AlertCircle, Loader2, User, FileText, Copy, Mail, Linkedin } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { supabase } from '../lib/supabase';
+import { logError } from '../lib/errorLogger';
 
 interface ClaimProfileModalProps {
   onClose: () => void;
@@ -62,6 +63,7 @@ export function ClaimProfileModal({ onClose, authorId, authorName, onClaimed }: 
       .maybeSingle();
 
     if (error) {
+      logError({ category: 'profile', message: `Slug check failed: ${error.message}`, component: 'ClaimProfileModal', action: 'check-slug', context: { code: error.code } });
       setSlugStatus('idle');
       return;
     }

--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -8,6 +8,7 @@ import { Globe, Info, MapPin, Users, Flag, ZoomIn, ZoomOut, RotateCcw } from 'lu
 import type { Publication, CoAuthorGeoData } from '../types/scholar';
 import { fetchCoAuthorGeoData } from '../services/openalex/coauthor-geo';
 import { timeoutSignal } from '../utils/api';
+import { logCaughtError } from '../lib/errorLogger';
 
 interface CoAuthorMapProps {
   publications: Publication[];
@@ -93,6 +94,9 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
         setGeoData(result);
         setLoading(false);
       }
+    }).catch(err => {
+      logCaughtError(err, 'openalex', 'CoAuthorMap', 'fetch-geo-data');
+      if (!cancelled) setLoading(false);
     });
     return () => { cancelled = true; };
   }, [authorName, authorAffiliation, publications, prefetchedData]);
@@ -361,7 +365,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
         }
       })
       .catch(err => {
-        console.warn('[CoAuthorMap] Failed to load world map data:', err);
+        logCaughtError(err, 'navigation', 'CoAuthorMap', 'load-world-topojson');
         setMapError(true);
       });
   }, [geoData]);

--- a/src/components/CreditPacks.tsx
+++ b/src/components/CreditPacks.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Zap, X, Shield, Clock, Check, Sparkles, Heart } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { AuthButton } from './AuthButton';
+import { logCaughtError } from '../lib/errorLogger';
 
 const PACKS = [
   {
@@ -65,7 +66,8 @@ export function CreditPacks({ onClose }: { onClose: () => void }) {
         window.location.href = data.url;
       }
     } catch (err) {
-      setError('Failed to create checkout session. Please try again.');
+      logCaughtError(err, 'profile', 'CreditPacks', 'create-checkout');
+      setError('Failed to create checkout session. Please try again. (SF-PAY)');
     } finally {
       setLoading(null);
     }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { AlertTriangle } from 'lucide-react';
+import { logError } from '../lib/errorLogger';
 
 interface Props {
   children: ReactNode;
@@ -25,6 +26,13 @@ export class ErrorBoundary extends Component<Props, State> {
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('Uncaught error:', error, errorInfo);
+    logError({
+      category: 'unhandled',
+      message: error.message,
+      stack: error.stack,
+      component: errorInfo.componentStack?.split('\n')[1]?.trim() || 'ErrorBoundary',
+      action: 'react_render_crash',
+    });
   }
 
   public render() {
@@ -39,6 +47,7 @@ export class ErrorBoundary extends Component<Props, State> {
             <p className="text-sm text-gray-600 mb-4">
               {this.state.error?.message || 'An unexpected error occurred'}
             </p>
+            <p className="text-[10px] text-gray-400 mb-4 font-mono">Error code: SF-CRASH</p>
             <button
               onClick={() => window.location.reload()}
               className="px-4 py-2 bg-[#1e293b] text-white rounded-lg hover:bg-slate-800 transition-colors"

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { X, Loader2 } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import { logCaughtError } from '../lib/errorLogger';
 
 interface FeedbackModalProps {
   mode: 'prompt' | 'button';
@@ -81,7 +82,8 @@ export function FeedbackModal({ mode, onClose, onSuccess, profileViewed, isFirst
         onSuccess(granted);
       }, 2000);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Something went wrong.');
+      logCaughtError(err, 'profile', 'FeedbackModal', 'submit-feedback');
+      setError(err instanceof Error ? err.message : 'Something went wrong. (SF-FEEDBACK)');
       setSubmitting(false);
     }
   };

--- a/src/components/NarrativeCvTab.tsx
+++ b/src/components/NarrativeCvTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Download, Info, Loader2 } from 'lucide-react';
+import { logCaughtError } from '../lib/errorLogger';
 // docx (~650KB) is dynamically imported on export click
 type NarrativeCvFormat = 'nwo' | 'erc' | 'msca';
 import type { Author, CoAuthorGeoData } from '../types/scholar';
@@ -59,8 +60,8 @@ export function NarrativeCvTab({ data, geoData }: NarrativeCvTabProps) {
       const { exportNarrativeCv } = await import('../utils/narrativeCvExport');
       await exportNarrativeCv(data, format, geoData);
     } catch (err) {
-      console.error('Narrative CV export failed:', err);
-      setExportError('Export failed. Please try again.');
+      logCaughtError(err, 'profile', 'NarrativeCvTab', 'export-narrative-cv', { format });
+      setExportError('Export failed. Please try again. (SF-EXPORT)');
     } finally {
       setExporting(null);
     }

--- a/src/components/PIndexSection.tsx
+++ b/src/components/PIndexSection.tsx
@@ -133,14 +133,14 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
       // The mailto= param in the URL is sufficient for OpenAlex polite pool
       const response = await fetch(url, { signal: timeoutSignal(15000) });
       if (!response.ok) {
-        setErrorMsg('Could not reach OpenAlex. Please wait a moment and try again.');
+        setErrorMsg(`Could not reach OpenAlex (HTTP ${response.status}). Please wait a moment and try again. (SF-PI-SEARCH)`);
         setStep('error');
         return;
       }
       const data: { results: OpenAlexSearchResult[] } = await response.json();
 
       if (!data.results?.length) {
-        setErrorMsg('No authors found in OpenAlex. Try adjusting the name.');
+        setErrorMsg('No authors found in OpenAlex. Try adjusting the name. (SF-PI-NORESULT)');
         setStep('error');
         return;
       }
@@ -150,7 +150,7 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       logCaughtError(err, 'pindex', 'PIndexSection', 'search', { firstName, lastName, institution });
-      setErrorMsg(`Could not reach OpenAlex: ${msg}`);
+      setErrorMsg(`Could not reach OpenAlex: ${msg} (SF-PI-NET)`);
       setStep('error');
     }
   }, [firstName, lastName, institution]);
@@ -162,7 +162,7 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
     try {
       const works = await fetchPIndexWorks(author.id);
       if (works.length === 0) {
-        setErrorMsg(`No publications found for ${author.display_name} (${author.id}) in OpenAlex.`);
+        setErrorMsg(`No publications found for ${author.display_name} in OpenAlex. (SF-PI-NOPUBS)`);
         setStep('error');
         return;
       }
@@ -201,7 +201,7 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       logCaughtError(err, 'pindex', 'PIndexSection', 'fetch-works', { authorId: author.id, authorName: author.display_name });
-      setErrorMsg(`Failed to fetch publications: ${msg}`);
+      setErrorMsg(`Failed to fetch publications: ${msg} (SF-PI-WORKS)`);
       setStep('error');
     }
   }, [scrapedPublications]);
@@ -247,13 +247,13 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
         onResult?.(pIndex);
         setStep('done');
       } else {
-        setErrorMsg('Could not compute p-index. No publications with journal data found.');
+        setErrorMsg('Could not compute p-index. No publications with journal data found. (SF-PI-NOJOURNAL)');
         setStep('error');
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       logCaughtError(err, 'pindex', 'PIndexSection', 'compute', { authorId: selectedAuthor?.id, includedCount: included.length });
-      setErrorMsg(`Calculation failed: ${msg}`);
+      setErrorMsg(`Calculation failed: ${msg} (SF-PI-CALC)`);
       setStep('error');
     }
   }, [selectedAuthor, allWorks, excludedIds, onResult]);

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -282,8 +282,9 @@ export function ProfileView({
                         const { exportProfilePdf } = await import('../utils/pdfExport');
                         await exportProfilePdf(data, scholarId || undefined, prefetchedGeo);
                       } catch (err) {
-                        console.error('PDF export failed:', err);
-                        setExportError('PDF export failed. Please try again.');
+                        const { logCaughtError } = await import('../lib/errorLogger');
+                        logCaughtError(err, 'profile', 'ProfileView', 'export-pdf');
+                        setExportError('PDF export failed. Please try again. (SF-PDF)');
                       } finally {
                         setExportingPdf(false);
                       }

--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { FileText, TrendingUp, Users, BookOpen, Award, Flag, Loader2, Check, Search } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import { logCaughtError } from '../lib/errorLogger';
 import type { Author, CoAuthorGeoData, FieldNormalizedMetrics } from '../types/scholar';
 import type { PIndexResult } from '../services/openalex/pindex';
 import { findJournalRanking } from '../data/journalRankings';
@@ -902,7 +903,7 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
         newWindow?.close();
       }
     } catch (err) {
-      console.warn('[Narrative] Author search failed for:', authorName, err);
+      logCaughtError(err, 'profile', 'ResearcherNarrative', 'author-link-search', { authorName });
       newWindow?.close();
     } finally {
       setSearchingAuthor(null);

--- a/src/services/openalex/author-lookup.ts
+++ b/src/services/openalex/author-lookup.ts
@@ -1,5 +1,6 @@
 import { timeoutSignal } from '../../utils/api';
 import { RateLimiter } from '../scholar/rate-limiter';
+import { logCaughtError } from '../../lib/errorLogger';
 
 const API_URL = 'https://api.openalex.org';
 const EMAIL = 'info@scholarfolio.org';
@@ -119,7 +120,8 @@ export async function findOpenAlexAuthor(
 
     authorCache.set(cacheKey, author);
     return author;
-  } catch {
+  } catch (err) {
+    logCaughtError(err, 'openalex', 'author-lookup', 'find-author', { name, affiliation });
     authorCache.set(cacheKey, null);
     return null;
   }

--- a/src/services/openalex/field-metrics.ts
+++ b/src/services/openalex/field-metrics.ts
@@ -1,4 +1,5 @@
 import { findOpenAlexAuthor, oaFetchJson, OA_API_URL, OA_EMAIL } from './author-lookup';
+import { logCaughtError } from '../../lib/errorLogger';
 import type { FieldNormalizedMetrics } from '../../types/scholar';
 
 export type { FieldNormalizedMetrics };
@@ -74,7 +75,7 @@ export async function fetchFieldNormalizedMetrics(
       rcrPaperCount: 0,
     };
   } catch (error) {
-    console.warn('[OpenAlex] Error fetching field-normalized metrics:', error);
+    logCaughtError(error, 'openalex', 'field-metrics', 'fetch-field-normalized');
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Log all user-visible errors to `client_errors` table (12 files updated)
- Add SF-* error codes to every error message users can see
- Fix React ErrorBoundary not logging crashes
- Fix missing `.catch()` on vanity slug lookup and co-author geo fetch

### Error code reference
| Code | Component | Meaning |
|------|-----------|---------|
| SF-CRASH | ErrorBoundary | React render crash |
| SF-PDF | ProfileView | PDF export failed |
| SF-EXPORT | NarrativeCvTab | Narrative CV export failed |
| SF-PAY | CreditPacks | Checkout session failed |
| SF-FEEDBACK | FeedbackModal | Feedback submission failed |
| SF-PI-SEARCH | PIndexSection | OpenAlex HTTP error |
| SF-PI-NET | PIndexSection | Network/timeout error |
| SF-PI-NORESULT | PIndexSection | No authors found |
| SF-PI-NOPUBS | PIndexSection | No publications found |
| SF-PI-WORKS | PIndexSection | Failed to fetch works |
| SF-PI-CALC | PIndexSection | Calculation failed |
| SF-PI-NOJOURNAL | PIndexSection | No journal data |

## Test plan
- [ ] Build passes
- [ ] Error codes visible in error messages
- [ ] Errors appear in admin dashboard client_errors section