### PR TITLE
Add preprints, repositories, and S2 stats to Open Science tab

### DIFF
--- a/src/components/MetricsCard.tsx
+++ b/src/components/MetricsCard.tsx
@@ -40,7 +40,7 @@ interface MetricsCardProps {
         'h5Index' | 'acc5' | 'citationsPerYear' | 'topCoAuthor' | 'avgCitationsPerPaper' |
         'citationGrowth' | 'peak' | 'trend' | 'fwci' | 'halfLife' | 'gini' | 'ageNormalized' |
         'oaPercent' | 'goldOa' | 'greenOa' | 'hybridOa' | 'bronzeOa' | 'closedAccess' | 'meanIF' |
-        'pindex' | 'owpi' | 'weightedCitations';
+        'pindex' | 'owpi' | 'weightedCitations' | 'influential' | 'preprint' | 'repository';
 }
 
 function useCountUp(target: number | string, duration = 600) {
@@ -147,6 +147,9 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
       case 'hybridOa': return <Unlock className="h-3.5 w-3.5" />;
       case 'bronzeOa': return <Unlock className="h-3.5 w-3.5" />;
       case 'closedAccess': return <Lock className="h-3.5 w-3.5" />;
+      case 'influential': return <Sparkles className="h-3.5 w-3.5" />;
+      case 'preprint': return <BookOpen className="h-3.5 w-3.5" />;
+      case 'repository': return <Network className="h-3.5 w-3.5" />;
 
       default: return <Citation className="h-3.5 w-3.5" />;
     }
@@ -190,6 +193,9 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
       case 'pindex': return 'pindex';
       case 'owpi': return 'owpi';
       case 'weightedCitations': return 'weightedCitations';
+      case 'influential': return 'citations';
+      case 'preprint': return 'citations';
+      case 'repository': return 'citations';
       default: return 'citations';
     }
   };
@@ -217,7 +223,11 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
         return 'from-cat-field-from to-cat-field-to';
       // Open access → green
       case 'oaPercent': case 'goldOa': case 'greenOa': case 'hybridOa': case 'bronzeOa': case 'closedAccess':
+      case 'preprint': case 'repository':
         return 'from-cat-oa-from to-cat-oa-to';
+      // Semantic Scholar → indigo
+      case 'influential':
+        return 'from-cat-field-from to-cat-field-to';
       default:
         return 'from-primary-start to-primary-end';
     }

--- a/src/components/OpenScienceTab.tsx
+++ b/src/components/OpenScienceTab.tsx
@@ -7,6 +7,37 @@ interface OpenScienceTabProps {
   data: Author;
 }
 
