### PR TITLE
Fix co-author lookup using full OpenAlex names

### DIFF
--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -624,7 +624,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
                   }
                   setScholarIdLookup({ loading: true, scholarId: null, notFound: false });
                   try {
-                    const results = await scholarService.searchAuthors(clickedCoAuthor.name);
+                    const results = await scholarService.searchAuthors(clickedCoAuthor.fullName || clickedCoAuthor.name);
                     if (results.length >= 1) {
                       const authorId = results[0].authorId;
                       setScholarIdLookup({ loading: false, scholarId: authorId, notFound: false });


### PR DESCRIPTION
## Summary
- Uses `fullName` from OpenAlex (e.g. "Dominik Mahr") instead of abbreviated Google Scholar name (e.g. "D Mahr") when searching for co-author profiles on the world map
- Fixes "Author not found on Google Scholar" errors that occurred because SerpAPI couldn't match abbreviated names

## Test plan
- [ ] Click a co-author dot on the world map
- [ ] Verify the Scholar lookup finds the correct profile
- [ ] Confirm the new tab navigates to the co-author's ScholarFolio page

🤖 Generated with [Claude Code](https://claude.com/claude-code)