### PR TITLE
Fix netlify.toml TOML parsing error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,9 +22,6 @@
 [functions]
   directory = "netlify/functions"
 
-[edge_functions]
-  directory = "netlify/edge-functions"
-
 [[edge_functions]]
   path = "/"
   function = "og-meta"


### PR DESCRIPTION
## Summary
- Remove conflicting `[edge_functions]` table entry that clashed with `[[edge_functions]]` array syntax
- This was causing Netlify CLI and deploys to fail with a TOML parse error

## Test plan
- [ ] `netlify status` succeeds locally
- [ ] Deploy preview builds without error