### PR TITLE
OpenAlex fallback profiles when Google Scholar is unavailable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import { supabase } from './lib/supabase';
 import { ADMIN_EMAIL } from './lib/constants';
 import type { Author } from './types/scholar';
 import { scholarService } from './services/scholar';
-import { openAlexService } from './services/openalex';
+import { openAlexService, fetchOpenAlexProfile, OPENALEX_ID_PREFIX } from './services/openalex';
 import { fetchFieldNormalizedMetrics } from './services/openalex/field-metrics';
 import { enrichWithSemanticScholar } from './services/semanticscholar';
 import { logCaughtError, logError } from './lib/errorLogger';
@@ -188,6 +188,12 @@ function AppContent() {
       }
     }
     const userParam = params.get('user');
+    // OpenAlex fallback profile (?user=openalex:A...) — must be checked before the
+    // generic Scholar handler, which would otherwise wrap it in a scholar.google URL.
+    if (userParam && userParam.startsWith(OPENALEX_ID_PREFIX) && handleSearchRef.current) {
+      handleSearchRef.current(userParam, true);
+      return;
+    }
     if (userParam && userParam.length >= 12 && handleSearchRef.current) {
       const scholarUrl = `https://scholar.google.com/citations?user=${encodeURIComponent(userParam)}`;
       handleSearchRef.current(scholarUrl, true);
@@ -255,8 +261,12 @@ function AppContent() {
       return;
     }
 
-    // Credit/usage checks (skip for direct profile links and vanity URLs)
-    if (!bypassCredits) {
+    // OpenAlex fallback profile (sourced from open data when Scholar is unavailable).
+    // Free to view — it never hits SerpAPI/credits — so skip the usage gates entirely.
+    const isOpenAlex = url.startsWith(OPENALEX_ID_PREFIX);
+
+    // Credit/usage checks (skip for direct profile links, vanity URLs, OpenAlex fallbacks)
+    if (!bypassCredits && !isOpenAlex) {
       if (!user) {
         // Anonymous user — check local free limit
         if (getAnonSearches() >= ANON_FREE_LIMIT) {
@@ -277,22 +287,29 @@ function AppContent() {
       setError(null);
       setData(null);
 
-      const { isValid, userId } = scholarService.validateProfileUrl(url);
-      if (!isValid) {
-        setError('Invalid Google Scholar URL format. Please enter a valid profile URL.');
-        setShowError(true);
-        return;
+      let profileData: Awaited<ReturnType<typeof scholarService.fetchProfile>>;
+      let userId: string | null;
+      if (isOpenAlex) {
+        userId = url; // keep the "openalex:<id>" token for sharing + analytics
+        profileData = await fetchOpenAlexProfile(url);
+      } else {
+        const validated = scholarService.validateProfileUrl(url);
+        if (!validated.isValid) {
+          setError('Invalid Google Scholar URL format. Please enter a valid profile URL.');
+          setShowError(true);
+          return;
+        }
+        userId = validated.userId;
+        profileData = await scholarService.fetchProfile(url, cacheOnly ? { cacheOnly: true } : undefined);
       }
-
-      const profileData = await scholarService.fetchProfile(url, cacheOnly ? { cacheOnly: true } : undefined);
       if (!profileData) {
         setError('Unable to fetch profile data. Please try again later or contact the site administrator.');
         setShowError(true);
         return;
       }
 
-      // Track usage (skip for direct profile links)
-      if (!bypassCredits) {
+      // Track usage (skip for direct profile links and OpenAlex fallbacks)
+      if (!bypassCredits && !isOpenAlex) {
         if (!user) {
           if (profileData.cacheStatus !== 'hit') {
             incrementAnonSearches();

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -116,10 +116,15 @@ export function ProfileView({
     return () => { cancelled = true; };
   }, [data?.name, data?.affiliation, data?.publications]);
 
-  // Extract scholar ID from URL params or profileUrl
-  const scholarId = new URLSearchParams(window.location.search).get('user')
-    || (profileUrl ? new URL(profileUrl).searchParams.get('user') : null)
+  // Extract scholar ID from URL params or profileUrl.
+  // OpenAlex fallback profiles use an "openalex:<id>" token, not a Scholar id —
+  // treat them as having no scholarId so Scholar-only features (embed, claim,
+  // "view on Google Scholar") stay hidden rather than pointing at a bad id.
+  const rawUserId = new URLSearchParams(window.location.search).get('user')
+    || (profileUrl && profileUrl.startsWith('http') ? new URL(profileUrl).searchParams.get('user') : null)
     || '';
+  const isOpenAlexProfile = rawUserId.startsWith('openalex:') || (!!profileUrl && profileUrl.startsWith('openalex:'));
+  const scholarId = isOpenAlexProfile ? '' : rawUserId;
 
   // Check if this profile has been claimed
   useEffect(() => {
@@ -156,9 +161,11 @@ export function ProfileView({
     if (!data) return;
     const title = `${data.name} — Scholar Folio`;
     const description = `${data.affiliation} · ${data.totalCitations.toLocaleString()} citations · h-index ${data.hIndex} · ${data.publications.length} publications`;
+    // OpenAlex profiles have an empty scholarId; fall back to the raw token
+    // (openalex:<id>) so link-preview crawlers get a URL that resolves.
     const url = claimedSlug
       ? `https://scholarfolio.org/${claimedSlug}`
-      : `https://scholarfolio.org/?user=${scholarId}`;
+      : `https://scholarfolio.org/?user=${scholarId || rawUserId}`;
 
     document.title = title;
 
@@ -179,7 +186,7 @@ export function ProfileView({
     return () => {
       document.title = 'Scholar Folio — Your research, at a glance';
     };
-  }, [data, claimedSlug, scholarId]);
+  }, [data, claimedSlug, scholarId, rawUserId]);
 
   const handleClaimed = (slug: string) => {
     setClaimedSlug(slug);
@@ -269,7 +276,7 @@ export function ProfileView({
               )}
               <div className="min-w-0">
                 <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-1 truncate">
-                  {profileUrl ? (
+                  {profileUrl && !isOpenAlexProfile ? (
                     <a
                       href={profileUrl}
                       target="_blank"

--- a/src/components/ScholarSearchModal.tsx
+++ b/src/components/ScholarSearchModal.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { Search, X, MapPin, GraduationCap, Loader2, Link, ArrowRight } from 'lucide-react';
+import { Search, X, MapPin, GraduationCap, Loader2, Link, ArrowRight, Database } from 'lucide-react';
 import { scholarService, type AuthorSearchResult } from '../services/scholar/index';
+import { searchOpenAlexAuthors, OPENALEX_ID_PREFIX } from '../services/openalex';
 
 function UrlFallback({ message, pastedUrl, setPastedUrl, urlError, setUrlError, onSubmit, compact }: {
   message: string;
@@ -73,31 +74,58 @@ export function ScholarSearchModal({ isOpen, onClose, onSelect, initialQuery = '
   const [loading, setLoading] = useState(false);
   const [searched, setSearched] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [source, setSource] = useState<'scholar' | 'openalex'>('scholar');
   const [pastedUrl, setPastedUrl] = useState('');
   const [urlError, setUrlError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const hasAutoSearched = useRef(false);
+
+  // Try Google Scholar first; if it returns nothing or hard-fails, fall back to
+  // OpenAlex's open dataset so users still get a result when Scholar is blocked.
+  const runSearch = useCallback(async (query: string) => {
+    setLoading(true);
+    setError(null);
+    setSearched(true);
+    setSource('scholar');
+
+    let scholarFailed = false;
+    try {
+      const profiles = await scholarService.searchAuthors(query);
+      if (profiles.length > 0) {
+        setResults(profiles);
+        setLoading(false);
+        return;
+      }
+    } catch {
+      scholarFailed = true;
+    }
+
+    // Scholar empty or unavailable — try OpenAlex.
+    try {
+      const oaProfiles = await searchOpenAlexAuthors(query);
+      if (oaProfiles.length > 0) {
+        setResults(oaProfiles);
+        setSource('openalex');
+        setLoading(false);
+        return;
+      }
+    } catch {
+      // ignore — handled by the empty/error states below
+    }
+
+    setResults([]);
+    if (scholarFailed) {
+      setError('Search is temporarily unavailable. Please try again, or paste a Google Scholar URL.');
+    }
+    setLoading(false);
+  }, []);
 
   useEffect(() => {
     if (isOpen) {
       if (initialQuery && !hasAutoSearched.current) {
         setName(initialQuery);
         hasAutoSearched.current = true;
-        // Auto-trigger search
-        (async () => {
-          setLoading(true);
-          setSearched(true);
-          setError(null);
-          try {
-            const profiles = await scholarService.searchAuthors(initialQuery);
-            setResults(profiles);
-          } catch (err) {
-            setError(err instanceof Error ? err.message : 'Search failed.');
-            setResults([]);
-          } finally {
-            setLoading(false);
-          }
-        })();
+        runSearch(initialQuery);
       } else {
         setTimeout(() => inputRef.current?.focus(), 100);
       }
@@ -106,36 +134,28 @@ export function ScholarSearchModal({ isOpen, onClose, onSelect, initialQuery = '
       setResults([]);
       setSearched(false);
       setError(null);
+      setSource('scholar');
       setLoading(false);
       setPastedUrl('');
       setUrlError(null);
       hasAutoSearched.current = false;
     }
-  }, [isOpen, initialQuery]);
+  }, [isOpen, initialQuery, runSearch]);
 
-  const handleSearch = useCallback(async (e: React.FormEvent) => {
+  const handleSearch = useCallback((e: React.FormEvent) => {
     e.preventDefault();
     const query = name.trim();
     if (!query || query.length < 2) return;
-
-    setLoading(true);
-    setError(null);
-    setSearched(true);
-
-    try {
-      const profiles = await scholarService.searchAuthors(query);
-      setResults(profiles);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Search failed. Please try again.');
-      setResults([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [name]);
+    runSearch(query);
+  }, [name, runSearch]);
 
   const handleSelect = useCallback((authorId: string) => {
-    const url = `https://scholar.google.com/citations?user=${authorId}`;
-    onSelect(url);
+    // OpenAlex candidates carry an "openalex:<id>" token routed directly;
+    // Google Scholar candidates are opened via their profile URL.
+    const target = authorId.startsWith(OPENALEX_ID_PREFIX)
+      ? authorId
+      : `https://scholar.google.com/citations?user=${authorId}`;
+    onSelect(target);
     onClose();
   }, [onSelect, onClose]);
 
@@ -244,6 +264,14 @@ export function ScholarSearchModal({ isOpen, onClose, onSelect, initialQuery = '
 
           {!loading && results.length > 0 && (
             <div className="space-y-2">
+              {source === 'openalex' && (
+                <div className="mb-3 flex items-start gap-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-100 dark:border-amber-900/40 px-3 py-2">
+                  <Database className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
+                  <p className="text-[11px] text-amber-700 dark:text-amber-300 leading-relaxed">
+                    Google Scholar is unavailable right now — showing results from <span className="font-medium">OpenAlex</span> instead. Metrics may differ slightly.
+                  </p>
+                </div>
+              )}
               <p className="text-xs text-gray-400 mb-3">{results.length} profile{results.length !== 1 ? 's' : ''} found — select the correct one</p>
               {results.map((profile) => (
                 <button

--- a/src/services/openalex/index.ts
+++ b/src/services/openalex/index.ts
@@ -2,6 +2,8 @@ import { timeoutSignal } from '../../utils/api';
 import type { JournalRanking, OpenAccessStats, OaStatus } from '../../types/scholar';
 import { findOpenAlexAuthor, oaFetchJson, oaRateLimiter, OA_API_URL, OA_EMAIL } from './author-lookup';
 
+export { searchOpenAlexAuthors, fetchOpenAlexProfile, OPENALEX_ID_PREFIX, toOpenAlexShortId } from './profile';
+
 export class OpenAlexService {
   /**
    * Search OpenAlex for an author by name + affiliation, return OA stats.

--- a/src/services/openalex/profile.ts
+++ b/src/services/openalex/profile.ts
@@ -1,0 +1,163 @@
+import type { Author, Publication } from '../../types/scholar';
+import { buildAuthorResult, type AuthorSearchResult } from '../scholar/index';
+import { oaFetchJson, OA_API_URL, OA_EMAIL } from './author-lookup';
+
+/**
+ * OpenAlex fallback profile source.
+ *
+ * When Google Scholar is unavailable (SerpAPI empty + scrape blocked), we can
+ * still build a full ScholarFolio profile from OpenAlex's open dataset. These
+ * profiles are namespaced with an `openalex:` identifier prefix so the rest of
+ * the app can route them without colliding with Google Scholar user IDs.
+ */
+
+export const OPENALEX_ID_PREFIX = 'openalex:';
+
+/** Strip the `openalex:` prefix and any OpenAlex URL wrapper, returning the bare id (e.g. "A5023888391"). */
+export function toOpenAlexShortId(identifier: string): string {
+  return identifier
+    .replace(OPENALEX_ID_PREFIX, '')
+    .replace('https://openalex.org/', '')
+    .trim();
+}
+
+interface OaAuthorRecord {
+  id: string;
+  display_name: string;
+  works_count?: number;
+  cited_by_count?: number;
+  summary_stats?: { h_index?: number; i10_index?: number };
+  last_known_institutions?: Array<{ display_name?: string }>;
+  affiliations?: Array<{ institution?: { display_name?: string } }>;
+  counts_by_year?: Array<{ year: number; cited_by_count: number }>;
+  topics?: Array<{ id: string; display_name: string; count?: number }>;
+  x_concepts?: Array<{ id: string; display_name: string; score?: number }>;
+}
+
+interface OaWork {
+  title?: string;
+  display_name?: string;
+  publication_year?: number;
+  cited_by_count?: number;
+  doi?: string;
+  id?: string;
+  authorships?: Array<{ author?: { display_name?: string } }>;
+  primary_location?: { source?: { display_name?: string } };
+}
+
+const SELECT_AUTHOR = 'id,display_name,works_count,cited_by_count,summary_stats,last_known_institutions,affiliations,counts_by_year,topics,x_concepts';
+const SELECT_WORK = 'title,display_name,publication_year,cited_by_count,doi,id,authorships,primary_location';
+const MAX_WORKS = 400;
+
+/**
+ * Search OpenAlex for authors by name, returning candidates shaped like Scholar
+ * search results. Used as a last-resort fallback when Scholar search hard-fails.
+ */
+export async function searchOpenAlexAuthors(query: string): Promise<AuthorSearchResult[]> {
+  const data = await oaFetchJson<{ results: OaAuthorRecord[] }>(
+    `${OA_API_URL}/authors?search=${encodeURIComponent(query)}&per_page=10&select=${SELECT_AUTHOR}&mailto=${OA_EMAIL}`,
+    10000
+  );
+
+  const results = data?.results;
+  if (!results?.length) return [];
+
+  return results
+    .filter(a => (a.works_count ?? 0) > 0)
+    .map(a => ({
+      name: a.display_name,
+      affiliation: affiliationOf(a),
+      imageUrl: '',
+      authorId: OPENALEX_ID_PREFIX + a.id.replace('https://openalex.org/', ''),
+      citedBy: a.cited_by_count ?? 0,
+      interests: interestsOf(a),
+    }));
+}
+
+/**
+ * Build a full Author profile from an OpenAlex author id (with or without the
+ * `openalex:` prefix). Fetches the author record plus their most-cited works and
+ * runs them through the same metrics pipeline used for Google Scholar profiles.
+ */
+export async function fetchOpenAlexProfile(identifier: string): Promise<Author> {
+  const shortId = toOpenAlexShortId(identifier);
+  // OpenAlex author ids are always "A" followed by digits. Validate before
+  // interpolating into request URLs so a crafted ?user= token can't inject.
+  if (!/^A\d+$/.test(shortId)) {
+    throw new Error('Invalid OpenAlex author id');
+  }
+  const fullId = `https://openalex.org/${shortId}`;
+
+  const author = await oaFetchJson<OaAuthorRecord>(
+    `${OA_API_URL}/authors/${shortId}?select=${SELECT_AUTHOR}&mailto=${OA_EMAIL}`,
+    15000
+  );
+  if (!author) {
+    throw new Error('OpenAlex author not found');
+  }
+
+  // Most-cited works first so a bounded fetch still captures everything that
+  // drives h-index / i10 / citation charts for prolific authors.
+  const works: OaWork[] = [];
+  let cursor = '*';
+  while (works.length < MAX_WORKS && cursor) {
+    const page = await oaFetchJson<{ results: OaWork[]; meta?: { next_cursor?: string } }>(
+      `${OA_API_URL}/works?filter=authorships.author.id:${fullId}` +
+      `&select=${SELECT_WORK}&sort=cited_by_count:desc&per_page=200&cursor=${encodeURIComponent(cursor)}&mailto=${OA_EMAIL}`,
+      15000
+    );
+    const batch = page?.results ?? [];
+    works.push(...batch);
+    cursor = batch.length > 0 ? (page?.meta?.next_cursor ?? '') : '';
+  }
+
+  const publications: Publication[] = works
+    .filter(w => w.title || w.display_name)
+    .map(w => ({
+      title: (w.title || w.display_name || '').trim(),
+      authors: (w.authorships || [])
+        .map(a => a.author?.display_name || '')
+        .filter(Boolean),
+      venue: w.primary_location?.source?.display_name || '',
+      year: w.publication_year || 0,
+      citations: w.cited_by_count ?? 0,
+      url: workUrl(w),
+    }));
+
+  // Real citations-per-year straight from OpenAlex's author counts.
+  const citationsPerYear: Record<string, number> = {};
+  for (const c of author.counts_by_year || []) {
+    if (c.year) citationsPerYear[String(c.year)] = c.cited_by_count;
+  }
+
+  return buildAuthorResult({
+    name: author.display_name,
+    affiliation: affiliationOf(author),
+    imageUrl: undefined,
+    topics: interestsOf(author).map(name => ({ name, url: '', paperCount: 0 })),
+    hIndex: author.summary_stats?.h_index ?? 0,
+    totalCitations: author.cited_by_count ?? 0,
+    publications,
+    metrics: { citationsPerYear, citationGraphSource: 'cited_by_graph' },
+    cacheStatus: 'miss',
+  });
+}
+
+function affiliationOf(a: OaAuthorRecord): string {
+  return (
+    a.last_known_institutions?.[0]?.display_name ||
+    a.affiliations?.[0]?.institution?.display_name ||
+    ''
+  );
+}
+
+function interestsOf(a: OaAuthorRecord): string[] {
+  const fromTopics = (a.topics || []).map(t => t.display_name).filter(Boolean);
+  if (fromTopics.length) return fromTopics.slice(0, 8);
+  return (a.x_concepts || []).map(c => c.display_name).filter(Boolean).slice(0, 8);
+}
+
+function workUrl(w: OaWork): string {
+  if (w.doi) return w.doi.startsWith('http') ? w.doi : `https://doi.org/${w.doi}`;
+  return w.id || '';
+}

--- a/src/services/scholar/index.ts
+++ b/src/services/scholar/index.ts
@@ -147,7 +147,7 @@ function stripTitleSuffix(name: string): string {
   return name.replace(/\s*[-–—]\s*(Full|Associate|Assistant|Emeritus|Adjunct|Visiting|Research|Senior|Junior|Distinguished|Clinical|Tenured)?\s*(Professor|Lecturer|Fellow|Director|Dean|Chair|Researcher|Scientist|Engineer|Doctor|PhD|Dr|MD|Instructor|Postdoc|PostDoc)\b.*/i, '').trim() || name;
 }
 
-function buildAuthorResult(data: any): Author {
+export function buildAuthorResult(data: any): Author {
   const cleanName = stripTitleSuffix(data.name || '');
 
   const publications = (data.publications || []).map(pub => ({


### PR DESCRIPTION
## What & why
When a Google Scholar search hard-fails (SerpAPI returns empty **and** the scrape fallback gets a 403 — ~3 cases in the last 7 days), users got a dead end. This adds an **OpenAlex fallback**: we search OpenAlex's open dataset and can build a full ScholarFolio profile from it, threaded through the exact same metrics/render pipeline as Scholar.

## How it works
- `services/openalex/profile.ts` — `searchOpenAlexAuthors()` returns candidates tagged `openalex:<id>`; `fetchOpenAlexProfile()` pulls the author record + up to 400 most-cited works and reuses `buildAuthorResult()` so metrics are computed identically.
- **Search modal** tries Scholar first, falls back to OpenAlex on empty/error, and shows an amber "showing OpenAlex results" banner.
- **Routing** — `openalex:` profiles are free to view (never touch SerpAPI/credits), shareable via `?user=openalex:<id>`, and Scholar-only features (embed, claim, "view on Google Scholar") are hidden for them.

## Safety
- Reviewed by the reviewer agent: **PASS**. Confirmed the credit/anon-search bypass is reachable only via the `openalex:` prefix and can never fetch *Scholar* data for free; no `openalex:` token leaks into the edge function, claimed_profiles, or a scholar.google URL.
- Author-id shape validated (`/^A\\d+$/`) before any request URL is built (per review).
- NaN-safe field mapping; 0-works and >400-works handled.

Build check passes.