### PR TITLE
Reclassify missing OpenAlex stats as a signal, not an error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -339,7 +339,9 @@ function AppContent() {
               });
           } else {
             setData(prev => prev ? { ...prev, openAccessFailed: true } : prev);
-            logError({ category: 'openalex', message: 'OA stats returned null', component: 'App', action: 'fetch-oa-stats', context: { name: sanitizedData.name } });
+            // Not an error — many authors simply aren't well-represented in OpenAlex.
+            // The profile still renders; track it as a signal, not a failure.
+            trackEvent('oa_stats_missing', { author: sanitizedData.name });
             // Still try S2 without DOI map (title search only, capped at 10)
             enrichWithSemanticScholar(sanitizedData.publications)
               .then(s2Result => {


### PR DESCRIPTION
Many authors aren't well-represented in OpenAlex, so OA stats come back null. The profile already renders fine (`openAccessFailed` flag) — it's a degraded state, not a failure. Track it as an `oa_stats_missing` analytics event instead of writing to `client_errors`.

Removes 3/22 rows from the last week's error feed; keeps the signal measurable in analytics.