### PR TITLE
Add Scholar search fallback for co-author lookup

### DIFF
--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -616,6 +616,11 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
                     window.open(`${window.location.origin}/?user=${scholarIdLookup.scholarId}`, '_blank');
                     return;
                   }
+                  if (scholarIdLookup.notFound) {
+                    const searchName = clickedCoAuthor.fullName || clickedCoAuthor.name;
+                    window.open(`https://scholar.google.com/citations?view_op=search_authors&mauthors=${encodeURIComponent(searchName)}`, '_blank');
+                    return;
+                  }
                   // Open window immediately to avoid popup blocker
                   const newWindow = window.open('about:blank', '_blank');
                   if (newWindow) {
@@ -633,11 +638,17 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
                       }
                     } else {
                       setScholarIdLookup({ loading: false, scholarId: null, notFound: true });
-                      newWindow?.close();
+                      if (newWindow) {
+                        const searchName = clickedCoAuthor.fullName || clickedCoAuthor.name;
+                        newWindow.location.href = `https://scholar.google.com/citations?view_op=search_authors&mauthors=${encodeURIComponent(searchName)}`;
+                      }
                     }
                   } catch {
                     setScholarIdLookup({ loading: false, scholarId: null, notFound: true });
-                    newWindow?.close();
+                    if (newWindow) {
+                      const searchName = clickedCoAuthor.fullName || clickedCoAuthor.name;
+                      newWindow.location.href = `https://scholar.google.com/citations?view_op=search_authors&mauthors=${encodeURIComponent(searchName)}`;
+                    }
                   }
                 }}
                 className="w-full flex items-center justify-center gap-2 py-2.5 text-sm font-medium rounded-lg bg-[#2d7d7d] text-white hover:bg-[#1f5c5c] transition-colors"
@@ -645,7 +656,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
                 {scholarIdLookup.loading ? (
                   <><Loader2 className="h-4 w-4 animate-spin" /> Looking up profile...</>
                 ) : scholarIdLookup.notFound ? (
-                  <><ExternalLink className="h-4 w-4" /> Not found on Google Scholar</>
+                  <><ExternalLink className="h-4 w-4" /> Search on Google Scholar</>
                 ) : (
                   <><ExternalLink className="h-4 w-4" /> View on ScholarFolio</>
                 )}

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -526,10 +526,14 @@ export function ProfileView({
               scholarService.searchAuthors(name).then(results => {
                 if (results.length >= 1 && newWindow) {
                   newWindow.location.href = `${window.location.origin}?user=${encodeURIComponent(results[0].authorId)}`;
-                } else {
-                  newWindow?.close();
+                } else if (newWindow) {
+                  newWindow.location.href = `https://scholar.google.com/citations?view_op=search_authors&mauthors=${encodeURIComponent(name)}`;
                 }
-              }).catch(() => newWindow?.close());
+              }).catch(() => {
+                if (newWindow) {
+                  newWindow.location.href = `https://scholar.google.com/citations?view_op=search_authors&mauthors=${encodeURIComponent(name)}`;
+                }
+              });
             }} />
           </div>
         )}


### PR DESCRIPTION
## Summary
- When co-author lookup fails (not found on ScholarFolio), redirects to Google Scholar author search instead of closing the tab
- World map: button changes to "Search on Google Scholar" and clicking opens the search
- Citation network: same fallback on double-click

## Test plan
- [ ] Click co-author on world map → if found, opens ScholarFolio profile
- [ ] Click co-author on world map → if NOT found, opens Google Scholar search for that name
- [ ] Double-click co-author on network graph → same fallback behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)