### PR TITLE
Stop logging aborted fetches as client errors

### DIFF
--- a/src/lib/errorLogger.ts
+++ b/src/lib/errorLogger.ts
@@ -44,8 +44,16 @@ const MAX_ERRORS_PER_SESSION = 20;
 // Dedup: don't log the same error twice in a session
 const loggedErrors = new Set<string>();
 
+// Aborted fetches (user navigated away, typed a new query, or the component
+// unmounted before the request resolved) are expected cancellations, not real
+// failures — drop them so genuine errors aren't buried in noise.
+function isAbortNoise(message: string): boolean {
+  return /\babort(ed)?\b/i.test(message);
+}
+
 export function logError(payload: ErrorLogPayload): void {
   if (errorCount >= MAX_ERRORS_PER_SESSION) return;
+  if (isAbortNoise(payload.message)) return;
 
   // Dedup by category + message
   const dedupeKey = `${payload.category}:${payload.message}`;


### PR DESCRIPTION
Aborted requests (user navigated away, retyped a query, or component unmounted before the fetch resolved) are expected cancellations, not failures. Over the last 7 days they were ~64% of `client_errors` rows, burying genuine errors.

Drops them at the `logError` boundary via an `isAbortNoise` message check, so real failures (Google Scholar 403s, OpenAlex nulls, etc.) stand out.

Build check passes.