### PR TITLE
Fix OpenAlex integration: keyed edge-function proxy

### DIFF
--- a/src/components/OpenAlexNotice.tsx
+++ b/src/components/OpenAlexNotice.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { Info, X } from 'lucide-react';
+
+const DISMISS_KEY = 'openalex-notice-dismissed';
+
+/**
+ * Temporary notice shown on OpenAlex-powered surfaces (World Map, Open Science,
+ * P-Index). OpenAlex began requiring API keys on 13 Feb 2026 and now hard-limits
+ * anonymous access, which intermittently returns 503s under load. Remove this
+ * component once the edge-function API-key proxy is live.
+ */
+export function OpenAlexNotice() {
+  const [dismissed, setDismissed] = useState(
+    () => typeof sessionStorage !== 'undefined' && sessionStorage.getItem(DISMISS_KEY) === '1'
+  );
+
+  if (dismissed) return null;
+
+  return (
+    <div className="relative flex items-start gap-3 rounded-xl border border-amber-300/60 bg-amber-50 px-4 py-3 mb-4 dark:border-amber-500/30 dark:bg-amber-500/10">
+      <Info className="h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5" />
+      <div className="pr-6 text-sm text-amber-900 dark:text-amber-100">
+        <span className="font-semibold">This section may be temporarily incomplete.</span>{' '}
+        Our open-data provider (OpenAlex) changed its API usage policy in February 2026
+        and is currently rate-limiting requests. We&rsquo;re rolling out a fix and expect
+        it back to normal shortly. Thanks for your patience!
+      </div>
+      <button
+        onClick={() => {
+          setDismissed(true);
+          try { sessionStorage.setItem(DISMISS_KEY, '1'); } catch { /* ignore */ }
+        }}
+        className="absolute top-2.5 right-2.5 text-amber-500 hover:text-amber-700 dark:hover:text-amber-300 transition-colors"
+        aria-label="Dismiss"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/PIndexSection.tsx
+++ b/src/components/PIndexSection.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { Search, Loader2, CheckCircle, AlertTriangle, ChevronDown, ChevronUp, Info } from 'lucide-react';
-import { OA_API_URL, OA_EMAIL, oaRateLimiter } from '../services/openalex/author-lookup';
-import { timeoutSignal } from '../utils/api';
+import { OA_API_URL, OA_EMAIL, oaRateLimiter, oaFetchJson } from '../services/openalex/author-lookup';
 import { logCaughtError } from '../lib/errorLogger';
 import { fetchPIndexWorks, computePIndexFromWorks, type PIndexWork, type PIndexResult } from '../services/openalex/pindex';
 import { MetricsCard } from './MetricsCard';
+import { OpenAlexNotice } from './OpenAlexNotice';
 
 interface OpenAlexSearchResult {
   id: string;
@@ -133,16 +133,14 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
     try {
       const query = `${firstName} ${lastName}`;
       const url = `${OA_API_URL}/authors?search=${encodeURIComponent(query)}&per_page=10&select=id,display_name,works_count,cited_by_count,last_known_institutions&mailto=${OA_EMAIL}`;
-      // Direct fetch — bypass the shared rate limiter to avoid queuing behind OA stats
-      // Don't send OA_HEADERS (custom User-Agent is a forbidden header on Firefox/mobile)
-      // The mailto= param in the URL is sufficient for OpenAlex polite pool
-      const response = await fetch(url, { signal: timeoutSignal(15000) });
-      if (!response.ok) {
-        setErrorMsg(`Could not reach OpenAlex (HTTP ${response.status}). Please wait a moment and try again. (SF-PI-SEARCH)`);
+      // Routed through the scholar edge function, which injects the server-side
+      // OpenAlex API key (mandatory since 2026-02-13) and caches the response.
+      const data = await oaFetchJson<{ results: OpenAlexSearchResult[] }>(url);
+      if (!data) {
+        setErrorMsg('Could not reach OpenAlex. Please wait a moment and try again. (SF-PI-SEARCH)');
         setStep('error');
         return;
       }
-      const data: { results: OpenAlexSearchResult[] } = await response.json();
 
       if (!data.results?.length) {
         setErrorMsg('No authors found in OpenAlex. Try adjusting the name. (SF-PI-NORESULT)');
@@ -289,6 +287,8 @@ export function PIndexSection({ authorName, affiliation, onResult, scrapedPublic
         P-Index
         <a href="https://academic.oup.com/jcr/article-abstract/51/1/191/7672992" target="_blank" rel="noopener noreferrer" className="text-[10px] font-normal text-gray-400 dark:text-gray-500 hover:text-[#2d7d7d] transition-colors">(Pham, Wu &amp; Wang, 2024)</a>
       </h3>
+
+      <OpenAlexNotice />
 
       {/* Step 1: Idle — info + search form */}
       {step === 'idle' && (

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -27,6 +27,7 @@ import { extractLastName } from '../utils/names';
 import { useFeedback } from '../hooks/useFeedback';
 import { FeedbackModal } from './FeedbackModal';
 import { FeedbackPromptBanner } from './FeedbackPromptBanner';
+import { OpenAlexNotice } from './OpenAlexNotice';
 import { trackProfileView } from '../services/profile-views';
 import packageJson from '../../package.json';
 
@@ -656,16 +657,22 @@ export function ProfileView({
         )}
 
         {activeTab === 'worldmap' && (
-          <CoAuthorMap
-            publications={data.publications}
-            authorName={data.name}
-            authorAffiliation={data.affiliation}
-            prefetchedData={prefetchedGeo}
-          />
+          <>
+            <OpenAlexNotice />
+            <CoAuthorMap
+              publications={data.publications}
+              authorName={data.name}
+              authorAffiliation={data.affiliation}
+              prefetchedData={prefetchedGeo}
+            />
+          </>
         )}
 
         {activeTab === 'openscience' && (
-          <OpenScienceTab data={data} />
+          <>
+            <OpenAlexNotice />
+            <OpenScienceTab data={data} />
+          </>
         )}
 
         {activeTab === 'publications' && (

--- a/src/services/openalex/author-lookup.ts
+++ b/src/services/openalex/author-lookup.ts
@@ -10,13 +10,36 @@ export const OA_API_URL = API_URL;
 /** Shared rate limiter for all OpenAlex calls (polite pool allows ~100/sec) */
 export const oaRateLimiter = new RateLimiter(5000, 100);
 
-/** Generic JSON fetcher with rate limiting and timeout */
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || '';
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || '';
+
+/** Strip the OpenAlex origin so only the path+query reaches our proxy. */
+function toOaPath(url: string): string {
+  return url.replace(/^https?:\/\/api\.openalex\.org/, '');
+}
+
+/**
+ * Generic OpenAlex JSON fetcher. Routed through the `scholar` edge function,
+ * which injects a server-side OpenAlex API key (mandatory since 2026-02-13) so
+ * every visitor shares one authenticated, rate-stable pool rather than the
+ * best-effort anonymous tier. Responses are cached server-side to conserve the
+ * daily credit budget.
+ */
 export async function oaFetchJson<T>(url: string, timeoutMs = 15000): Promise<T | null> {
   try {
     await oaRateLimiter.acquireToken();
-    const response = await fetch(url, { signal: timeoutSignal(timeoutMs) });
+    const oaPath = toOaPath(url);
+    const response = await fetch(`${SUPABASE_URL}/functions/v1/scholar`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
+      },
+      body: JSON.stringify({ action: 'openalex', oaPath }),
+      signal: timeoutSignal(timeoutMs),
+    });
     if (!response.ok) {
-      console.warn(`[OpenAlex] HTTP ${response.status} for ${url.split('?')[0]}`);
+      console.warn(`[OpenAlex] proxy HTTP ${response.status} for ${toOaPath(url).split('?')[0]}`);
       return null;
     }
     return await response.json() as T;

--- a/src/services/openalex/index.ts
+++ b/src/services/openalex/index.ts
@@ -1,6 +1,5 @@
-import { timeoutSignal } from '../../utils/api';
 import type { JournalRanking, OpenAccessStats, OaStatus } from '../../types/scholar';
-import { findOpenAlexAuthor, oaFetchJson, oaRateLimiter, OA_API_URL, OA_EMAIL } from './author-lookup';
+import { findOpenAlexAuthor, oaFetchJson, OA_API_URL, OA_EMAIL } from './author-lookup';
 
 export { searchOpenAlexAuthors, fetchOpenAlexProfile, OPENALEX_ID_PREFIX, toOpenAlexShortId } from './profile';
 
@@ -17,14 +16,9 @@ export class OpenAlexService {
       const authorId = author.id;
 
       // Get works grouped by OA status
-      await oaRateLimiter.acquireToken();
       const worksUrl = `${OA_API_URL}/works?filter=authorships.author.id:${authorId}&group_by=open_access.oa_status&per_page=10&mailto=${OA_EMAIL}`;
-      const worksResponse = await fetch(worksUrl, {
-        signal: timeoutSignal(10000)
-      });
-
-      if (!worksResponse.ok) return null;
-      const worksData = await worksResponse.json();
+      const worksData = await oaFetchJson<{ group_by?: Array<{ key: string; count: number }> }>(worksUrl);
+      if (!worksData) return null;
 
       const groups: Record<string, number> = {};
       let total = 0;
@@ -53,13 +47,9 @@ export class OpenAlexService {
       let page = 1;
       const maxPages = 10;
       while (page <= maxPages) {
-        await oaRateLimiter.acquireToken();
         const pubsUrl = `${OA_API_URL}/works?filter=authorships.author.id:${authorId}&select=title,open_access,best_oa_location,publication_year,doi&per_page=200&page=${page}&mailto=${OA_EMAIL}`;
-        const pubsResponse = await fetch(pubsUrl, {
-          signal: timeoutSignal(15000)
-        });
-        if (!pubsResponse.ok) break;
-        const pubsData = await pubsResponse.json();
+        const pubsData = await oaFetchJson<{ results?: any[] }>(pubsUrl);
+        if (!pubsData) break;
         const results = pubsData.results || [];
         if (results.length === 0) break;
 

--- a/supabase/functions/scholar/index.ts
+++ b/supabase/functions/scholar/index.ts
@@ -45,10 +45,42 @@ function getRequestIp(req: Request): string {
 const CACHE_DURATION = 604800; // 7 days in seconds
 const SERPAPI_KEY = Deno.env.get('SERPAPI_KEY') ?? '';
 
+// --- OpenAlex proxy config ---
+// OpenAlex made API keys mandatory on 2026-02-13 and now throttles keyless/anonymous
+// traffic. We inject a server-side key so every visitor shares one authenticated,
+// rate-stable pool instead of the best-effort anonymous tier.
+const OPENALEX_BASE = 'https://api.openalex.org';
+const OA_ALLOWED_ENDPOINTS = new Set([
+  'authors', 'works', 'institutions', 'sources', 'venues',
+  'concepts', 'topics', 'funders', 'publishers',
+]);
+const OA_CACHE_TTL_SECONDS = 259200; // 3 days
+
 const supabase = createClient(
   Deno.env.get('SUPABASE_URL') ?? '',
   Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
 );
+
+// Resolve the OpenAlex API key. Prefers a platform env secret (OPENALEX_API_KEY);
+// falls back to the RLS-locked `app_config` table (service-role only) so the key
+// can be set/rotated via SQL without a redeploy. Cached per warm instance.
+let _oaKeyCache: string | null = null;
+async function getOpenAlexKey(): Promise<string> {
+  const envKey = Deno.env.get('OPENALEX_API_KEY');
+  if (envKey) return envKey;
+  if (_oaKeyCache !== null) return _oaKeyCache;
+  try {
+    const { data } = await supabase
+      .from('app_config')
+      .select('value')
+      .eq('key', 'openalex_api_key')
+      .maybeSingle();
+    _oaKeyCache = data?.value ?? '';
+  } catch {
+    _oaKeyCache = '';
+  }
+  return _oaKeyCache;
+}
 
 // --- SerpAPI fetch (primary) ---
 async function fetchViaSerpAPI(authorId: string) {
@@ -842,6 +874,120 @@ async function searchAuthorsByName(query: string) {
   throw new Error(`All search methods failed for "${query}": ${errors.join(' | ')}`);
 }
 
+// --- In-memory per-IP rate limit for the OpenAlex proxy ---
+// Module-scoped (per warm instance). Combined with response caching this bounds
+// credit-drain / DoS abuse of the shared server key without writing a row per call
+// to request_logs (which would bloat analytics and the daily_search_stats trigger).
+// A large profile view fans out ~50-60 OA calls, so the cap allows ~2 views/min/IP.
+const OA_RL_WINDOW_MS = 60_000;
+const OA_RL_MAX = 120;
+const oaRateHits = new Map<string, number[]>();
+
+function oaProxyRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const cutoff = now - OA_RL_WINDOW_MS;
+  const hits = (oaRateHits.get(ip) || []).filter((t) => t > cutoff);
+  // Opportunistic prune to keep the map from growing unbounded.
+  if (oaRateHits.size > 5000) {
+    for (const [k, v] of oaRateHits) {
+      if (v.every((t) => t <= cutoff)) oaRateHits.delete(k);
+    }
+  }
+  if (hits.length >= OA_RL_MAX) {
+    oaRateHits.set(ip, hits);
+    return true;
+  }
+  hits.push(now);
+  oaRateHits.set(ip, hits);
+  return false;
+}
+
+// --- OpenAlex proxy ---
+// Accepts a relative OpenAlex path (e.g. "/authors?search=..."), validates the
+// endpoint against an allowlist (prevents this from becoming an open proxy),
+// injects the server-side API key, and caches responses in scholar_cache to
+// conserve the daily credit budget. Never throws — returns a status/body object.
+async function handleOpenAlexProxy(
+  oaPath: unknown
+): Promise<{ status: number; body: any; cache?: 'HIT' | 'MISS' }> {
+  if (typeof oaPath !== 'string' || !oaPath.startsWith('/') || oaPath.length > 2000) {
+    return { status: 400, body: { error: 'Invalid OpenAlex path' } };
+  }
+
+  const endpoint = oaPath.slice(1).split(/[/?]/)[0];
+  if (!OA_ALLOWED_ENDPOINTS.has(endpoint)) {
+    return { status: 400, body: { error: `OpenAlex endpoint not allowed: ${endpoint}` } };
+  }
+
+  let target: URL;
+  try {
+    target = new URL(OPENALEX_BASE + oaPath);
+  } catch {
+    return { status: 400, body: { error: 'Malformed OpenAlex path' } };
+  }
+  // Hard SSRF guard — the host must remain OpenAlex regardless of the input.
+  if (target.hostname !== 'api.openalex.org') {
+    return { status: 400, body: { error: 'Invalid OpenAlex host' } };
+  }
+
+  // Strip any client-supplied credentials; the server controls these.
+  target.searchParams.delete('api_key');
+  target.searchParams.delete('mailto');
+
+  // Cache key excludes auth params so it stays stable.
+  const cacheKey = `oa:${target.pathname}?${target.searchParams.toString()}`;
+
+  try {
+    const { data: cached } = await supabase
+      .from('scholar_cache')
+      .select('data')
+      .eq('url', cacheKey)
+      .gt('expires_at', new Date().toISOString())
+      .maybeSingle();
+    if (cached?.data) {
+      return { status: 200, body: cached.data, cache: 'HIT' };
+    }
+  } catch (_) { /* cache miss is non-fatal */ }
+
+  // Attach server credentials: real key if configured, else fall back to the
+  // (now best-effort) polite pool so nothing hard-breaks before the key is set.
+  const oaKey = await getOpenAlexKey();
+  if (oaKey) {
+    target.searchParams.set('api_key', oaKey);
+  } else {
+    target.searchParams.set('mailto', 'info@scholarfolio.org');
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch(target.toString(), { signal: AbortSignal.timeout(15000) });
+  } catch (e) {
+    // Do NOT echo the error: Deno's fetch failure message embeds the full request
+    // URL, which includes the api_key. Log it server-side only, return generic text.
+    console.error('[OpenAlex proxy] fetch failed:', e instanceof Error ? e.message : String(e));
+    return { status: 502, body: { error: 'OpenAlex request failed' } };
+  }
+
+  if (!resp.ok) {
+    return { status: resp.status, body: { error: `OpenAlex HTTP ${resp.status}` } };
+  }
+
+  let json: any;
+  try {
+    json = await resp.json();
+  } catch {
+    return { status: 502, body: { error: 'OpenAlex returned invalid JSON' } };
+  }
+
+  // Best-effort cache write — never blocks the response.
+  try {
+    const expiresAt = new Date(Date.now() + OA_CACHE_TTL_SECONDS * 1000).toISOString();
+    await supabase.from('scholar_cache').upsert({ url: cacheKey, data: json, expires_at: expiresAt });
+  } catch (_) { /* non-fatal */ }
+
+  return { status: 200, body: json, cache: 'MISS' };
+}
+
 Deno.serve(async (req) => {
   const corsHeaders = getCorsHeaders(req);
 
@@ -877,6 +1023,25 @@ Deno.serve(async (req) => {
       if (!authError && authUser) {
         userId = authUser.id;
       }
+    }
+
+    // --- OpenAlex proxy (server-keyed, cached, per-IP rate limited) ---
+    if (action === 'openalex') {
+      if (oaProxyRateLimited(clientIp)) {
+        return new Response(
+          JSON.stringify({ error: 'Too many requests. Please slow down.' }),
+          { status: 429, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+      const proxied = await handleOpenAlexProxy(requestData.oaPath);
+      return new Response(JSON.stringify(proxied.body), {
+        status: proxied.status,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+          ...(proxied.cache ? { 'X-OA-Cache': proxied.cache } : {}),
+        },
+      });
     }
 
     // --- Author search by name (no credit cost, but rate limited) ---


### PR DESCRIPTION
## Problem
OpenAlex made API keys mandatory on **2026-02-13** and now throttles keyless/`mailto` (anonymous) traffic. Under load it returns `503 "Anonymous search is temporarily rate-limited"`, which silently broke:
- **World Map** (co-author geography)
- **Open Science** (OA breakdown, ORCID)
- **Field-Normalized metrics** (FWCI, mean journal impact)
- **P-Index**

Google Scholar data (citations, h/g/i10, trends, co-author network) was unaffected.

## Fix
- All client OpenAlex calls now route through the `scholar` edge function via a new `action: "openalex"` proxy.
- The proxy injects a **server-side OpenAlex API key** (env secret or RLS-locked `app_config` table), so every visitor shares one authenticated, rate-stable pool instead of the deprecated anonymous tier.
- Responses cached in `scholar_cache` (3-day TTL) to conserve the daily credit budget.
- Endpoint **allowlist + SSRF host guard** so it can't be used as an open proxy; **per-IP in-memory rate limit** to prevent credit-drain abuse; fetch errors no longer echo the key.
- Dismissible notice on affected tabs while the change propagates.

## Deploy status
- Edge function **already deployed** (v88, `verify_jwt=false`) and verified live: OpenAlex author search returns 200 (was 503), cache HIT confirmed, SSRF probes blocked, normal search regression-tested OK.
- `OPENALEX_API_KEY` stored server-side.

Merging this ships the frontend rewiring to Netlify.