### PR TITLE
Store multi-source IDs in coauthor_links

### DIFF
--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -663,7 +663,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
                     });
                     if (match) {
                       // Save to cache for future lookups
-                      saveCoAuthorLink({ name: searchName, scholarId: match.authorId, institution: clickedCoAuthor.institution }).catch(() => {});
+                      saveCoAuthorLink({ name: searchName, scholarId: match.authorId, openalexId: clickedCoAuthor.openalexId, institution: clickedCoAuthor.institution }).catch(() => {});
                       setScholarIdLookup({ loading: false, scholarId: match.authorId, notFound: false });
                       if (newWindow) {
                         newWindow.location.href = `${window.location.origin}/?user=${encodeURIComponent(match.authorId)}`;
@@ -717,6 +717,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
                           name: searchName,
                           scholarId,
                           scholarUrl: urlInputValue,
+                          openalexId: clickedCoAuthor.openalexId,
                           institution: clickedCoAuthor.institution,
                         }).catch(() => {});
                         setScholarIdLookup({ loading: false, scholarId, notFound: false });

--- a/src/services/coauthor-links.ts
+++ b/src/services/coauthor-links.ts
@@ -4,9 +4,11 @@ function normalizeName(name: string): string {
   return name.toLowerCase().trim().replace(/\s+/g, ' ').replace(/[.,]/g, '');
 }
 
-interface CoAuthorLink {
+export interface CoAuthorLink {
   scholar_id: string | null;
   openalex_id: string | null;
+  orcid: string | null;
+  s2_author_id: string | null;
   name: string;
 }
 
@@ -15,19 +17,21 @@ export async function lookupCoAuthorLink(name: string): Promise<CoAuthorLink | n
   const normalized = normalizeName(name);
   const { data } = await supabase
     .from('coauthor_links')
-    .select('scholar_id, openalex_id, name')
+    .select('scholar_id, openalex_id, orcid, s2_author_id, name')
     .eq('name_normalized', normalized)
     .limit(1)
     .single();
   return data ?? null;
 }
 
-/** Save a verified co-author → Scholar mapping (upsert by normalized name) */
+/** Save a verified co-author link (upsert by normalized name, merges fields) */
 export async function saveCoAuthorLink(params: {
   name: string;
-  scholarId: string;
+  scholarId?: string;
   scholarUrl?: string;
   openalexId?: string;
+  orcid?: string;
+  s2AuthorId?: string;
   institution?: string;
   contributedBy?: string;
 }): Promise<void> {
@@ -36,19 +40,22 @@ export async function saveCoAuthorLink(params: {
   // Check if exists
   const { data: existing } = await supabase
     .from('coauthor_links')
-    .select('id')
+    .select('id, scholar_id, openalex_id, orcid, s2_author_id')
     .eq('name_normalized', normalized)
     .limit(1)
     .single();
 
   if (existing) {
+    // Merge: only overwrite fields that are being provided (don't null out existing data)
     await supabase
       .from('coauthor_links')
       .update({
-        scholar_id: params.scholarId,
-        scholar_url: params.scholarUrl ?? null,
-        openalex_id: params.openalexId ?? null,
-        institution: params.institution ?? null,
+        ...(params.scholarId && { scholar_id: params.scholarId }),
+        ...(params.scholarUrl && { scholar_url: params.scholarUrl }),
+        ...(params.openalexId && { openalex_id: params.openalexId }),
+        ...(params.orcid && { orcid: params.orcid }),
+        ...(params.s2AuthorId && { s2_author_id: params.s2AuthorId }),
+        ...(params.institution && { institution: params.institution }),
         updated_at: new Date().toISOString(),
       })
       .eq('id', existing.id);
@@ -58,9 +65,11 @@ export async function saveCoAuthorLink(params: {
       .insert({
         name: params.name,
         name_normalized: normalized,
-        scholar_id: params.scholarId,
+        scholar_id: params.scholarId ?? null,
         scholar_url: params.scholarUrl ?? null,
         openalex_id: params.openalexId ?? null,
+        orcid: params.orcid ?? null,
+        s2_author_id: params.s2AuthorId ?? null,
         institution: params.institution ?? null,
         contributed_by: params.contributedBy ?? null,
       });

--- a/src/services/openalex/coauthor-geo.ts
+++ b/src/services/openalex/coauthor-geo.ts
@@ -221,6 +221,7 @@ export async function fetchCoAuthorGeoData(
     coAuthors.push({
       name: m.sfName,
       fullName: m.oaInfo.displayName,
+      openalexId: m.oaInfo.oaId,
       institution: m.oaInfo.institutionName,
       countryCode: m.oaInfo.countryCode,
       lat: geo.lat,

--- a/src/types/scholar.ts
+++ b/src/types/scholar.ts
@@ -121,6 +121,8 @@ export interface CoAuthorGeoData {
   name: string;
   /** Full display name from OpenAlex (for reliable Scholar search) */
   fullName?: string;
+  /** OpenAlex author ID */
+  openalexId?: string;
   institution: string;
   countryCode: string;
   lat: number;


### PR DESCRIPTION
## Summary
- Added `orcid` and `s2_author_id` columns to `coauthor_links` table
- Added `openalexId` to `CoAuthorGeoData` interface, populated from geo lookup
- `saveCoAuthorLink` now uses merge-upsert (only overwrites provided fields, preserves existing)
- OpenAlex ID saved alongside Scholar ID on every successful world map lookup

## ID sources mapped per co-author
| Source | Field | Populated when |
|---|---|---|
| Google Scholar | `scholar_id` | Auto-found or manually linked by user |
| OpenAlex | `openalex_id` | Always (from world map data) |
| ORCID | `orcid` | Future: from OpenAlex author record |
| Semantic Scholar | `s2_author_id` | Future: from paper enrichment |

🤖 Generated with [Claude Code](https://claude.com/claude-code)