### PR TITLE
Fix top-venue count: fold punctuation/whitespace variants

### DIFF
--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -52,6 +52,12 @@ function getTopVenues(publications: Author['publications'], limit: number): { na
         .replace(/,\s*\d[\d()–\-\s]*$/, '')
         .replace(/\s+\d+\s*,.*$/, '')
         .replace(/\s+\d+\s*$/, '')
+        // Collapse internal whitespace and strip trailing punctuation so
+        // "Computers in Human Behavior." folds into "Computers in Human Behavior"
+        // rather than splitting the count. Distinct titles (e.g. "… Reports")
+        // are preserved.
+        .replace(/\s+/g, ' ')
+        .replace(/[.,;:]+$/, '')
         .trim();
       // Skip non-journal venues (repositories, working papers, etc.)
       const lowerBase = baseName.toLowerCase();


### PR DESCRIPTION
The 'most frequent publication outlets (N)' narrative grouped venues by a key that retained trailing punctuation and non-normalized whitespace, so variants like `Computers in Human Behavior.` vs `Computers in Human Behavior` split into separate buckets and undercounted. Collapses whitespace and strips trailing punctuation before keying. Distinct journal titles (e.g. sister journals `… Reports` / `…: Artificial Humans`) remain separate.