### PR TITLE
chore: upgrade stripe-node 14.14.0 → 17.7.0

### DIFF
--- a/supabase/functions/create-checkout/index.ts
+++ b/supabase/functions/create-checkout/index.ts
@@ -1,5 +1,5 @@
 import { createClient } from "npm:@supabase/supabase-js@2.39.3";
-import Stripe from "npm:stripe@14.14.0";
+import Stripe from "npm:stripe@17.7.0";
 
 const ALLOWED_ORIGINS = [
   'https://scholarfolio.org',
@@ -29,7 +29,7 @@ const PACKS: Record<string, { credits: number; priceInCents: number; name: strin
 };
 
 const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') ?? '', {
-  apiVersion: '2023-10-16',
+  apiVersion: '2025-02-24.acacia',
 });
 
 const supabase = createClient(

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,8 +1,8 @@
 import { createClient } from "npm:@supabase/supabase-js@2.39.3";
-import Stripe from "npm:stripe@14.14.0";
+import Stripe from "npm:stripe@17.7.0";
 
 const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') ?? '', {
-  apiVersion: '2023-10-16',
+  apiVersion: '2025-02-24.acacia',
 });
 
 const endpointSecret = Deno.env.get('STRIPE_WEBHOOK_SECRET') ?? '';


### PR DESCRIPTION
## Summary

Upgrades `stripe-node` from 14.14.0 → 17.7.0 and the pinned `apiVersion` from `2023-10-16` → `2025-02-24.acacia` in both Stripe edge functions.

**Changed files:**
- `supabase/functions/create-checkout/index.ts`
- `supabase/functions/stripe-webhook/index.ts`

**No logic changes.** Only the npm specifier and `apiVersion` string are touched. All checkout params, webhook event handling, idempotency logic, and CORS headers are identical.

---

## Breaking changes reviewed (v14 → v17)

| Version | Breaking change | Impact on this code |
|---------|----------------|---------------------|
| **v15.0.0** | Rename `features` → `marketing_features` on `Product*` | Not used here |
| **v15.0.0** | Remove deprecated event types (InvoiceitemCreated, etc.) | Not used here |
| **v15.0.0** | Remove `subscription_pause` from BillingPortal | Not used here |
| **v15.0.0** | Remove `rendering_options` on Invoice (use `rendering`) | Not used here |
| **v16.0.0** | Rename `volume_decimal` → `quantity_decimal` on Issuing fuel | Not used here |
| **v16.0.0** | `Capabilities.Requirements.disabled_reason` now an enum | Not used here |
| **v16.0.0** | Remove `PlatformTaxFee` resource | Not used here |
| **v17.0.0** | Rename `usage_threshold_config` → `usage_threshold` on Billing.Alert | Not used here |
| **v17.0.0** | Remove `customer_consent_collected` on Terminal.ReaderProcessSetupIntent | Not used here |
| **v17.0.0** | Default max retries: 1→2, timeout: 2s→5s | Minor: retries increase from 1 to 2. Acceptable for an edge function — Stripe checkout sessions are idempotent on the session create side |
| **apiVersion** | `2023-10-16` → `2025-02-24.acacia` (two named API releases: acacia 2024-09-30, then 2025-02-24) | See API changelog notes below |

### API changelog impact (2023-10-16 → 2025-02-24.acacia)

The code uses exactly two Stripe API surface areas:
1. **`checkout.sessions.create`** — params used: `payment_method_types`, `line_items.price_data`, `mode`, `success_url`, `cancel_url`, `metadata`. None of these params were renamed or removed in any API version between 2023-10-16 and 2025-02-24.acacia.
2. **`webhooks.constructEventAsync`** — already using the async variant (required for Deno/edge environments). This is correct and unchanged. The synchronous `constructEvent` would fail in Deno; the code was already correct before this upgrade.

### Webhook method: already correct

The webhook function already calls `stripe.webhooks.constructEventAsync()` (not `constructEvent`). This is the required pattern for Deno edge functions where the Web Crypto API is used for HMAC verification. No change needed here.

---

## Build status

`npm run build` — PASSED (frontend TypeScript + Vite build, 4.05s, 0 errors)

Deno type-check not run (deno not installed locally). The changes are import specifier strings only — no TypeScript API surface changes that would cause type errors for the code patterns used.

---

## DEPLOY CHECKLIST FOR LATER

**Before running `supabase functions deploy create-checkout --no-verify-jwt` and `supabase functions deploy stripe-webhook --no-verify-jwt`:**

- [ ] In Stripe Dashboard → **Test mode**: confirm a checkout session can be created end-to-end (click "Buy credits" in the app, verify Stripe-hosted page loads with correct EUR amounts for both packs)
- [ ] Complete a test payment with Stripe test card `4242 4242 4242 4242` and confirm:
  - Webhook fires (`checkout.session.completed`)
  - `credit_purchases` row is inserted with correct `stripe_session_id`, `credits`, `amount_cents`
  - `increment_credits` RPC executes and credits appear in the user's account
- [ ] Verify webhook signature verification passes (no 400 responses in Supabase edge function logs)
- [ ] Confirm idempotency: replay the same `checkout.session.completed` event from the Stripe Dashboard webhook tester → should return `{ received: true, duplicate: true }` and NOT double-credit
- [ ] Check Stripe Dashboard → Developers → Logs for any API version deprecation warnings after the first live call
- [ ] Only after all above pass in test mode: deploy to production and monitor Supabase edge function logs for the first real transaction