### PR TITLE
Fix co-author map: CSP blocking topojson + click vs zoom conflict

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,4 +5,4 @@
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   X-Robots-Tag: noai, noimageai
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.openalex.org https://pub.orcid.org https://api.crossref.org https://api.semanticscholar.org https://icite.od.nih.gov; font-src 'self' https://fonts.gstatic.com
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.openalex.org https://pub.orcid.org https://api.crossref.org https://api.semanticscholar.org https://icite.od.nih.gov https://unpkg.com; font-src 'self' https://fonts.gstatic.com

--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -178,6 +178,15 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
     let currentScale = 1;
     const zoom = d3Zoom<SVGSVGElement, unknown>()
       .scaleExtent([0.5, 20])
+      .filter((event: Event) => {
+        // Don't let zoom intercept clicks/touches on dots — allow them to bubble to the dot's click handler
+        const target = event.target as SVGElement;
+        if (target.classList?.contains('geo-dot')) {
+          // Allow scroll/pinch zoom on dots, but block drag (which eats click)
+          return event.type === 'wheel' || event.type === 'dblclick';
+        }
+        return true;
+      })
       .on('zoom', event => {
         zoomGroup.attr('transform', event.transform);
         currentScale = event.transform.k;


### PR DESCRIPTION
## Summary
- Add `https://unpkg.com` to CSP `connect-src` — the world map topojson was being blocked
- Add zoom filter so D3 zoom doesn't swallow click events on co-author dots

## Test plan
- [ ] World map loads (no "Failed to load world map data" error)
- [ ] Click co-author dot → popup appears with View/Share buttons
- [ ] Zoom/pan still works on the map background

🤖 Generated with [Claude Code](https://claude.com/claude-code)