### PR TITLE
Fix name normalization merging different people

### DIFF
--- a/src/utils/names.ts
+++ b/src/utils/names.ts
@@ -108,6 +108,14 @@ export function normalizeAuthorNames(publications: { authors: string[] }[]): typ
     groups.get(key)!.push(name);
   }
 
+  // Count non-initial words before the last name (words with >2 chars that aren't the last name)
+  function nonInitialWordCount(name: string): number {
+    const lastName = extractLastName(name);
+    const before = name.slice(0, name.length - lastName.length).trim();
+    if (!before) return 0;
+    return before.split(/\s+/).filter(w => w.replace(/[.,]/g, '').length > 2).length;
+  }
+
   // For each group with >1 variant, pick canonical and build replacement map
   const replacements = new Map<string, string>();
   for (const variants of groups.values()) {
@@ -119,11 +127,16 @@ export function normalizeAuthorNames(publications: { authors: string[] }[]): typ
     ));
     if (baseLastNames.size > 1) continue;
 
-    // Pick canonical: prefer longest name (most complete), break ties by frequency
+    // Safety check: reject groups where variants have different numbers of
+    // non-initial words before the last name (e.g. "J Bloemer" vs "J Sit Bloemer")
+    const wordCounts = new Set(variants.map(nonInitialWordCount));
+    if (wordCounts.size > 1) continue;
+
+    // Pick canonical: prefer most frequent name, break ties by length (most complete)
     const canonical = variants.sort((a, b) => {
-      const lenDiff = b.length - a.length;
-      if (lenDiff !== 0) return lenDiff;
-      return (nameFreq.get(b) || 0) - (nameFreq.get(a) || 0);
+      const freqDiff = (nameFreq.get(b) || 0) - (nameFreq.get(a) || 0);
+      if (freqDiff !== 0) return freqDiff;
+      return b.length - a.length;
     })[0];
 
     for (const v of variants) {


### PR DESCRIPTION
## Summary
- **"J Sit Bloemer" bug**: Added safety check rejecting merges where variants have different numbers of non-initial words before the last name. "J Sit" and "J Bloemer" can no longer merge into one person.
- **"M de Wetzels" bug**: Changed canonical selection from length-first to frequency-first. The rare "M de Wetzels" variant (with spurious "de") no longer overrides the common "M Wetzels".

## Test plan
- [ ] Load Ko de Ruyter profile — "J Bloemer" should appear separately, not as "J Sit Bloemer"
- [ ] Top co-author should be "M Wetzels" not "M de Wetzels"
- [ ] Other profiles with compound last names (e.g. "Ko de Ruyter") should still normalize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)