### PR TITLE
Add organic growth features: OG meta, trending, sharing, CTA

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,6 +22,13 @@
 [functions]
   directory = "netlify/functions"
 
+[edge_functions]
+  directory = "netlify/edge-functions"
+
+[[edge_functions]]
+  path = "/"
+  function = "og-meta"
+
 # Sitemap redirect must come before the SPA catch-all
 [[redirects]]
   from = "/sitemap.xml"

--- a/netlify/edge-functions/og-meta.ts
+++ b/netlify/edge-functions/og-meta.ts
@@ -1,0 +1,148 @@
+import type { Context } from '@netlify/edge-functions';
+
+const SUPABASE_URL = 'https://mixaxkywkojoclgbjjur.supabase.co';
+// Publishable anon key — safe to embed, same as client-side
+const SUPABASE_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1peGF4a3l3a29qb2NsZ2JqanVyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDIyMjg5NTcsImV4cCI6MjA1NzgwNDk1N30.sb_publishable_oKej73idzSJ1eJqwmgF5WQ_m2rvKae5';
+
+const CRAWLER_AGENTS = [
+  'facebookexternalhit',
+  'twitterbot',
+  'linkedinbot',
+  'slackbot',
+  'whatsapp',
+  'telegrambot',
+  'discordbot',
+];
+
+const DEFAULT_TITLE = 'ScholarFolio — Academic Research Profiles';
+const DEFAULT_DESCRIPTION =
+  'Explore research profiles, citation metrics, and co-author networks for academics worldwide.';
+const DEFAULT_IMAGE = 'https://scholarfolio.org/og-default.png';
+
+interface ScholarData {
+  name?: string;
+  affiliation?: string;
+  totalCitations?: number;
+  hIndex?: number;
+  imageUrl?: string;
+}
+
+function isCrawler(userAgent: string): boolean {
+  const ua = userAgent.toLowerCase();
+  return CRAWLER_AGENTS.some((bot) => ua.includes(bot));
+}
+
+async function fetchScholarData(userId: string): Promise<ScholarData | null> {
+  const scholarUrl = `https://scholar.google.com/citations?user=${encodeURIComponent(userId)}`;
+  const apiUrl = `${SUPABASE_URL}/rest/v1/scholar_cache?url=eq.${encodeURIComponent(scholarUrl)}&select=data&limit=1`;
+
+  try {
+    const res = await fetch(apiUrl, {
+      headers: {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+      },
+    });
+
+    if (!res.ok) return null;
+
+    const rows = await res.json();
+    if (!rows || rows.length === 0) return null;
+
+    return rows[0].data as ScholarData;
+  } catch {
+    return null;
+  }
+}
+
+function buildOgTags(data: ScholarData, userId: string): string {
+  const title = data.name ? `${data.name} — ScholarFolio` : DEFAULT_TITLE;
+
+  let description = DEFAULT_DESCRIPTION;
+  if (data.name) {
+    const parts: string[] = [];
+    if (data.affiliation) parts.push(data.affiliation);
+    if (data.totalCitations != null) parts.push(`${data.totalCitations} citations`);
+    if (data.hIndex != null) parts.push(`h-index ${data.hIndex}`);
+    if (parts.length > 0) description = parts.join(' · ');
+  }
+
+  const image = data.imageUrl || DEFAULT_IMAGE;
+  const url = `https://scholarfolio.org/?user=${userId}`;
+
+  return `
+    <meta property="og:title" content="${escapeAttr(title)}" />
+    <meta property="og:description" content="${escapeAttr(description)}" />
+    <meta property="og:image" content="${escapeAttr(image)}" />
+    <meta property="og:url" content="${escapeAttr(url)}" />
+    <meta property="og:type" content="profile" />
+    <meta property="og:site_name" content="ScholarFolio" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="${escapeAttr(title)}" />
+    <meta name="twitter:description" content="${escapeAttr(description)}" />`;
+}
+
+function escapeAttr(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function injectOgTags(html: string, tags: string): string {
+  // Remove any existing og: and twitter: meta tags from the static HTML
+  const cleaned = html
+    .replace(/<meta\s+property="og:[^"]*"[^>]*\/?>/gi, '')
+    .replace(/<meta\s+name="twitter:[^"]*"[^>]*\/?>/gi, '');
+
+  // Inject new tags before </head>
+  return cleaned.replace('</head>', `${tags}\n  </head>`);
+}
+
+export default async function handler(req: Request, context: Context): Promise<Response> {
+  const url = new URL(req.url);
+  const userId = url.searchParams.get('user');
+  const userAgent = req.headers.get('user-agent') || '';
+
+  // Pass through non-crawler requests immediately
+  if (!userId || !isCrawler(userAgent)) {
+    return context.next();
+  }
+
+  // Fetch the original HTML from the SPA
+  let originalResponse: Response;
+  try {
+    originalResponse = await context.next();
+  } catch {
+    return context.next();
+  }
+
+  // Only process HTML responses
+  const contentType = originalResponse.headers.get('content-type') || '';
+  if (!contentType.includes('text/html')) {
+    return originalResponse;
+  }
+
+  let html: string;
+  try {
+    html = await originalResponse.text();
+  } catch {
+    return originalResponse;
+  }
+
+  // Fetch scholar data from Supabase cache
+  const scholarData = await fetchScholarData(userId);
+  const ogTags = buildOgTags(scholarData || {}, userId);
+  const modifiedHtml = injectOgTags(html, ogTags);
+
+  return new Response(modifiedHtml, {
+    status: originalResponse.status,
+    headers: {
+      ...Object.fromEntries(originalResponse.headers.entries()),
+      'content-type': 'text/html; charset=utf-8',
+      'cache-control': 'public, max-age=300, s-maxage=300',
+    },
+  });
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { Linkedin, Github, ExternalLink } from 'lucide-react';
+import { Linkedin, Github, ExternalLink, TrendingUp } from 'lucide-react';
 import { ThemeToggle } from './components/ThemeToggle';
 import { AuthHeaderControls } from './components/AuthHeaderControls';
 import { LandingPage } from './components/LandingPage';
@@ -11,6 +11,7 @@ import { AdminDashboard } from './components/AdminDashboard';
 import { TermsPage } from './components/TermsPage';
 import { PrivacyPage } from './components/PrivacyPage';
 import { ChangelogPage } from './components/ChangelogPage';
+import { TrendingPage } from './components/TrendingPage';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { AuthButton } from './components/AuthButton';
 import { CreditPacks } from './components/CreditPacks';
@@ -32,7 +33,7 @@ const SOCIAL_LINKS = {
   github: 'https://github.com/JonasHeller1212/ResearchFolio'
 };
 
-type Page = 'home' | 'about' | 'terms' | 'privacy' | 'admin' | 'changelog';
+type Page = 'home' | 'about' | 'terms' | 'privacy' | 'admin' | 'changelog' | 'trending';
 
 function SocialLinks() {
   return (
@@ -76,6 +77,13 @@ function Footer({ onNavigate, onSupport }: { onNavigate: (page: Page) => void; o
           >
             GitHub <ExternalLink className="h-3 w-3" />
           </a>
+          <button
+            onClick={() => onNavigate('trending')}
+            className="text-sm text-[#3d9494] hover:text-white transition-colors inline-flex items-center gap-1"
+          >
+            <TrendingUp className="h-3 w-3" />
+            Trending
+          </button>
           <button
             onClick={() => onNavigate('about')}
             className="text-sm text-[#3d9494] hover:text-white transition-colors"
@@ -154,6 +162,10 @@ function AppContent() {
     const params = new URLSearchParams(window.location.search);
     if (params.get('page') === 'admin') {
       setPage('admin');
+      return;
+    }
+    if (params.get('page') === 'trending') {
+      setPage('trending');
       return;
     }
     const userParam = params.get('user');
@@ -394,6 +406,7 @@ function AppContent() {
       if (!isAdmin) { handleNavigate('home'); return null; }
       return <div className="page-enter"><AdminDashboard onBack={() => handleNavigate('home')} /></div>;
     }
+    if (page === 'trending') return <div className="page-enter"><TrendingPage onBack={() => handleNavigate('home')} /></div>;
     if (page === 'about') return <div className="page-enter"><AboutPage onBack={() => handleNavigate('home')} socialLinks={<SocialLinks />} authControls={authControls} /></div>;
     if (page === 'terms') return <div className="page-enter"><TermsPage onBack={() => handleNavigate('home')} /></div>;
     if (page === 'privacy') return <div className="page-enter"><PrivacyPage onBack={() => handleNavigate('home')} /></div>;

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock, ExternalLink, Heart, BadgeCheck, Link, Globe, FileText, MessageSquare } from 'lucide-react';
+import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock, ExternalLink, Heart, BadgeCheck, Link, Globe, FileText, MessageSquare, Mail, MapPin } from 'lucide-react';
 import { NarrativeCvTab } from './NarrativeCvTab';
 import { EmbedModal } from './EmbedModal';
 import { ClaimProfileModal } from './ClaimProfileModal';
@@ -25,6 +25,7 @@ import { extractLastName } from '../utils/names';
 import { useFeedback } from '../hooks/useFeedback';
 import { FeedbackModal } from './FeedbackModal';
 import { FeedbackPromptBanner } from './FeedbackPromptBanner';
+import { trackProfileView } from '../services/profile-views';
 import packageJson from '../../package.json';
 
 interface ProfileViewProps {
@@ -136,10 +137,15 @@ export function ProfileView({
     checkClaim();
   }, [scholarId, user?.id]);
 
-  // Track profile views for feedback prompt
+  // Track profile views for feedback prompt + trending leaderboard
   useEffect(() => {
-    if (scholarId) feedback.trackProfileView(scholarId);
-  }, [scholarId]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (scholarId) {
+      feedback.trackProfileView(scholarId);
+      if (data) {
+        trackProfileView(scholarId, data.name, data.affiliation ?? '');
+      }
+    }
+  }, [scholarId, data?.name]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Update document title and OG meta tags for link previews
   useEffect(() => {
@@ -177,10 +183,13 @@ export function ProfileView({
     setShowClaimModal(false);
   };
 
+  const [showShareMenu, setShowShareMenu] = useState(false);
+
   const handleShare = () => {
     const url = window.location.href;
     navigator.clipboard.writeText(url).then(() => {
       setCopied(true);
+      setShowShareMenu(false);
       setTimeout(() => setCopied(false), 2000);
     });
   };
@@ -259,13 +268,47 @@ export function ProfileView({
                 </h2>
                 <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">{data.affiliation}</p>
                 <div className="flex flex-wrap items-center gap-2">
-                  <button
-                    onClick={handleShare}
-                    className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] dark:text-[#5bbdbd] hover:text-[#1a5c5c] bg-[#eaf4f4] dark:bg-[#2d7d7d]/20 hover:bg-[#d5ecec] dark:hover:bg-[#2d7d7d]/30 px-2.5 py-1 rounded-full transition-colors"
-                  >
-                    {copied ? <Check className="h-3 w-3" /> : <Share2 className="h-3 w-3" />}
-                    {copied ? 'Link copied!' : 'Share profile'}
-                  </button>
+                  <div className="relative">
+                    <button
+                      onClick={() => setShowShareMenu(!showShareMenu)}
+                      className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] dark:text-[#5bbdbd] hover:text-[#1a5c5c] bg-[#eaf4f4] dark:bg-[#2d7d7d]/20 hover:bg-[#d5ecec] dark:hover:bg-[#2d7d7d]/30 px-2.5 py-1 rounded-full transition-colors"
+                    >
+                      {copied ? <Check className="h-3 w-3" /> : <Share2 className="h-3 w-3" />}
+                      {copied ? 'Link copied!' : 'Share profile'}
+                    </button>
+                    {showShareMenu && (
+                      <>
+                        <div className="fixed inset-0 z-40" onClick={() => setShowShareMenu(false)} />
+                        <div className="absolute left-0 top-full mt-1 z-50 bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-gray-200 dark:border-slate-700 py-1 min-w-[180px]">
+                          <button onClick={handleShare} className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700">
+                            <Link className="h-3 w-3" /> Copy link
+                          </button>
+                          <button onClick={() => {
+                            const text = `Check out ${data.name}'s research profile on ScholarFolio`;
+                            window.open(`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(window.location.href)}`, '_blank', 'width=600,height=400');
+                            setShowShareMenu(false);
+                          }} className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700">
+                            <ExternalLink className="h-3 w-3" /> Share on LinkedIn
+                          </button>
+                          <button onClick={() => {
+                            const text = `${data.name}'s research profile — ${data.totalCitations.toLocaleString()} citations, h-index ${data.hIndex}`;
+                            window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(window.location.href)}`, '_blank', 'width=600,height=400');
+                            setShowShareMenu(false);
+                          }} className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700">
+                            <ExternalLink className="h-3 w-3" /> Share on X
+                          </button>
+                          <button onClick={() => {
+                            const subject = `${data.name} — Research Profile`;
+                            const body = `Check out ${data.name}'s research profile on ScholarFolio:\n\n${data.affiliation}\n${data.totalCitations.toLocaleString()} citations · h-index ${data.hIndex}\n\n${window.location.href}`;
+                            window.location.href = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+                            setShowShareMenu(false);
+                          }} className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-slate-700">
+                            <Mail className="h-3 w-3" /> Send via email
+                          </button>
+                        </div>
+                      </>
+                    )}
+                  </div>
                   {scholarId && (
                     <button
                       onClick={() => setShowEmbed(true)}
@@ -377,6 +420,39 @@ export function ProfileView({
               <Heart className="h-3.5 w-3.5" />
               Support Scholar Folio
             </button>
+          </div>
+        )}
+
+        {/* Explore Co-Authors CTA */}
+        {data.metrics.totalCoAuthors > 0 && (
+          <div className="bg-gradient-to-r from-[#eaf4f4] to-[#e0f0f0] dark:from-[#2d7d7d]/15 dark:to-[#2d7d7d]/10 rounded-xl border border-[#2d7d7d]/10 dark:border-[#2d7d7d]/20 p-4 mb-6">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <div className="w-9 h-9 rounded-lg bg-white dark:bg-slate-800 flex items-center justify-center flex-shrink-0 shadow-sm">
+                  <Users className="h-4.5 w-4.5 text-[#2d7d7d]" />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Explore {data.name.split(' ')[0]}'s co-author network</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    Discover <strong>{data.metrics.totalCoAuthors}</strong> collaborators across the world map and citation network
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => { setActiveTab('worldmap'); }}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-[#2d7d7d] hover:bg-[#1f5c5c] rounded-lg transition-colors whitespace-nowrap"
+                >
+                  <MapPin className="h-3 w-3" /> World Map
+                </button>
+                <button
+                  onClick={() => { setActiveTab('network'); }}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-[#2d7d7d] bg-white dark:bg-slate-800 hover:bg-gray-50 dark:hover:bg-slate-700 border border-[#2d7d7d]/20 rounded-lg transition-colors whitespace-nowrap"
+                >
+                  <Network className="h-3 w-3" /> Network Graph
+                </button>
+              </div>
+            </div>
           </div>
         )}
 

--- a/src/components/TrendingPage.tsx
+++ b/src/components/TrendingPage.tsx
@@ -1,0 +1,164 @@
+import React, { useState, useEffect } from 'react';
+import { ArrowLeft, TrendingUp, Eye, ExternalLink } from 'lucide-react';
+import { Logo } from './Logo';
+import { fetchTrendingProfiles, fetchTotalViewCount, type TrendingProfile } from '../services/profile-views';
+
+type TimeRange = '7' | '30' | '0';
+
+const TIME_RANGE_LABELS: Record<TimeRange, string> = {
+  '7': '7 days',
+  '30': '30 days',
+  '0': 'All time',
+};
+
+interface TrendingPageProps {
+  onBack: () => void;
+}
+
+export function TrendingPage({ onBack }: TrendingPageProps) {
+  const [timeRange, setTimeRange] = useState<TimeRange>('7');
+  const [profiles, setProfiles] = useState<TrendingProfile[]>([]);
+  const [totalViews, setTotalViews] = useState<number>(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+
+    const days = parseInt(timeRange, 10);
+
+    Promise.all([
+      fetchTrendingProfiles(days, 20),
+      fetchTotalViewCount(days),
+    ]).then(([profilesResult, viewCount]) => {
+      if (!cancelled) {
+        setProfiles(profilesResult);
+        setTotalViews(viewCount);
+        setLoading(false);
+      }
+    }).catch(() => {
+      if (!cancelled) setLoading(false);
+    });
+
+    return () => { cancelled = true; };
+  }, [timeRange]);
+
+  return (
+    <main className="flex-1 min-h-screen bg-gray-50 dark:bg-gray-950">
+      <nav className="border-b border-gray-200/60 bg-white/60 dark:bg-gray-900/60 backdrop-blur-lg sticky top-0 z-10">
+        <div className="max-w-4xl mx-auto px-6 h-14 flex items-center gap-3">
+          <button
+            onClick={onBack}
+            className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4 text-gray-500" />
+          </button>
+          <Logo size={28} />
+          <span className="font-semibold text-gray-900 dark:text-gray-100 text-sm tracking-tight">Scholar Folio</span>
+        </div>
+      </nav>
+
+      <div className="max-w-4xl mx-auto px-6 py-12">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-2">
+          <TrendingUp className="h-6 w-6 text-[#2d7d7d]" />
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Trending Profiles</h1>
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
+          Most-viewed researcher profiles on Scholar Folio
+        </p>
+
+        {/* Stats + Time range */}
+        <div className="flex flex-col sm:flex-row sm:items-center gap-4 mb-8">
+          <div className="flex items-center gap-2 bg-[#eaf4f4] dark:bg-[#2d7d7d]/10 border border-[#2d7d7d]/20 rounded-xl px-4 py-2.5">
+            <Eye className="h-4 w-4 text-[#2d7d7d]" />
+            <span className="text-sm font-semibold text-[#2d7d7d]">
+              {loading ? '—' : totalViews.toLocaleString()}
+            </span>
+            <span className="text-sm text-[#2d7d7d]/70">
+              {timeRange === '0' ? 'total views' : `views in ${TIME_RANGE_LABELS[timeRange]}`}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-1 ml-auto bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl p-1">
+            {(Object.entries(TIME_RANGE_LABELS) as [TimeRange, string][]).map(([value, label]) => (
+              <button
+                key={value}
+                onClick={() => setTimeRange(value)}
+                className={`px-3 py-1.5 text-sm rounded-lg transition-colors font-medium ${
+                  timeRange === value
+                    ? 'bg-[#2d7d7d] text-white'
+                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Leaderboard */}
+        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 overflow-hidden">
+          {loading ? (
+            <div className="py-20 flex items-center justify-center">
+              <div className="h-6 w-6 border-2 border-[#2d7d7d] border-t-transparent rounded-full animate-spin" />
+            </div>
+          ) : profiles.length === 0 ? (
+            <div className="py-20 text-center">
+              <TrendingUp className="h-8 w-8 text-gray-300 dark:text-gray-600 mx-auto mb-3" />
+              <p className="text-sm text-gray-500 dark:text-gray-400">No profile views recorded yet</p>
+              <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">Come back after some profiles have been visited</p>
+            </div>
+          ) : (
+            <ul>
+              {profiles.map((profile, index) => (
+                <li
+                  key={profile.scholar_id}
+                  className="flex items-center gap-4 px-6 py-4 border-b border-gray-100 dark:border-gray-800 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+                >
+                  {/* Rank */}
+                  <span className={`text-sm font-bold w-6 text-center shrink-0 ${
+                    index === 0 ? 'text-amber-500' :
+                    index === 1 ? 'text-gray-400' :
+                    index === 2 ? 'text-amber-700' :
+                    'text-gray-400 dark:text-gray-500'
+                  }`}>
+                    {index + 1}
+                  </span>
+
+                  {/* Author info */}
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+                      {profile.author_name ?? 'Unknown Author'}
+                    </p>
+                    {profile.affiliation && (
+                      <p className="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5">
+                        {profile.affiliation}
+                      </p>
+                    )}
+                  </div>
+
+                  {/* View count */}
+                  <div className="flex items-center gap-1 shrink-0">
+                    <Eye className="h-3.5 w-3.5 text-gray-400" />
+                    <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+                      {profile.view_count.toLocaleString()}
+                    </span>
+                  </div>
+
+                  {/* View profile button */}
+                  <a
+                    href={`/?user=${encodeURIComponent(profile.scholar_id)}`}
+                    className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-[#2d7d7d] text-white hover:bg-[#25696a] transition-colors"
+                  >
+                    View <ExternalLink className="h-3 w-3" />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/services/profile-views.ts
+++ b/src/services/profile-views.ts
@@ -1,0 +1,42 @@
+import { supabase } from '../lib/supabase';
+
+export interface TrendingProfile {
+  scholar_id: string;
+  author_name: string | null;
+  affiliation: string | null;
+  view_count: number;
+}
+
+/** Fire-and-forget: track a profile view */
+export function trackProfileView(scholarId: string, authorName: string, affiliation: string): void {
+  supabase
+    .from('profile_views')
+    .insert({ scholar_id: scholarId, author_name: authorName, affiliation })
+    .then(() => {})
+    .catch(() => {});
+}
+
+/** Fetch trending profiles using server-side aggregation */
+export async function fetchTrendingProfiles(days: number = 7, limit: number = 20): Promise<TrendingProfile[]> {
+  const { data, error } = await supabase.rpc('trending_profiles', {
+    days_ago: days,
+    max_results: limit,
+  });
+  if (error || !data) return [];
+  return data as TrendingProfile[];
+}
+
+/** Get total view count */
+export async function fetchTotalViewCount(days: number = 0): Promise<number> {
+  let query = supabase
+    .from('profile_views')
+    .select('id', { count: 'exact', head: true });
+
+  if (days > 0) {
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+    query = query.gte('viewed_at', since);
+  }
+
+  const { count } = await query;
+  return count ?? 0;
+}


### PR DESCRIPTION
## Summary
- **OG meta edge function** — injects dynamic OpenGraph tags (title, description, image) for social media crawlers (Facebook, Twitter, LinkedIn, Slack, etc.)
- **Trending profiles page** — leaderboard at `?page=trending` with 7d/30d/all-time tabs, powered by `profile_views` table + `trending_profiles` RPC
- **Enhanced share dropdown** — LinkedIn, X, email, and copy link options replace the single copy button
- **Explore Co-Authors CTA** — banner below metrics linking to World Map and Network Graph tabs
- **Profile view tracking** — fire-and-forget inserts to `profile_views` for trending leaderboard

## Test plan
- [ ] Share a profile link on LinkedIn/X and verify OG preview card shows name, affiliation, citations
- [ ] Visit `?page=trending` and verify leaderboard renders with time range tabs
- [ ] Click "Share profile" and verify dropdown with all 4 options
- [ ] Verify "Explore co-author network" CTA appears and navigates to correct tabs
- [ ] Check dark mode styling for all new components