### PR TITLE
Fix self-detection in co-author metrics (diacritics + initials)

### DIFF
--- a/src/services/metrics/collaboration/co-author-metrics.ts
+++ b/src/services/metrics/collaboration/co-author-metrics.ts
@@ -28,9 +28,10 @@ export function calculateCoAuthorMetrics(publications: Publication[], authorName
   let totalAuthors = 0;
   let soloCount = 0;
 
-  // Helper function to normalize author names
+  // Helper function to normalize author names (strip diacritics + punctuation)
   const normalizeAuthorName = (name: string) => {
-    return name.toLowerCase()
+    return name.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
       .trim()
       .replace(/\s+/g, ' ')
       .replace(/[.,]/g, '');
@@ -60,8 +61,16 @@ export function calculateCoAuthorMetrics(publications: Publication[], authorName
 
     pub.authors.forEach(author => {
       const normalizedAuthor = normalizeAuthorName(author);
-      const isMainAuthor = mainAuthorVariations.some(variation => 
+      const authorParts = normalizedAuthor.split(' ');
+      const isMainAuthor = mainAuthorVariations.some(variation =>
         normalizedAuthor.includes(variation) || variation.includes(normalizedAuthor)
+      ) || (
+        // Handle abbreviated names: "E Efendic" matches "Emir Efendic"
+        // Check if last name matches and first part is an initial of the main author's first name
+        authorParts.length >= 2 && mainAuthorParts.length >= 2 &&
+        authorParts[authorParts.length - 1] === mainAuthorParts[mainAuthorParts.length - 1] &&
+        (authorParts[0].length <= 2 && mainAuthorParts[0].startsWith(authorParts[0]) ||
+         mainAuthorParts[0].length <= 2 && authorParts[0].startsWith(mainAuthorParts[0]))
       );
 
       if (!isMainAuthor) {


### PR DESCRIPTION
## Summary
Author was listed as their own top co-author when name appeared with diacritics
(Efendić vs Efendic) or abbreviated initials (E Efendić vs Emir Efendic).

- Strip diacritics via NFD decomposition in name normalization
- Match abbreviated first names (1-2 chars) against full first name
- Fixes narrative CV showing "most frequent collaborator is E Efendić" for Emir Efendic

## Test plan
- [ ] Search Emir Efendic — top co-author should NOT be E Efendić / himself
- [ ] Check narrative CV no longer mentions self as collaborator
- [ ] Verify other profiles still show correct top co-author

Generated with [Claude Code](https://claude.com/claude-code)