+function RepositoryBreakdown({ repositoryCounts }: { repositoryCounts: Record<string, number> }) {
+  const sorted = useMemo(
+    () => Object.entries(repositoryCounts).sort(([, a], [, b]) => b - a),
+    [repositoryCounts]
+  );
+  if (sorted.length === 0) return null;
+  const max = sorted[0][1];
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">Where Open Work Is Hosted</h3>
+      <div className="bg-white dark:bg-slate-800 rounded-xl border border-gray-100 dark:border-slate-700 shadow-card p-6">
+        <div className="space-y-2.5">
+          {sorted.slice(0, 8).map(([name, count]) => (
+            <div key={name} className="flex items-center gap-3">
+              <span className="text-xs text-gray-600 dark:text-gray-400 w-48 truncate shrink-0" title={name}>{name}</span>
+              <div className="flex-1 bg-gray-100 dark:bg-slate-700 rounded-full h-4 overflow-hidden">
+                <div
+                  className="h-full bg-gradient-to-r from-[#2d7d7d] to-[#3a9a9a] rounded-full transition-all duration-500"
+                  style={{ width: `${(count / max) * 100}%` }}
+                />
+              </div>
+              <span className="text-xs font-medium text-gray-700 dark:text-gray-300 w-8 text-right shrink-0">{count}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function OaTrend({ publications, publicationOa }: { publications: Author['publications']; publicationOa?: Record<string, { status: OaStatus }> }) {
   const [hoveredYear, setHoveredYear] = useState<number | null>(null);
 
@@ -136,6 +167,10 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
           {oa.hybrid > 0 && <MetricsCard title="Hybrid OA" value={oa.hybrid} subtitle="OA in subscription journals" icon="hybridOa" />}
           {oa.bronze > 0 && <MetricsCard title="Bronze OA" value={oa.bronze} subtitle="Free to read, no license" icon="bronzeOa" />}
           {oa.closed > 0 && <MetricsCard title="Closed Access" value={oa.closed} subtitle="Behind paywall" icon="closedAccess" />}
+          {(oa.preprintCount ?? 0) > 0 && <MetricsCard title="Preprints" value={oa.preprintCount!} subtitle="Early versions available" icon="preprint" />}
+          {data.s2Stats && data.s2Stats.totalInfluentialCitations > 0 && (
+            <MetricsCard title="Influential Citations" value={data.s2Stats.totalInfluentialCitations} subtitle={`Across ${data.s2Stats.matched} matched papers`} icon="influential" />
+          )}
         </div>
       </div>
 
@@ -213,6 +248,11 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
       {/* OA trend over time */}
       <OaTrend publications={data.publications} publicationOa={oa.publicationOa} />
 
+      {/* Repository breakdown */}
+      {oa.repositoryCounts && Object.keys(oa.repositoryCounts).length > 0 && (
+        <RepositoryBreakdown repositoryCounts={oa.repositoryCounts} />
+      )}
+
       {/* ORCID */}
       {oa.orcid && (
         <div>
@@ -238,6 +278,14 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
         <a href="https://openalex.org" target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-500">
           OpenAlex
         </a>
+        {data.s2Stats && data.s2Stats.totalInfluentialCitations > 0 && (
+          <>
+            {' '}and{' '}
+            <a href="https://www.semanticscholar.org" target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-500">
+              Semantic Scholar
+            </a>
+          </>
+        )}
       </p>
     </div>
   );

--- a/src/services/openalex/index.ts
+++ b/src/services/openalex/index.ts
@@ -43,14 +43,16 @@ export class OpenAlexService {
       // ORCID is already fetched by shared author lookup
       const orcid = author.orcid;
 
-      // Fetch per-publication OA status + DOIs (paginated, up to 200 works per page)
+      // Fetch per-publication OA status + DOIs + location data (paginated, up to 200 works per page)
       const publicationOa: Record<string, { status: OaStatus; oaUrl?: string }> = {};
       const doiMap: Record<string, string> = {};
+      const repositoryCounts: Record<string, number> = {};
+      let preprintCount = 0;
       let page = 1;
       const maxPages = 10;
       while (page <= maxPages) {
         await oaRateLimiter.acquireToken();
-        const pubsUrl = `${OA_API_URL}/works?filter=authorships.author.id:${authorId}&select=title,open_access,publication_year,doi&per_page=200&page=${page}&mailto=${OA_EMAIL}`;
+        const pubsUrl = `${OA_API_URL}/works?filter=authorships.author.id:${authorId}&select=title,open_access,best_oa_location,publication_year,doi&per_page=200&page=${page}&mailto=${OA_EMAIL}`;
         const pubsResponse = await fetch(pubsUrl, {
           signal: timeoutSignal(15000)
         });
@@ -69,9 +71,17 @@ export class OpenAlexService {
             };
             // Extract DOI for Semantic Scholar batch lookup
             if (work.doi) {
-              // OpenAlex DOIs are full URLs like "https://doi.org/10.1234/..."
               const doi = work.doi.replace('https://doi.org/', '');
               if (doi) doiMap[normalizedTitle] = doi;
+            }
+            // Extract preprint/repository info from best_oa_location
+            const boa = work.best_oa_location;
+            if (boa?.version === 'submittedVersion') {
+              preprintCount++;
+            }
+            if (boa?.source?.display_name && boa?.is_oa) {
+              const repoName = boa.source.display_name;
+              repositoryCounts[repoName] = (repositoryCounts[repoName] || 0) + 1;
             }
           }
         }
@@ -92,6 +102,8 @@ export class OpenAlexService {
         orcid,
         publicationOa,
         doiMap,
+        preprintCount,
+        repositoryCounts,
       };
     } catch (error) {
       console.warn('[OpenAlex] Error fetching OA stats:', error);

--- a/src/types/scholar.ts
+++ b/src/types/scholar.ts
@@ -76,6 +76,10 @@ export interface OpenAccessStats {
   publicationOa?: Record<string, { status: OaStatus; oaUrl?: string }>;
   /** DOI map from normalized title to DOI string (from OpenAlex) */
   doiMap?: Record<string, string>;
+  /** Number of papers with a preprint (submittedVersion) available */
+  preprintCount?: number;
+  /** OA repository/source breakdown: display_name → count */
+  repositoryCounts?: Record<string, number>;
 }
 
 export interface FieldNormalizedMetrics {


### PR DESCRIPTION
## Summary
- Fetch `best_oa_location` from OpenAlex (no new API, just an extra field)
- Preprint count: papers with `submittedVersion` available
- Repository breakdown: horizontal bar chart showing where open work is hosted (SSRN, arXiv, institutional repos, etc.)
- Influential Citations metric card: surfaces S2 aggregate stats that were fetched but never displayed
- Semantic Scholar attribution added to data source footer

## Test plan
- [ ] Search a researcher with preprints (e.g. someone with SSRN papers) — verify Preprints card shows
- [ ] Verify "Where Open Work Is Hosted" section appears with repo names
- [ ] Verify Influential Citations card appears when S2 data is available
- [ ] Verify no regressions on existing OA metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)