### PR TITLE
Add ORCID login

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,6 +29,12 @@
   path = "/"
   function = "og-meta"
 
+# ORCID OAuth callback
+[[redirects]]
+  from = "/api/orcid-callback"
+  to = "/.netlify/functions/orcid-callback"
+  status = 200
+
 # Sitemap redirect must come before the SPA catch-all
 [[redirects]]
   from = "/sitemap.xml"

--- a/netlify/functions/orcid-callback.ts
+++ b/netlify/functions/orcid-callback.ts
@@ -1,0 +1,131 @@
+import type { Handler, HandlerEvent } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+const ORCID_TOKEN_URL = 'https://orcid.org/oauth/token';
+const SITE_URL = 'https://scholarfolio.org';
+
+const handler: Handler = async (event: HandlerEvent) => {
+  const code = event.queryStringParameters?.code;
+  const error = event.queryStringParameters?.error;
+
+  if (error || !code) {
+    return {
+      statusCode: 302,
+      headers: { Location: `${SITE_URL}?orcid_error=access_denied` },
+    };
+  }
+
+  const clientId = process.env.ORCID_CLIENT_ID;
+  const clientSecret = process.env.ORCID_CLIENT_SECRET;
+  const supabaseUrl = process.env.VITE_SUPABASE_URL || 'https://mixaxkywkojoclgbjjur.supabase.co';
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!clientId || !clientSecret || !serviceRoleKey) {
+    return {
+      statusCode: 302,
+      headers: { Location: `${SITE_URL}?orcid_error=config` },
+    };
+  }
+
+  // Exchange authorization code for access token + ORCID iD
+  let orcidId: string;
+  let orcidName: string;
+  try {
+    const tokenRes = await fetch(ORCID_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+      body: new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: `${SITE_URL}/api/orcid-callback`,
+      }),
+    });
+
+    if (!tokenRes.ok) {
+      return {
+        statusCode: 302,
+        headers: { Location: `${SITE_URL}?orcid_error=token_exchange` },
+      };
+    }
+
+    const tokenData = await tokenRes.json();
+    orcidId = tokenData.orcid;
+    orcidName = tokenData.name || '';
+  } catch {
+    return {
+      statusCode: 302,
+      headers: { Location: `${SITE_URL}?orcid_error=token_exchange` },
+    };
+  }
+
+  if (!orcidId) {
+    return {
+      statusCode: 302,
+      headers: { Location: `${SITE_URL}?orcid_error=no_orcid` },
+    };
+  }
+
+  // Create or find Supabase user by synthetic email derived from ORCID iD
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const syntheticEmail = `${orcidId.replace(/-/g, '')}@orcid.scholarfolio.org`;
+
+  // Try to find existing user by synthetic email
+  const { data: { users } } = await supabase.auth.admin.listUsers({ perPage: 1000 });
+  const existingUser = users?.find(
+    (u) => u.email === syntheticEmail || u.user_metadata?.orcid_id === orcidId
+  );
+
+  if (existingUser) {
+    // Update name if it changed
+    if (orcidName && existingUser.user_metadata?.full_name !== orcidName) {
+      await supabase.auth.admin.updateUserById(existingUser.id, {
+        user_metadata: { ...existingUser.user_metadata, full_name: orcidName },
+      });
+    }
+  } else {
+    // Create new user
+    const { data: newUser, error: createError } = await supabase.auth.admin.createUser({
+      email: syntheticEmail,
+      email_confirm: true,
+      user_metadata: {
+        orcid_id: orcidId,
+        full_name: orcidName,
+        provider: 'orcid',
+      },
+    });
+
+    if (createError || !newUser.user) {
+      return {
+        statusCode: 302,
+        headers: { Location: `${SITE_URL}?orcid_error=create_user` },
+      };
+    }
+  }
+
+  // Generate a magic link for automatic sign-in
+  const { data: linkData, error: linkError } = await supabase.auth.admin.generateLink({
+    type: 'magiclink',
+    email: syntheticEmail,
+    options: { redirectTo: SITE_URL },
+  });
+
+  if (linkError || !linkData?.properties?.action_link) {
+    return {
+      statusCode: 302,
+      headers: { Location: `${SITE_URL}?orcid_error=session` },
+    };
+  }
+
+  // Redirect to Supabase's verify endpoint which will set the session
+  return {
+    statusCode: 302,
+    headers: { Location: linkData.properties.action_link },
+  };
+};
+
+export { handler };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -168,6 +168,13 @@ function AppContent() {
       setPage('trending');
       return;
     }
