### PR TITLE
Name-based search as primary landing page input

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -48,8 +48,49 @@ function useScrollReveal() {
   return ref;
 }
 
+function NameSearchInput({ onSearch, isLoading }: { onSearch: (name: string) => void; isLoading: boolean }) {
+  const [name, setName] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (name.trim().length >= 2 && !isLoading) {
+      onSearch(name.trim());
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="w-full">
+      <div className="relative search-focus-glow rounded-lg transition-all">
+        <input
+          type="text"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="Search by researcher name..."
+          disabled={isLoading}
+          className="w-full py-3 pl-12 pr-28 text-sm text-gray-700 dark:text-gray-200 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-600 focus:border-[#2d7d7d] focus:ring-[#2d7d7d]/20 rounded-lg focus:outline-none focus:ring-2 transition-all"
+          autoComplete="off"
+          spellCheck="false"
+        />
+        <div className="absolute left-4 top-3.5 flex items-center justify-center">
+          <Search className="h-5 w-5 gradient-icon" />
+        </div>
+        <button
+          type="submit"
+          disabled={name.trim().length < 2 || isLoading}
+          className="absolute right-2 top-2 px-4 py-1.5 bg-[#2d7d7d] text-white rounded-lg btn-lift disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center space-x-2 text-xs min-w-[80px]"
+        >
+          <Search className="h-4 w-4" />
+          <span>Find</span>
+        </button>
+      </div>
+    </form>
+  );
+}
+
 export function LandingPage({ onSearch, loading, error, onNavigate, authControls }: LandingPageProps) {
   const [showScholarSearch, setShowScholarSearch] = useState(false);
+  const [initialSearchQuery, setInitialSearchQuery] = useState('');
+  const [showUrlInput, setShowUrlInput] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const featuresRef = useScrollReveal();
   const ctaRef = useScrollReveal();
@@ -140,9 +181,9 @@ export function LandingPage({ onSearch, loading, error, onNavigate, authControls
             Get a shareable portfolio page for your research — your publications, citations, and collaboration network at a memorable URL like <span className="font-medium text-[#2d7d7d]">scholarfolio.org/your-name</span>.
           </p>
 
-          {/* Search area */}
+          {/* Search area — name search primary */}
           <div className="animate-fade-up-scale animate-delay-350 w-full max-w-xl mx-auto mb-2">
-            <SearchBar onSearch={onSearch} isLoading={loading} error={error} />
+            <NameSearchInput onSearch={(q) => { setInitialSearchQuery(q); setShowScholarSearch(true); }} isLoading={loading} />
           </div>
 
           {!user && (
@@ -159,13 +200,19 @@ export function LandingPage({ onSearch, loading, error, onNavigate, authControls
           </p>
 
           <button
-            onClick={() => setShowScholarSearch(true)}
+            onClick={() => setShowUrlInput(!showUrlInput)}
             className="animate-fade-up animate-delay-350 inline-flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-[#2d7d7d] transition-colors group"
           >
-            <Search className="h-3.5 w-3.5" />
-            <span>Or search by author name</span>
+            <Link className="h-3.5 w-3.5" />
+            <span>Or paste a Google Scholar URL</span>
             <ArrowRight className="h-3.5 w-3.5 opacity-0 -translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 transition-all" />
           </button>
+
+          {showUrlInput && (
+            <div className="animate-fade-up w-full max-w-xl mx-auto mt-3">
+              <SearchBar onSearch={onSearch} isLoading={loading} error={error} compact />
+            </div>
+          )}
         </div>
       </section>
 
@@ -257,7 +304,7 @@ export function LandingPage({ onSearch, loading, error, onNavigate, authControls
             </p>
 
             <div className="max-w-xl mx-auto mb-3">
-              <SearchBar onSearch={onSearch} isLoading={loading} />
+              <NameSearchInput onSearch={(q) => { setInitialSearchQuery(q); setShowScholarSearch(true); }} isLoading={loading} />
             </div>
 
             <p className="text-xs text-white/40 italic mb-5">
@@ -278,8 +325,9 @@ export function LandingPage({ onSearch, loading, error, onNavigate, authControls
 
       <ScholarSearchModal
         isOpen={showScholarSearch}
-        onClose={() => setShowScholarSearch(false)}
+        onClose={() => { setShowScholarSearch(false); setInitialSearchQuery(''); }}
         onSelect={onSearch}
+        initialQuery={initialSearchQuery}
       />
     </main>
   );

--- a/src/components/ScholarSearchModal.tsx
+++ b/src/components/ScholarSearchModal.tsx
@@ -1,61 +1,103 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { Search, X, ExternalLink, ClipboardPaste, ArrowRight } from 'lucide-react';
+import { Search, X, MapPin, GraduationCap, Loader2 } from 'lucide-react';
+import { scholarService, type AuthorSearchResult } from '../services/scholar/index';
 
 interface ScholarSearchModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSelect: (profileUrl: string) => void;
+  initialQuery?: string;
 }
 
-export function ScholarSearchModal({ isOpen, onClose, onSelect }: ScholarSearchModalProps) {
-  const [pastedUrl, setPastedUrl] = useState('');
+export function ScholarSearchModal({ isOpen, onClose, onSelect, initialQuery = '' }: ScholarSearchModalProps) {
+  const [name, setName] = useState('');
+  const [results, setResults] = useState<AuthorSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searched, setSearched] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const hasAutoSearched = useRef(false);
 
   useEffect(() => {
     if (isOpen) {
-      setTimeout(() => inputRef.current?.focus(), 100);
+      if (initialQuery && !hasAutoSearched.current) {
+        setName(initialQuery);
+        hasAutoSearched.current = true;
+        // Auto-trigger search
+        (async () => {
+          setLoading(true);
+          setSearched(true);
+          setError(null);
+          try {
+            const profiles = await scholarService.searchAuthors(initialQuery);
+            setResults(profiles);
+          } catch (err) {
+            setError(err instanceof Error ? err.message : 'Search failed.');
+            setResults([]);
+          } finally {
+            setLoading(false);
+          }
+        })();
+      } else {
+        setTimeout(() => inputRef.current?.focus(), 100);
+      }
     } else {
-      setPastedUrl('');
+      setName('');
+      setResults([]);
+      setSearched(false);
       setError(null);
+      setLoading(false);
+      hasAutoSearched.current = false;
     }
-  }, [isOpen]);
+  }, [isOpen, initialQuery]);
 
-  const openGoogleScholar = () => {
-    window.open('https://scholar.google.com/citations?view_op=search_authors', '_blank');
-  };
-
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSearch = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
-    const url = pastedUrl.trim();
-    if (!url) return;
+    const query = name.trim();
+    if (!query || query.length < 2) return;
 
-    if (url.includes('scholar.google.com/citations') && url.includes('user=')) {
-      onSelect(url);
-      onClose();
-    } else {
-      setError('Please paste a valid Google Scholar profile URL (should contain scholar.google.com/citations?user=...)');
+    setLoading(true);
+    setError(null);
+    setSearched(true);
+
+    try {
+      const profiles = await scholarService.searchAuthors(query);
+      setResults(profiles);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Search failed. Please try again.');
+      setResults([]);
+    } finally {
+      setLoading(false);
     }
-  };
+  }, [name]);
+
+  const handleSelect = useCallback((authorId: string) => {
+    const url = `https://scholar.google.com/citations?user=${authorId}`;
+    onSelect(url);
+    onClose();
+  }, [onSelect, onClose]);
 
   if (!isOpen) return null;
 
   return createPortal(
     <div
-      className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-start justify-center pt-[15vh] p-4"
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-start justify-center pt-[10vh] p-4"
       role="dialog"
       aria-modal="true"
       aria-labelledby="scholar-search-title"
       onClick={onClose}
       onKeyDown={e => { if (e.key === 'Escape') onClose(); }}
     >
-      <div className="bg-white dark:bg-gray-900 rounded-xl max-w-lg w-full shadow-2xl flex flex-col" onClick={e => e.stopPropagation()}>
+      <div
+        className="bg-white dark:bg-gray-900 rounded-xl max-w-lg w-full shadow-2xl flex flex-col max-h-[75vh]"
+        onClick={e => e.stopPropagation()}
+      >
         {/* Header */}
         <div className="p-4 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between flex-shrink-0">
           <h2 id="scholar-search-title" className="text-base font-semibold text-gray-900 dark:text-gray-100 flex items-center">
             <Search className="h-4 w-4 text-[#2d7d7d] mr-2" />
-            Find Author on Google Scholar
+            Find Researcher
           </h2>
           <button
             onClick={onClose}
@@ -66,79 +108,109 @@ export function ScholarSearchModal({ isOpen, onClose, onSelect }: ScholarSearchM
           </button>
         </div>
 
-        {/* Steps */}
-        <div className="p-5 space-y-5">
-          {/* Step 1 */}
-          <div className="flex gap-3">
-            <div className="flex-shrink-0 w-6 h-6 rounded-full bg-[#2d7d7d] text-white text-xs font-bold flex items-center justify-center mt-0.5">
-              1
+        {/* Search form */}
+        <div className="p-4 border-b border-gray-100 dark:border-gray-700 flex-shrink-0">
+          <form onSubmit={handleSearch} className="flex gap-2">
+            <div className="relative flex-1">
+              <input
+                ref={inputRef}
+                type="text"
+                value={name}
+                onChange={e => { setName(e.target.value); setError(null); }}
+                placeholder="Enter researcher name..."
+                className="w-full px-4 py-2.5 pl-10 text-sm text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:border-[#2d7d7d] focus:ring-2 focus:ring-[#2d7d7d]/20 focus:bg-white dark:focus:bg-gray-800 transition-all"
+                autoComplete="off"
+                spellCheck="false"
+              />
+              <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
             </div>
-            <div className="flex-1">
-              <p className="text-sm font-medium text-gray-800 dark:text-gray-200 mb-2">
-                Search for the author on Google Scholar
-              </p>
-              <button
-                onClick={openGoogleScholar}
-                className="inline-flex items-center gap-2 px-4 py-2 bg-[#2d7d7d] text-white text-sm font-medium rounded-lg hover:bg-[#236363] transition-colors"
-              >
-                <ExternalLink className="h-3.5 w-3.5" />
-                Open Google Scholar
-              </button>
-            </div>
-          </div>
+            <button
+              type="submit"
+              disabled={loading || name.trim().length < 2}
+              className="px-4 py-2.5 bg-[#2d7d7d] text-white text-sm font-medium rounded-lg hover:bg-[#236363] disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+            >
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+              Search
+            </button>
+          </form>
+          {error && (
+            <p className="text-xs text-red-500 mt-2">{error}</p>
+          )}
+        </div>
 
-          {/* Step 2 */}
-          <div className="flex gap-3">
-            <div className="flex-shrink-0 w-6 h-6 rounded-full bg-[#2d7d7d] text-white text-xs font-bold flex items-center justify-center mt-0.5">
-              2
+        {/* Results */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {loading && (
+            <div className="flex flex-col items-center justify-center py-8 text-gray-400">
+              <Loader2 className="h-6 w-6 animate-spin mb-2" />
+              <p className="text-sm">Searching Google Scholar...</p>
             </div>
-            <div className="flex-1">
-              <p className="text-sm font-medium text-gray-800 dark:text-gray-200">
-                Click on the author's profile, then copy the URL from your browser
-              </p>
-              <p className="text-xs text-gray-400 mt-1">
-                It should look like: scholar.google.com/citations?user=...
-              </p>
-            </div>
-          </div>
+          )}
 
-          {/* Step 3 */}
-          <div className="flex gap-3">
-            <div className="flex-shrink-0 w-6 h-6 rounded-full bg-[#2d7d7d] text-white text-xs font-bold flex items-center justify-center mt-0.5">
-              3
+          {!loading && searched && results.length === 0 && !error && (
+            <div className="text-center py-8">
+              <p className="text-sm text-gray-500 dark:text-gray-400">No profiles found for "{name.trim()}"</p>
+              <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">Try a different spelling or include the full name</p>
             </div>
-            <div className="flex-1">
-              <p className="text-sm font-medium text-gray-800 dark:text-gray-200 mb-2">
-                Paste the profile URL here
-              </p>
-              <form onSubmit={handleSubmit}>
-                <div className="relative">
-                  <input
-                    ref={inputRef}
-                    type="text"
-                    value={pastedUrl}
-                    onChange={(e) => { setPastedUrl(e.target.value); setError(null); }}
-                    placeholder="https://scholar.google.com/citations?user=..."
-                    className="w-full px-4 py-2.5 pl-10 pr-12 text-sm text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg focus:outline-none focus:border-[#2d7d7d] focus:ring-2 focus:ring-[#2d7d7d]/20 focus:bg-white dark:focus:bg-gray-800 transition-all"
-                    autoComplete="off"
-                    spellCheck="false"
-                  />
-                  <ClipboardPaste className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                  {pastedUrl.trim() && (
-                    <button
-                      type="submit"
-                      className="absolute right-2 top-1.5 p-1.5 bg-[#2d7d7d] text-white rounded-md hover:bg-[#236363] transition-colors"
-                    >
-                      <ArrowRight className="h-3.5 w-3.5" />
-                    </button>
-                  )}
-                </div>
-                {error && (
-                  <p className="text-xs text-red-500 mt-1.5">{error}</p>
-                )}
-              </form>
+          )}
+
+          {!loading && results.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-xs text-gray-400 mb-3">{results.length} profile{results.length !== 1 ? 's' : ''} found — select the correct one</p>
+              {results.map((profile) => (
+                <button
+                  key={profile.authorId}
+                  onClick={() => handleSelect(profile.authorId)}
+                  className="w-full text-left p-3 rounded-lg border border-gray-100 dark:border-gray-700 hover:border-[#2d7d7d] hover:bg-[#2d7d7d]/5 dark:hover:bg-[#2d7d7d]/10 transition-all group"
+                >
+                  <div className="flex items-start gap-3">
+                    {profile.imageUrl ? (
+                      <img
+                        src={profile.imageUrl}
+                        alt=""
+                        className="w-10 h-10 rounded-full object-cover flex-shrink-0 bg-gray-100 dark:bg-gray-800"
+                        onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                      />
+                    ) : (
+                      <div className="w-10 h-10 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center flex-shrink-0">
+                        <GraduationCap className="h-5 w-5 text-gray-400" />
+                      </div>
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-gray-900 dark:text-gray-100 group-hover:text-[#2d7d7d] transition-colors truncate">
+                        {profile.name}
+                      </p>
+                      {profile.affiliation && (
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 truncate flex items-center gap-1">
+                          <MapPin className="h-3 w-3 flex-shrink-0" />
+                          {profile.affiliation}
+                        </p>
+                      )}
+                      <div className="flex items-center gap-3 mt-1">
+                        {profile.citedBy > 0 && (
+                          <span className="text-[11px] text-gray-400 dark:text-gray-500">
+                            Cited by {profile.citedBy.toLocaleString()}
+                          </span>
+                        )}
+                        {profile.interests.length > 0 && (
+                          <span className="text-[11px] text-gray-400 dark:text-gray-500 truncate">
+                            {profile.interests.slice(0, 3).join(', ')}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </button>
+              ))}
             </div>
-          </div>
+          )}
+
+          {!loading && !searched && (
+            <div className="text-center py-8">
+              <GraduationCap className="h-8 w-8 text-gray-300 dark:text-gray-600 mx-auto mb-2" />
+              <p className="text-sm text-gray-400 dark:text-gray-500">Enter a researcher's name to find their profile</p>
+            </div>
+          )}
         </div>
       </div>
     </div>,


### PR DESCRIPTION
## Summary
- Replace URL-only search bar with name-based search input on landing page
- Typing a name and hitting "Find" opens a modal that searches Google Scholar via the existing SerpAPI backend
- Modal shows matching profiles with photo, affiliation, citation count, and research interests
- Selecting a profile auto-constructs the GS URL and triggers the full analysis
- URL paste kept as secondary "Or paste a Google Scholar URL" toggle

## Test plan
- [ ] Type a name on landing page, verify modal opens with search results
- [ ] Select a profile from results, verify full analysis loads
- [ ] Test "Or paste a Google Scholar URL" fallback still works
- [ ] Test bottom CTA section name search works
- [ ] Test no-results state and error handling

Generated with [Claude Code](https://claude.com/claude-code)