### PR TITLE
Deploy: Fix OpenAlex on Firefox/Safari

### DIFF
--- a/src/components/OpenScienceTab.tsx
+++ b/src/components/OpenScienceTab.tsx
@@ -107,8 +107,12 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
         <Unlock className="h-8 w-8 text-gray-300 mx-auto mb-3" />
         {data.openAccessFailed ? (
           <>
-            <p className="text-sm text-gray-500">Open Access data unavailable</p>
-            <p className="text-xs text-gray-400 mt-1">Could not retrieve data from OpenAlex. Try refreshing the profile.</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">Open Access data unavailable</p>
+            <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+              This researcher could not be matched on{' '}
+              <a href="https://openalex.org" target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">OpenAlex</a>.
+              {' '}This can happen if the name or affiliation differs from the OpenAlex record.
+            </p>
           </>
         ) : (
           <>

--- a/src/services/openalex/author-lookup.ts
+++ b/src/services/openalex/author-lookup.ts
@@ -4,7 +4,6 @@ import { logCaughtError } from '../../lib/errorLogger';
 
 const API_URL = 'https://api.openalex.org';
 const EMAIL = 'info@scholarfolio.org';
-export const OA_HEADERS = { 'User-Agent': `ScholarFolio/1.0 (mailto:${EMAIL})` };
 export const OA_EMAIL = EMAIL;
 export const OA_API_URL = API_URL;
 
@@ -15,7 +14,7 @@ export const oaRateLimiter = new RateLimiter(5000, 100);
 export async function oaFetchJson<T>(url: string, timeoutMs = 15000): Promise<T | null> {
   try {
     await oaRateLimiter.acquireToken();
-    const response = await fetch(url, { headers: OA_HEADERS, signal: timeoutSignal(timeoutMs) });
+    const response = await fetch(url, { signal: timeoutSignal(timeoutMs) });
     if (!response.ok) {
       console.warn(`[OpenAlex] HTTP ${response.status} for ${url.split('?')[0]}`);
       return null;

--- a/src/services/openalex/index.ts
+++ b/src/services/openalex/index.ts
@@ -1,6 +1,6 @@
 import { timeoutSignal } from '../../utils/api';
 import type { JournalRanking, OpenAccessStats, OaStatus } from '../../types/scholar';
-import { findOpenAlexAuthor, oaFetchJson, oaRateLimiter, OA_HEADERS, OA_API_URL, OA_EMAIL } from './author-lookup';
+import { findOpenAlexAuthor, oaFetchJson, oaRateLimiter, OA_API_URL, OA_EMAIL } from './author-lookup';
 
 export class OpenAlexService {
   /**
@@ -18,7 +18,6 @@ export class OpenAlexService {
       await oaRateLimiter.acquireToken();
       const worksUrl = `${OA_API_URL}/works?filter=authorships.author.id:${authorId}&group_by=open_access.oa_status&per_page=10&mailto=${OA_EMAIL}`;
       const worksResponse = await fetch(worksUrl, {
-        headers: OA_HEADERS,
         signal: timeoutSignal(10000)
       });
 
@@ -53,7 +52,6 @@ export class OpenAlexService {
         await oaRateLimiter.acquireToken();
         const pubsUrl = `${OA_API_URL}/works?filter=authorships.author.id:${authorId}&select=title,open_access,publication_year,doi&per_page=200&page=${page}&mailto=${OA_EMAIL}`;
         const pubsResponse = await fetch(pubsUrl, {
-          headers: OA_HEADERS,
           signal: timeoutSignal(15000)
         });
         if (!pubsResponse.ok) break;


### PR DESCRIPTION
Merges develop → main. Fixes OpenAlex API calls silently failing on Firefox and mobile Safari due to forbidden User-Agent header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)