+    // Handle ORCID OAuth error
+    const orcidError = params.get('orcid_error');
+    if (orcidError) {
+      const url = new URL(window.location.href);
+      url.searchParams.delete('orcid_error');
+      window.history.replaceState({}, '', url.pathname + url.search);
+    }
     const userParam = params.get('user');
     if (userParam && userParam.length >= 12 && handleSearchRef.current) {
       const scholarUrl = `https://scholar.google.com/citations?user=${encodeURIComponent(userParam)}`;

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -147,6 +147,25 @@ export function AuthButton() {
               Continue with Google
             </button>
 
+            {/* ORCID sign-in */}
+            <button
+              onClick={() => {
+                if (isSignUp && !agreedToTerms) {
+                  setError('Please agree to the Terms of Use to continue.');
+                  return;
+                }
+                const redirectUri = encodeURIComponent(`${window.location.origin}/api/orcid-callback`);
+                window.location.href = `https://orcid.org/oauth/authorize?client_id=APP-R9QF1AQWVYVJW0V9&response_type=code&scope=/authenticate&redirect_uri=${redirectUri}`;
+              }}
+              className="w-full flex items-center justify-center gap-2 py-2.5 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors mt-2"
+            >
+              <svg className="h-4 w-4" viewBox="0 0 256 256">
+                <path fill="#A6CE39" d="M256 128c0 70.7-57.3 128-128 128S0 198.7 0 128 57.3 0 128 0s128 57.3 128 128z"/>
+                <path fill="#fff" d="M86.3 186.2H70.9V79.1h15.4v107.1zm22.2 0h15.4V127c0-10.9 5.1-17.4 14.9-17.4 8.3 0 12.9 5.1 12.9 15v61.6h15.4V121.1c0-17.9-10.1-28.4-26.6-28.4-11.7 0-18.7 5.1-22.2 12.6h-.3V79.1H108v107.1h.5zM86.3 65.4c-5.1 0-9.1 4-9.1 9.1s4 9.1 9.1 9.1 9.1-4 9.1-9.1-4.1-9.1-9.1-9.1z"/>
+              </svg>
+              Continue with ORCID
+            </button>
+
             <div className="flex items-center gap-3 my-1">
               <div className="flex-1 h-px bg-gray-200" />
               <span className="text-xs text-gray-400">or</span>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -90,7 +90,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             const createdAt = new Date(session.user.created_at).getTime();
             const now = Date.now();
             // If account was created within the last 30 seconds, it's a new sign-up
-            if (now - createdAt < 30000 && session.user.app_metadata?.provider === 'google') {
+            const provider = session.user.app_metadata?.provider;
+            if (now - createdAt < 30000 && (provider === 'google' || session.user.user_metadata?.provider === 'orcid')) {
               setShowWelcome(true);
             }
           }


### PR DESCRIPTION
## Summary
- Custom ORCID OAuth flow using a Netlify serverless function to keep the client secret server-side
- Creates/finds Supabase users via admin API with synthetic email derived from ORCID iD
- Auto-signs in via magic link redirect after successful ORCID authorization
- ORCID button (green logo) in auth modal alongside existing Google sign-in
- New user welcome detection works for both Google and ORCID sign-ups

## Setup required
Add these env vars in Netlify (Site settings → Environment variables):
- `ORCID_CLIENT_ID`
- `ORCID_CLIENT_SECRET`
- `SUPABASE_SERVICE_ROLE_KEY`

Update ORCID redirect URI to: `https://scholarfolio.org/api/orcid-callback`

## Test plan
- [ ] Click "Continue with ORCID" → redirected to orcid.org
- [ ] Authorize → redirected back to ScholarFolio, signed in
- [ ] Second login with same ORCID → same user, no duplicate
- [ ] Error handling: deny authorization → returns to app without crash