### PR TITLE
Move Influential Citations to Impact tab with S2 disclaimer

### DIFF
--- a/src/components/OpenScienceTab.tsx
+++ b/src/components/OpenScienceTab.tsx
@@ -168,9 +168,6 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
           {oa.bronze > 0 && <MetricsCard title="Bronze OA" value={oa.bronze} subtitle="Free to read, no license" icon="bronzeOa" />}
           {oa.closed > 0 && <MetricsCard title="Closed Access" value={oa.closed} subtitle="Behind paywall" icon="closedAccess" />}
           {(oa.preprintCount ?? 0) > 0 && <MetricsCard title="Preprints" value={oa.preprintCount!} subtitle="Early versions available" icon="preprint" />}
-          {data.s2Stats && data.s2Stats.totalInfluentialCitations > 0 && (
-            <MetricsCard title="Influential Citations" value={data.s2Stats.totalInfluentialCitations} subtitle={`Across ${data.s2Stats.matched} matched papers`} icon="influential" />
-          )}
         </div>
       </div>
 
@@ -278,14 +275,6 @@ export function OpenScienceTab({ data }: OpenScienceTabProps) {
         <a href="https://openalex.org" target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-500">
           OpenAlex
         </a>
-        {data.s2Stats && data.s2Stats.totalInfluentialCitations > 0 && (
-          <>
-            {' '}and{' '}
-            <a href="https://www.semanticscholar.org" target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-500">
-              Semantic Scholar
-            </a>
-          </>
-        )}
       </p>
     </div>
   );

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -528,7 +528,22 @@ export function ProfileView({
                   subtitle="Age-normalized rate"
                   icon="ageNormalized"
                 />
+                {data.s2Stats && data.s2Stats.totalInfluentialCitations > 0 && (
+                  <MetricsCard
+                    title="Influential Citations"
+                    value={data.s2Stats.totalInfluentialCitations}
+                    subtitle={`${data.s2Stats.matched} of ${data.s2Stats.total} papers matched`}
+                    icon="influential"
+                  />
+                )}
               </div>
+              {data.s2Stats && data.s2Stats.totalInfluentialCitations > 0 && (
+                <p className="text-[10px] text-gray-400 dark:text-gray-500 mt-1">
+                  Influential Citations from{' '}
+                  <a href="https://www.semanticscholar.org" target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-500">Semantic Scholar</a>
+                  {' '}— counts may differ from Google Scholar as coverage varies.
+                </p>
+              )}
             </div>
 
             {data.fieldMetrics && (data.fieldMetrics.fwci !== null || data.fieldMetrics.meanCitedness !== null || data.fieldMetrics.rcrMean !== null) && (


### PR DESCRIPTION
## Summary
- Moved Influential Citations metric card from Open Science tab to Impact Metrics section
- Added note: "Influential Citations from Semantic Scholar — counts may differ from Google Scholar as coverage varies"
- Shows match rate (e.g. "32 of 47 papers matched") for transparency

## Test plan
- [ ] Verify Influential Citations no longer appears in Open Science tab
- [ ] Verify it appears in Impact Metrics with disclaimer text
- [ ] Verify preprints + repositories still show correctly in Open Science

🤖 Generated with [Claude Code](https://claude.com/claude-code)