### PR TITLE
Fix P-Index institution extraction from affiliation

### DIFF
--- a/src/components/PIndexSection.tsx
+++ b/src/components/PIndexSection.tsx
@@ -72,10 +72,15 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
     return parts.slice(surnameStart).join(' ');
   });
   const [institution, setInstitution] = useState(() => {
-    const stripped = affiliation.replace(/^(Assistant|Associate|Full|Adjunct|Visiting|Emeritus)?\s*(Professor|Lecturer|Researcher|Fellow|Instructor)\s*(of|in|for|,)\s*/i, '');
-    if (stripped !== affiliation) return stripped.replace(/^,\s*/, '').trim();
-    const parts = affiliation.split(',');
-    return parts[parts.length - 1].trim();
+    // Strip academic titles like "Full Professor, " or "Associate Professor of Marketing, "
+    let cleaned = affiliation
+      .replace(/^(Distinguished|Emeritus|Adjunct|Visiting|Clinical|Tenured|Senior|Junior|Assistant|Associate|Full)?\s*(Professor|Lecturer|Researcher|Fellow|Instructor|Reader|Chair|Director|Dean)\s*(of\s+\w[\w\s]*?)?\s*[,·]\s*/i, '')
+      .trim();
+    if (cleaned === affiliation) cleaned = affiliation;
+    const parts = cleaned.split(',').map(p => p.trim()).filter(Boolean);
+    // Skip "Department of X" / "School of X" / "Faculty of X" parts — prefer the university name
+    const inst = parts.find(p => !/^(Department|School|Faculty|Division|Institute|Center|Centre|College)\s+(of|for)\s+/i.test(p)) || parts[0] || affiliation;
+    return inst;
   });
 
   const includedCount = useMemo(() => allWorks.length - excludedIds.size, [allWorks, excludedIds]);


### PR DESCRIPTION
## Summary
The institution field in the P-Index search form was pulling wrong values:
- "United Kingdom" instead of "King's College" (took last comma part)
- Research topic instead of university (no title stripping)
- "Department of X" instead of the university name

Now:
1. Strips academic title prefixes ("Full Professor of Marketing, ")
2. Skips department/school/faculty parts
3. Takes the first institution-like part from the comma-separated affiliation

## Test plan
- [ ] "King's College, ..., United Kingdom" → shows "King's College"
- [ ] "Full Professor, Maastricht University" → shows "Maastricht University"
- [ ] "Professor, Department of Economics, University of Oxford" → shows "University of Oxford"

🤖 Generated with [Claude Code](https://claude.com/claude-code)