### PR TITLE
Correct git commit identity in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,4 +16,5 @@ React + TypeScript, Vite, Tailwind CSS.
 - One change per deploy. Never bundle unrelated changes.
 
 ## Git
-- Commit as: `Jonas Heller <jonasheller89@gmail.com>`
+- Commit as: `Jonas Heller <168646044+jheller1212@users.noreply.github.com>`
+  (GitHub email privacy is enabled — pushes using `jonasheller89@gmail.com` are rejected.)


### PR DESCRIPTION
`CLAUDE.md` instructed commits as `jonasheller89@gmail.com`, which GitHub's email-privacy setting rejects on push. Points at the working noreply identity.