### PR TITLE
Perf: 52% smaller initial bundle + UX fixes

### DIFF
--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -26,6 +26,9 @@ interface TooltipState {
   data: CoAuthorGeoData | null;
 }
 
+// Module-level cache for world topology (84KB JSON, fetched once)
+let cachedWorldTopology: WorldTopology | null = null;
+
 interface WorldTopology extends Topology {
   objects: {
     countries: GeometryCollection;
@@ -208,13 +211,14 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
       setTooltip(prev => ({ ...prev, visible: false }));
     }, { passive: true } as unknown as boolean);
 
-    // Load world TopoJSON
-    fetch('https://unpkg.com/world-atlas@2/countries-110m.json', { signal: timeoutSignal(15000) })
-      .then(r => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        return r.json();
-      })
-      .then((world: WorldTopology) => {
+    // Load world TopoJSON (cached after first fetch)
+    const worldPromise = cachedWorldTopology
+      ? Promise.resolve(cachedWorldTopology)
+      : fetch('https://unpkg.com/world-atlas@2/countries-110m.json', { signal: timeoutSignal(15000) })
+          .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
+          .then((data: WorldTopology) => { cachedWorldTopology = data; return data; });
+
+    worldPromise.then((world: WorldTopology) => {
         const countries = topojson.feature(world, world.objects.countries);
 
         // Outer sphere (ocean)

--- a/src/components/ProfileSkeleton.tsx
+++ b/src/components/ProfileSkeleton.tsx
@@ -2,7 +2,7 @@ export function ProfileSkeleton() {
   return (
     <div className="min-h-screen mesh-bg">
       {/* Header skeleton */}
-      <header className="sticky top-0 z-10 bg-white/80 backdrop-blur-lg border-b border-gray-100/80">
+      <header className="sticky top-0 z-10 bg-white/80 dark:bg-slate-900/80 backdrop-blur-lg border-b border-gray-100/80 dark:border-slate-700/80">
         <div className="max-w-7xl mx-auto px-4 py-2.5">
           <div className="flex items-center gap-4">
             <div className="skeleton w-8 h-8 rounded-lg" />
@@ -14,7 +14,7 @@ export function ProfileSkeleton() {
 
       <main className="max-w-7xl mx-auto px-4 py-6">
         {/* Profile card skeleton */}
-        <div className="bg-white rounded-2xl border border-gray-100 shadow-card p-6 mb-6">
+        <div className="bg-white dark:bg-slate-800 rounded-2xl border border-gray-100 dark:border-slate-700 shadow-card p-6 mb-6">
           <div className="flex flex-col md:flex-row md:items-center gap-6">
             <div className="flex items-start gap-4 flex-1">
               <div className="skeleton w-16 h-16 rounded-xl flex-shrink-0" />
@@ -26,33 +26,33 @@ export function ProfileSkeleton() {
                   <div className="skeleton w-20 h-6 rounded-full" />
                   <div className="skeleton w-16 h-6 rounded-full" />
                 </div>
-                <div className="flex gap-2">
-                  <div className="skeleton w-16 h-5 rounded-full" />
-                  <div className="skeleton w-20 h-5 rounded-full" />
-                  <div className="skeleton w-24 h-5 rounded-full" />
-                </div>
               </div>
             </div>
-            <div className="flex flex-col items-end gap-2">
-              <div className="skeleton w-32 h-10 rounded-xl" />
-              <div className="skeleton w-24 h-4" />
+            {/* Stats: matches the 3-number layout in ProfileView */}
+            <div className="flex items-center gap-8">
+              {[1, 2, 3].map(i => (
+                <div key={i} className="text-center space-y-1">
+                  <div className="skeleton w-12 h-7 mx-auto" />
+                  <div className="skeleton w-16 h-3 mx-auto" />
+                </div>
+              ))}
             </div>
           </div>
         </div>
 
         {/* Tab bar skeleton */}
         <div className="mb-6">
-          <div className="flex gap-1 p-1 bg-gray-100/80 rounded-xl w-fit">
-            {[120, 130, 140, 110, 120].map((w, i) => (
+          <div className="flex gap-1 p-1 bg-gray-100/80 dark:bg-slate-800/80 rounded-xl w-fit">
+            {[100, 110, 130, 100, 120, 100, 110].map((w, i) => (
               <div key={i} className="skeleton rounded-lg" style={{ width: w, height: 36 }} />
             ))}
           </div>
         </div>
 
-        {/* Metrics grid skeleton */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <div key={i} className="bg-white p-3 rounded-xl border border-gray-100 shadow-card">
+        {/* Metrics grid skeleton — matches grid-cols-2 sm:3 md:4 lg:5 */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+          {Array.from({ length: 10 }).map((_, i) => (
+            <div key={i} className="bg-white dark:bg-slate-800 p-3 rounded-xl border border-gray-100 dark:border-slate-700 shadow-card">
               <div className="flex items-start gap-2.5">
                 <div className="skeleton w-8 h-8 rounded-lg flex-shrink-0" />
                 <div className="flex-1 space-y-2">

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -1,19 +1,21 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, lazy, Suspense } from 'react';
 import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock, ExternalLink, Heart, BadgeCheck, Link, Globe, FileText, MessageSquare, Mail, MapPin } from 'lucide-react';
-import { NarrativeCvTab } from './NarrativeCvTab';
 import { EmbedModal } from './EmbedModal';
 import { ClaimProfileModal } from './ClaimProfileModal';
 // pdfExport is dynamically imported on click to avoid bundling jsPDF (344KB)
 import { SearchBar } from './SearchBar';
 import { TopicsList } from './TopicsList';
 import { PublicationsList } from './PublicationsList';
-import { CitationsChart } from './CitationsChart';
 import { MetricsCard } from './MetricsCard';
-import { CitationNetwork } from './CitationNetwork';
-import { CoAuthorMap } from './CoAuthorMap';
-import { OpenScienceTab } from './OpenScienceTab';
 import { ResearcherNarrative } from './ResearcherNarrative';
 import { PIndexSection } from './PIndexSection';
+
+// Lazy-load heavy tab components (D3, Leaflet, recharts, docx)
+const CitationsChart = lazy(() => import('./CitationsChart').then(m => ({ default: m.CitationsChart })));
+const CitationNetwork = lazy(() => import('./CitationNetwork').then(m => ({ default: m.CitationNetwork })));
+const CoAuthorMap = lazy(() => import('./CoAuthorMap').then(m => ({ default: m.CoAuthorMap })));
+const OpenScienceTab = lazy(() => import('./OpenScienceTab').then(m => ({ default: m.OpenScienceTab })));
+const NarrativeCvTab = lazy(() => import('./NarrativeCvTab').then(m => ({ default: m.NarrativeCvTab })));
 import { Logo } from './Logo';
 import { useAuth } from '../contexts/AuthContext';
 import { supabase } from '../lib/supabase';
@@ -242,6 +244,8 @@ export function ProfileView({
                 <img
                   src={data.imageUrl}
                   alt={data.name}
+                  width={64}
+                  height={64}
                   className="w-16 h-16 rounded-xl object-cover bg-[#eaf4f4] flex-shrink-0"
                   onError={() => setImgError(true)}
                 />
@@ -471,6 +475,7 @@ export function ProfileView({
                 role="tab"
                 aria-selected={activeTab === tab.id}
                 tabIndex={activeTab === tab.id ? 0 : -1}
+                title={tab.label}
                 onClick={() => { setActiveTab(tab.id); setTabKey(k => k + 1); }}
                 className={`relative z-10 flex items-center gap-1.5 px-2 sm:px-4 py-2 text-xs font-medium rounded-lg transition-colors whitespace-nowrap ${
                   activeTab === tab.id
@@ -600,6 +605,7 @@ export function ProfileView({
         </div>
 
         <div key={tabKey} className="tab-content-enter">
+        <Suspense fallback={<div className="flex items-center justify-center py-16"><div className="h-6 w-6 border-2 border-gray-200 border-t-[#2d7d7d] rounded-full animate-spin" /></div>}>
         {activeTab === 'trends' && (
           <div className="w-full">
             <CitationsChart citationsPerYear={data.metrics.citationsPerYear} citationGraphSource={data.metrics.citationGraphSource} publications={data.publications} />
@@ -649,6 +655,7 @@ export function ProfileView({
         {activeTab === 'narrativecv' && (
           <NarrativeCvTab data={data} geoData={prefetchedGeo} />
         )}
+        </Suspense>
         </div>
       </main>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,7 +55,11 @@ export default defineConfig({
         background: 'src/background.ts'
       },
       output: {
-        entryFileNames: '[name].js'
+        entryFileNames: '[name].js',
+        manualChunks: {
+          'd3-vendor': ['d3', 'topojson-client'],
+          'recharts-vendor': ['recharts'],
+        }
       }
     },
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- **Code splitting**: lazy-load 5 heavy tab components via React.lazy
- **Vendor chunks**: d3+topojson (80KB) and recharts (563KB) load on demand
- **Main bundle**: 1,374KB → 652KB (52% reduction)
- **World map**: cache 84KB topology JSON at module level (no re-fetch on resize)
- **Skeleton**: dark mode support, matches real ProfileView layout
- **CLS fix**: explicit width/height on profile image
- **Mobile**: title attributes on tab buttons

## Test plan
- [ ] Profile loads correctly, metrics tab shows immediately
- [ ] Switching to Trends tab loads recharts chunk
- [ ] Switching to Network/Map tab loads d3 chunk
- [ ] Dark mode skeleton matches ProfileView
- [ ] Resize map — no duplicate network requests

Generated with [Claude Code](https://claude.com/claude-code)