### PR TITLE
Fix self-detection for profiles with title suffixes

### DIFF
--- a/src/services/metrics/collaboration/co-author-metrics.ts
+++ b/src/services/metrics/collaboration/co-author-metrics.ts
@@ -12,6 +12,7 @@ interface CoAuthorStats {
   topCoAuthorLastYear: number;
   topCoAuthorFirstPaper: string;
   topCoAuthorLastPaper: string;
+  topCoAuthors: Array<{ name: string; papers: number }>;
 }
 
 export function calculateCoAuthorMetrics(publications: Publication[], authorName: string): CoAuthorStats {
@@ -35,8 +36,11 @@ export function calculateCoAuthorMetrics(publications: Publication[], authorName
       .replace(/[.,]/g, '');
   };
 
+  // Strip title suffixes like " - Full Professor" or " - Associate Professor"
+  const cleanAuthorName = authorName.replace(/\s*[-–—]\s*(Full|Associate|Assistant|Emeritus|Adjunct|Visiting|Research)?\s*(Professor|Lecturer|Fellow|Director|Dean|Chair|Researcher|Scientist|Engineer|Doctor|PhD|Dr)\b.*/i, '').trim() || authorName;
+
   // Create variations of the main author's name for matching
-  const mainAuthorNormalized = normalizeAuthorName(authorName);
+  const mainAuthorNormalized = normalizeAuthorName(cleanAuthorName);
   const mainAuthorParts = mainAuthorNormalized.split(' ');
   const mainAuthorVariations = [
     mainAuthorNormalized,
@@ -100,6 +104,13 @@ export function calculateCoAuthorMetrics(publications: Publication[], authorName
     }
   });
 
+  // Top co-authors sorted by paper count (max 4, min 2 papers each)
+  const topCoAuthors = [...coAuthorCounts.entries()]
+    .sort((a, b) => b[1].count - a[1].count)
+    .slice(0, 4)
+    .filter(([, d]) => d.count >= 2)
+    .map(([name, d]) => ({ name, papers: d.count }));
+
   return {
     totalCoAuthors: coAuthorCounts.size,
     averageAuthors: parseFloat((totalAuthors / publications.length).toFixed(1)),
@@ -111,6 +122,7 @@ export function calculateCoAuthorMetrics(publications: Publication[], authorName
     topCoAuthorFirstYear: topCoAuthorData.firstYear,
     topCoAuthorLastYear: topCoAuthorData.lastYear,
     topCoAuthorFirstPaper: topCoAuthorData.firstPaper,
-    topCoAuthorLastPaper: topCoAuthorData.lastPaper
+    topCoAuthorLastPaper: topCoAuthorData.lastPaper,
+    topCoAuthors
   };
 }

--- a/src/services/metrics/index.ts
+++ b/src/services/metrics/index.ts
@@ -139,6 +139,7 @@ class MetricsCalculator {
       topCoAuthorLastYear: 0,
       topCoAuthorFirstPaper: '',
       topCoAuthorLastPaper: '',
+      topCoAuthors: [],
       citationHalfLife: 0,
       citationGini: 0,
       ageNormalizedRate: 0,

--- a/src/services/scholar/index.ts
+++ b/src/services/scholar/index.ts
@@ -139,7 +139,14 @@ async function fetchViaEdgeFunction(normalizedUrl: string, cacheOnly?: boolean) 
   return data;
 }
 
+/** Strip academic title suffixes from profile names (e.g. "Name - Full Professor" → "Name") */
+function stripTitleSuffix(name: string): string {
+  return name.replace(/\s*[-–—]\s*(Full|Associate|Assistant|Emeritus|Adjunct|Visiting|Research|Senior|Junior|Distinguished|Clinical|Tenured)?\s*(Professor|Lecturer|Fellow|Director|Dean|Chair|Researcher|Scientist|Engineer|Doctor|PhD|Dr|MD|Instructor|Postdoc|PostDoc)\b.*/i, '').trim() || name;
+}
+
 function buildAuthorResult(data: any): Author {
+  const cleanName = stripTitleSuffix(data.name || '');
+
   const publications = (data.publications || []).map(pub => ({
     ...pub,
     journalRanking: pub.journalRanking || findJournalRanking(pub.venue)
@@ -151,7 +158,7 @@ function buildAuthorResult(data: any): Author {
   const metrics = metricsCalculator.calculateMetrics(
     publications,
     data.metrics?.citationsPerYear || {},
-    data.name
+    cleanName
   );
 
   // Propagate the citation graph source from the edge function response
@@ -160,7 +167,7 @@ function buildAuthorResult(data: any): Author {
   }
 
   return {
-    name: data.name,
+    name: cleanName,
     affiliation: data.affiliation || '',
     imageUrl: data.imageUrl,
     topics: data.topics || [],

--- a/src/services/scholar/metrics.ts
+++ b/src/services/scholar/metrics.ts
@@ -203,8 +203,11 @@ export class MetricsCalculator {
         .replace(/[.,]/g, '');
     };
 
+    // Strip title suffixes like " - Full Professor" before matching
+    const cleanAuthorName = authorName.replace(/\s*[-–—]\s*(Full|Associate|Assistant|Emeritus|Adjunct|Visiting|Research)?\s*(Professor|Lecturer|Fellow|Director|Dean|Chair|Researcher|Scientist|Engineer|Doctor|PhD|Dr)\b.*/i, '').trim() || authorName;
+
     // Normalize the main author's name and create variations for matching
-    const mainAuthorNormalized = normalizeAuthorName(authorName);
+    const mainAuthorNormalized = normalizeAuthorName(cleanAuthorName);
     const mainAuthorParts = mainAuthorNormalized.split(' ');
     const mainAuthorVariations = [
       mainAuthorNormalized,


### PR DESCRIPTION
## Summary
- Strip academic title suffixes (e.g. "- Full Professor") from `data.name` before use
- Fixes profiles like "Annouk Lievens - Full Professor" showing the author as their own top co-author
- Adds `topCoAuthors` array to metrics calculator (was missing, causing "Other frequent co-authors" sentence to never appear)
- Clean name used for display, OpenAlex lookups, and co-author matching

## Test plan
- [ ] Load "Annouk Lievens" profile — should NOT show self as top co-author
- [ ] Verify "Other frequent co-authors include X, Y, Z" appears in narrative
- [ ] World map should find the author on OpenAlex (no "No geographic data" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)