### PR TITLE
Structural fix: isSameAuthor() for all name formats

### DIFF
--- a/src/services/metrics/collaboration/co-author-metrics.ts
+++ b/src/services/metrics/collaboration/co-author-metrics.ts
@@ -15,6 +15,117 @@ interface CoAuthorStats {
   topCoAuthors: Array<{ name: string; papers: number }>;
 }
 
+/** Strip diacritics, lowercase, remove punctuation except hyphens */
+function normalizeName(name: string): string {
+  return name
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[.,;:'"()]/g, '')
+    .replace(/\s+/g, ' ');
+}
+
+/** Parse a name into { given: string[], last: string }
+ *  Handles "LastName, FirstName" and "FirstName LastName" formats.
+ *  For multi-word last names, uses heuristics (van, de, von, etc.) */
+function parseName(normalized: string): { given: string[]; last: string } {
+  // Handle "LastName, FirstName MiddleName" format
+  if (normalized.includes(',')) {
+    const [last, ...rest] = normalized.split(',').map(s => s.trim());
+    const given = rest.join(' ').split(' ').filter(Boolean);
+    return { given, last };
+  }
+
+  const parts = normalized.split(' ').filter(Boolean);
+  if (parts.length === 0) return { given: [], last: '' };
+  if (parts.length === 1) return { given: [], last: parts[0] };
+
+  // Detect multi-word last name prefixes (van, de, von, el, al, di, du, le, la, etc.)
+  const prefixes = new Set(['van', 'von', 'de', 'del', 'della', 'di', 'du', 'le', 'la', 'el', 'al', 'bin', 'ibn', 'den', 'der', 'het', 'ter', 'ten']);
+  let lastStart = parts.length - 1;
+  while (lastStart > 1 && prefixes.has(parts[lastStart - 1])) {
+    lastStart--;
+  }
+
+  return {
+    given: parts.slice(0, lastStart),
+    last: parts.slice(lastStart).join(' '),
+  };
+}
+
+/** Check if two given-name parts are compatible.
+ *  "e" matches "emir", "ec" matches "ec", "emir" matches "emir" */
+function givenPartMatches(a: string, b: string): boolean {
+  if (a === b) return true;
+  // One is an initial/abbreviation of the other
+  if (a.length <= 2 && b.startsWith(a)) return true;
+  if (b.length <= 2 && a.startsWith(b)) return true;
+  return false;
+}
+
+/** Check if two names likely refer to the same person.
+ *  Handles diacritics, initials, abbreviated names, name ordering. */
+function isSameAuthor(nameA: string, nameB: string): boolean {
+  const a = parseName(normalizeName(nameA));
+  const b = parseName(normalizeName(nameB));
+
+  // Last names must match
+  if (a.last !== b.last) return false;
+
+  // If either has no given names, last name match is enough
+  // (e.g., just "Efendic" listed as author)
+  if (a.given.length === 0 || b.given.length === 0) return true;
+
+  // Compare given name parts — the shorter list drives the comparison.
+  // "E" matches "Emir", "EC" matches "Elisabeth C", etc.
+  const shorter = a.given.length <= b.given.length ? a.given : b.given;
+  const longer = a.given.length <= b.given.length ? b.given : a.given;
+
+  // Each part in the shorter set must match some part in the longer set
+  // (handles cases where middle names are present in one but not the other)
+  const used = new Set<number>();
+  for (const sp of shorter) {
+    let matched = false;
+    for (let i = 0; i < longer.length; i++) {
+      if (!used.has(i) && givenPartMatches(sp, longer[i])) {
+        used.add(i);
+        matched = true;
+        break;
+      }
+    }
+    // If a given name part doesn't match any, it could be a combined initial
+    // like "ec" matching "e" + "c" or just be a non-match
+    if (!matched) {
+      // Try combined initials: "ppfm" could match "p" + "p" + "f" + "m"
+      // But more commonly "ec" for "elisabeth c" — check if the short part
+      // is all initials that match the starts of unused longer parts
+      if (sp.length > 1 && sp.length <= 4) {
+        const initials = sp.split('');
+        let allMatch = true;
+        const tempUsed = new Set(used);
+        for (const initial of initials) {
+          let found = false;
+          for (let i = 0; i < longer.length; i++) {
+            if (!tempUsed.has(i) && longer[i].startsWith(initial)) {
+              tempUsed.add(i);
+              found = true;
+              break;
+            }
+          }
+          if (!found) { allMatch = false; break; }
+        }
+        if (allMatch) {
+          for (const i of tempUsed) used.add(i);
+          matched = true;
+        }
+      }
+      if (!matched) return false;
+    }
+  }
+
+  return true;
+}
+
 export function calculateCoAuthorMetrics(publications: Publication[], authorName: string): CoAuthorStats {
   const coAuthorCounts = new Map<string, {
     count: number;
@@ -28,52 +139,19 @@ export function calculateCoAuthorMetrics(publications: Publication[], authorName
   let totalAuthors = 0;
   let soloCount = 0;
 
-  // Helper function to normalize author names (strip diacritics + punctuation)
-  const normalizeAuthorName = (name: string) => {
-    return name.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
-      .toLowerCase()
-      .trim()
-      .replace(/\s+/g, ' ')
-      .replace(/[.,]/g, '');
-  };
-
   // Strip title suffixes like " - Full Professor" or " - Associate Professor"
   const cleanAuthorName = authorName.replace(/\s*[-–—]\s*(Full|Associate|Assistant|Emeritus|Adjunct|Visiting|Research)?\s*(Professor|Lecturer|Fellow|Director|Dean|Chair|Researcher|Scientist|Engineer|Doctor|PhD|Dr)\b.*/i, '').trim() || authorName;
-
-  // Create variations of the main author's name for matching
-  const mainAuthorNormalized = normalizeAuthorName(cleanAuthorName);
-  const mainAuthorParts = mainAuthorNormalized.split(' ');
-  const mainAuthorVariations = [
-    mainAuthorNormalized,
-    mainAuthorParts[mainAuthorParts.length - 1],
-    mainAuthorParts[0],
-    mainAuthorParts.length > 1 ? `${mainAuthorParts[0]} ${mainAuthorParts[mainAuthorParts.length - 1]}` : '',
-    mainAuthorParts.length > 1 ? `${mainAuthorParts[mainAuthorParts.length - 1]}, ${mainAuthorParts[0]}` : ''
-  ].filter(Boolean);
 
   // Process each publication
   publications.forEach(pub => {
     if (pub.authors.length === 1) {
       soloCount++;
     }
-    
+
     totalAuthors += pub.authors.length;
 
     pub.authors.forEach(author => {
-      const normalizedAuthor = normalizeAuthorName(author);
-      const authorParts = normalizedAuthor.split(' ');
-      const isMainAuthor = mainAuthorVariations.some(variation =>
-        normalizedAuthor.includes(variation) || variation.includes(normalizedAuthor)
-      ) || (
-        // Handle abbreviated names: "E Efendic" matches "Emir Efendic"
-        // Check if last name matches and first part is an initial of the main author's first name
-        authorParts.length >= 2 && mainAuthorParts.length >= 2 &&
-        authorParts[authorParts.length - 1] === mainAuthorParts[mainAuthorParts.length - 1] &&
-        (authorParts[0].length <= 2 && mainAuthorParts[0].startsWith(authorParts[0]) ||
-         mainAuthorParts[0].length <= 2 && authorParts[0].startsWith(mainAuthorParts[0]))
-      );
-
-      if (!isMainAuthor) {
+      if (!isSameAuthor(author, cleanAuthorName)) {
         const existingData = coAuthorCounts.get(author) || {
           count: 0,
           citations: 0,


### PR DESCRIPTION
## Summary
Replace fragile variations-based self-detection with proper `isSameAuthor()`:
- `parseName()` — splits into given names + last name, handles comma format + multi-word prefixes (van, von, de, etc.)
- `normalizeName()` — strips diacritics via NFD, removes punctuation
- `givenPartMatches()` — flexible initial matching (E = Emir, EC = E + C)
- Combined initial support (PPFM matches P + P + F + M)

Covers: diacritics, initials, comma format, multi-word last names, middle names, title suffixes.

## Test plan
- [ ] Emir Efendic — top co-author is NOT himself (E Efendić)
- [ ] Elisabeth Brüggen — no self-match with EC Brüggen
- [ ] Researchers with van/von/de last names
- [ ] Researchers with middle initials

Generated with [Claude Code](https://claude.com/claude-code)