### PR TITLE
Add fullName to CoAuthorGeoData for Scholar lookup

### DIFF
--- a/src/services/openalex/coauthor-geo.ts
+++ b/src/services/openalex/coauthor-geo.ts
@@ -220,6 +220,7 @@ export async function fetchCoAuthorGeoData(
     if (!geo) continue;
     coAuthors.push({
       name: m.sfName,
+      fullName: m.oaInfo.displayName,
       institution: m.oaInfo.institutionName,
       countryCode: m.oaInfo.countryCode,
       lat: geo.lat,

--- a/src/types/scholar.ts
+++ b/src/types/scholar.ts
@@ -119,6 +119,8 @@ export interface Author {
 
 export interface CoAuthorGeoData {
   name: string;
+  /** Full display name from OpenAlex (for reliable Scholar search) */
+  fullName?: string;
   institution: string;
   countryCode: string;
   lat: number;


### PR DESCRIPTION
## Summary
- Adds `fullName?: string` to `CoAuthorGeoData` type
- Populates it from OpenAlex `displayName` in `coauthor-geo.ts`
- Required companion to PR #184 which uses `fullName` for the search

## Test plan
- [ ] Load a profile with co-authors on world map
- [ ] Click a co-author dot — verify lookup uses full name and finds the author

🤖 Generated with [Claude Code](https://claude.com/claude-code)