### PR TITLE
Deploy: Fix sitemap redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
+/sitemap.xml  /.netlify/functions/sitemap  200
 /*    /index.html   200


### PR DESCRIPTION
Sitemap redirect fix — _redirects catch-all was overriding netlify.toml.