### PR TITLE
Fix co-author click: use SerpAPI + add network double-click

### DIFF
--- a/src/components/CitationNetwork.tsx
+++ b/src/components/CitationNetwork.tsx
@@ -35,6 +35,7 @@ interface Link {
 interface CitationNetworkProps {
   publications: Publication[];
   fullScreen?: boolean;
+  onCoAuthorClick?: (name: string) => void;
 }
 
 type ViewMode = 'publications' | 'citations' | 'temporal' | 'clusters';
@@ -187,7 +188,7 @@ const CLUSTER_COLORS = [
   '#2563eb', '#d97706', '#6366f1', '#dc2626', '#0891b2'
 ];
 
-export function CitationNetwork({ publications, fullScreen = false }: CitationNetworkProps) {
+export function CitationNetwork({ publications, fullScreen = false, onCoAuthorClick }: CitationNetworkProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const simulationRef = useRef<D3Simulation<Node, Link> | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('publications');
@@ -560,6 +561,15 @@ export function CitationNetwork({ publications, fullScreen = false }: CitationNe
         }
         return text;
       });
+
+    // Double-click to open co-author profile
+    node.on('dblclick', (_event: MouseEvent, d: any) => {
+      _event.stopPropagation();
+      _event.preventDefault();
+      if (d.group !== 0 && onCoAuthorClick) {
+        onCoAuthorClick(d.name);
+      }
+    });
 
     // Click-to-highlight
     node.on('click', (_event, d) => {

--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -9,6 +9,7 @@ import type { Publication, CoAuthorGeoData } from '../types/scholar';
 import { fetchCoAuthorGeoData } from '../services/openalex/coauthor-geo';
 import { timeoutSignal } from '../utils/api';
 import { logCaughtError } from '../lib/errorLogger';
+import { scholarService } from '../services/scholar';
 
 interface CoAuthorMapProps {
   publications: Publication[];
@@ -615,29 +616,28 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
                     window.open(`${window.location.origin}/?user=${scholarIdLookup.scholarId}`, '_blank');
                     return;
                   }
+                  // Open window immediately to avoid popup blocker
+                  const newWindow = window.open('about:blank', '_blank');
+                  if (newWindow) {
+                    newWindow.document.write(`<!DOCTYPE html><html><head><title>Scholar Folio</title><style>*{margin:0;padding:0;box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f8fafa;display:flex;align-items:center;justify-content:center;min-height:100vh;color:#334155}.wrap{text-align:center}.spinner{width:36px;height:36px;border:3px solid #e2e8f0;border-top-color:#2d7d7d;border-radius:50%;animation:spin .8s linear infinite;margin:0 auto 16px}@keyframes spin{to{transform:rotate(360deg)}}.title{font-size:14px;font-weight:600;color:#1e293b;margin-bottom:4px}.sub{font-size:13px;color:#64748b}</style></head><body><div class="wrap"><div class="spinner"></div><div class="title">Loading profile</div><div class="sub">${clickedCoAuthor.name.replace(/'/g, '&#39;')}</div></div></body></html>`);
+                    newWindow.document.close();
+                  }
                   setScholarIdLookup({ loading: true, scholarId: null, notFound: false });
                   try {
-                    // Search OpenAlex for co-author → get their Google Scholar external ID
-                    const searchUrl = `https://api.openalex.org/authors?search=${encodeURIComponent(clickedCoAuthor.name)}&per_page=5&select=id,display_name,ids&mailto=info@scholarfolio.org`;
-                    const resp = await fetch(searchUrl, { signal: timeoutSignal(10000) });
-                    const data = await resp.json();
-                    const results = data?.results || [];
-                    // Find best match by name
-                    const nameLower = clickedCoAuthor.name.toLowerCase().trim();
-                    const match = results.find((r: { display_name: string }) => r.display_name.toLowerCase().trim() === nameLower) || results[0];
-                    const gsUrl = match?.ids?.google_scholar as string | undefined;
-                    if (gsUrl) {
-                      // Extract Scholar ID from URL like "https://scholar.google.com/citations?user=ABC123"
-                      const gsMatch = gsUrl.match(/user=([A-Za-z0-9_-]+)/);
-                      if (gsMatch) {
-                        setScholarIdLookup({ loading: false, scholarId: gsMatch[1], notFound: false });
-                        window.open(`${window.location.origin}/?user=${gsMatch[1]}`, '_blank');
-                        return;
+                    const results = await scholarService.searchAuthors(clickedCoAuthor.name);
+                    if (results.length >= 1) {
+                      const authorId = results[0].authorId;
+                      setScholarIdLookup({ loading: false, scholarId: authorId, notFound: false });
+                      if (newWindow) {
+                        newWindow.location.href = `${window.location.origin}/?user=${encodeURIComponent(authorId)}`;
                       }
+                    } else {
+                      setScholarIdLookup({ loading: false, scholarId: null, notFound: true });
+                      newWindow?.close();
                     }
-                    setScholarIdLookup({ loading: false, scholarId: null, notFound: true });
                   } catch {
                     setScholarIdLookup({ loading: false, scholarId: null, notFound: true });
+                    newWindow?.close();
                   }
                 }}
                 className="w-full flex items-center justify-center gap-2 py-2.5 text-sm font-medium rounded-lg bg-[#2d7d7d] text-white hover:bg-[#1f5c5c] transition-colors"
@@ -663,11 +663,6 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
               >
                 <Share2 className="h-4 w-4" /> Share with {clickedCoAuthor.name.split(' ')[0]}
               </button>
-              {scholarIdLookup.notFound && (
-                <p className="text-xs text-center text-gray-400 dark:text-gray-500 mt-1">
-                  No Google Scholar profile found. Share the link so they can create one!
-                </p>
-              )}
             </div>
           </div>
         </div>

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -20,6 +20,7 @@ import { supabase } from '../lib/supabase';
 import type { Author, CoAuthorGeoData } from '../types/scholar';
 import type { PIndexResult } from '../services/openalex/pindex';
 import { fetchCoAuthorGeoData } from '../services/openalex/coauthor-geo';
+import { scholarService } from '../services/scholar';
 import { extractLastName } from '../utils/names';
 import { useFeedback } from '../hooks/useFeedback';
 import { FeedbackModal } from './FeedbackModal';
@@ -516,7 +517,20 @@ export function ProfileView({
 
         {activeTab === 'network' && (
           <div className="w-full">
-            <CitationNetwork publications={data.publications} fullScreen={true} />
+            <CitationNetwork publications={data.publications} fullScreen={true} onCoAuthorClick={(name) => {
+              const newWindow = window.open('about:blank', '_blank');
+              if (newWindow) {
+                newWindow.document.write(`<!DOCTYPE html><html><head><title>Scholar Folio</title><style>*{margin:0;padding:0;box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f8fafa;display:flex;align-items:center;justify-content:center;min-height:100vh;color:#334155}.wrap{text-align:center}.spinner{width:36px;height:36px;border:3px solid #e2e8f0;border-top-color:#2d7d7d;border-radius:50%;animation:spin .8s linear infinite;margin:0 auto 16px}@keyframes spin{to{transform:rotate(360deg)}}.title{font-size:14px;font-weight:600;color:#1e293b;margin-bottom:4px}.sub{font-size:13px;color:#64748b}</style></head><body><div class="wrap"><div class="spinner"></div><div class="title">Loading profile</div><div class="sub">${name.replace(/'/g, '&#39;')}</div></div></body></html>`);
+                newWindow.document.close();
+              }
+              scholarService.searchAuthors(name).then(results => {
+                if (results.length >= 1 && newWindow) {
+                  newWindow.location.href = `${window.location.origin}?user=${encodeURIComponent(results[0].authorId)}`;
+                } else {
+                  newWindow?.close();
+                }
+              }).catch(() => newWindow?.close());
+            }} />
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- World map: switched from OpenAlex IDs lookup (rarely has Scholar IDs) to SerpAPI via `scholarService.searchAuthors` — same reliable method as the narrative
- Citation network: double-click any co-author node to open their profile
- Both use the popup-blocker-safe pattern (open window immediately, navigate after search)

## Test plan
- [ ] Click co-author dot on world map → new tab opens with loading spinner → navigates to their profile
- [ ] Double-click co-author node in network graph → same behavior
- [ ] If co-author not found, window closes gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)