### PR TITLE
Unify venue normalization + fold journal abbreviations

### DIFF
--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -5,6 +5,7 @@ import { logCaughtError } from '../lib/errorLogger';
 import type { Author, CoAuthorGeoData, FieldNormalizedMetrics } from '../types/scholar';
 import type { PIndexResult } from '../services/openalex/pindex';
 import { findJournalRanking } from '../data/journalRankings';
+import { normalizeVenueName } from '../utils/venue';
 import { scholarService } from '../services/scholar';
 
 interface ResearcherNarrativeProps {
@@ -64,8 +65,11 @@ function getTopVenues(publications: Author['publications'], limit: number): { na
       const isNonJournal = /\b(ssrn|arxiv|researchgate|netspar|rijksoverheid|working paper|discussion paper|technical report|preprint|mimeo|unpublished|available at|course|thesis|dissertation|patent|us patent|google patent|university press|academic press|verlag|publisher|editora)\b/i.test(lowerBase);
       if (isNonJournal || baseName.length <= 3) return;
 
-      if (baseName.length > 0) {
-        const key = baseName.toLowerCase();
+      // Group on the canonical key (shared with journal-ranking lookup) so
+      // abbreviations and punctuation/whitespace variants fold together, while
+      // the human-readable baseName is kept for display.
+      const key = normalizeVenueName(venue);
+      if (key.length >= 3) {
         const existing = venueCounts.get(key);
         if (existing) {
           existing.count++;

--- a/src/data/journalRankings.ts
+++ b/src/data/journalRankings.ts
@@ -1,4 +1,6 @@
 // Journal rankings data with extended information
+import { normalizeVenueName } from '../utils/venue';
+
 export const JOURNAL_RANKINGS: Record<string, {
   sjr?: 'Q1' | 'Q2' | 'Q3' | 'Q4';
   jcr?: string;
@@ -84,21 +86,6 @@ export const JOURNAL_RANKINGS: Record<string, {
   'frontiers in sports and active living': { sjr: 'Q2', jcr: '2.231', abdc: 'C' },
   'advances in consumer research': { sjr: 'Q2', abs: '2', abdc: 'B' }
 };
-
-// Helper function to normalize a venue/journal name for matching
-function normalizeVenueName(name: string): string {
-  return name.toLowerCase()
-    .replace(/,.*$/, '')           // Remove everything after first comma
-    .replace(/\s+\d+.*$/, '')      // Remove volume/issue numbers and everything after
-    .replace(/\([^)]*\)/g, '')     // Remove parenthetical content
-    .replace(/proceedings.*$/i, '')
-    .replace(/conference.*$/i, '')
-    .trim()
-    .replace(/\s+/g, ' ')
-    .replace(/[.,;:\-]/g, '')
-    .replace(/&/g, 'and')
-    .replace(/^the\s+/, '');
-}
 
 // Helper function to find matching journal with strict matching logic
 export function findJournalRanking(venue: string) {

--- a/src/utils/venue.ts
+++ b/src/utils/venue.ts
@@ -1,0 +1,53 @@
+// Canonical venue-name normalization, shared by the top-venue counter
+// (ResearcherNarrative) and the journal-ranking matcher (journalRankings) so the
+// two stay consistent — a journal that's counted is normalized the same way it's
+// looked up for FT50/ABS tags.
+
+// Common ISO-4-style journal abbreviations → canonical full names. An abbreviated
+// venue string ("Comput. Hum. Behav.") folds into the same key as the full name
+// instead of splitting the count. Keys are in already-normalized form (lowercased,
+// punctuation-stripped). Only EXACT matches expand, so distinct journals are never
+// conflated (e.g. "computers in human behavior reports" stays separate).
+const VENUE_ABBREVIATIONS: Record<string, string> = {
+  'comput hum behav': 'computers in human behavior',
+  'j mark': 'journal of marketing',
+  'j mark res': 'journal of marketing research',
+  'j consum res': 'journal of consumer research',
+  'j consum psychol': 'journal of consumer psychology',
+  'j retail': 'journal of retailing',
+  'j retail consum serv': 'journal of retailing and consumer services',
+  'j bus res': 'journal of business research',
+  'j serv res': 'journal of service research',
+  'j serv manag': 'journal of service management',
+  'int j res mark': 'international journal of research in marketing',
+  'j acad mark sci': 'journal of the academy of marketing science',
+  'eur j mark': 'european journal of marketing',
+  'ind mark manag': 'industrial marketing management',
+  'psychol mark': 'psychology and marketing',
+  'psychol sci': 'psychological science',
+  'mark sci': 'marketing science',
+  'mis q': 'mis quarterly',
+  'inf syst res': 'information systems research',
+};
+
+/**
+ * Normalize a raw venue string to a canonical match key: strip volume/issue/page
+ * suffixes, parentheticals, conference/proceedings tails, and punctuation; collapse
+ * whitespace; fold `&`→`and` and a leading `the`; then expand known abbreviations.
+ * Returns '' when nothing meaningful remains.
+ */
+export function normalizeVenueName(name: string): string {
+  if (!name) return '';
+  const base = name.toLowerCase()
+    .replace(/,.*$/, '')            // drop everything after the first comma (vol/page)
+    .replace(/\s+\d+.*$/, '')       // drop volume/issue numbers and everything after
+    .replace(/\([^)]*\)/g, '')      // drop parenthetical content
+    .replace(/proceedings.*$/i, '')
+    .replace(/conference.*$/i, '')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/[.,;:\-]/g, '')       // strip punctuation (folds "behavior." → "behavior")
+    .replace(/&/g, 'and')
+    .replace(/^the\s+/, '');
+  return VENUE_ABBREVIATIONS[base] ?? base;
+}


### PR DESCRIPTION
Extracts a single canonical `normalizeVenueName()` (`src/utils/venue.ts`) shared by the top-venue counter (`ResearcherNarrative`) and the journal-ranking matcher (`journalRankings`), removing the two divergent normalizers. Adds an abbreviation map so `Comput. Hum. Behav.` folds into `Computers in Human Behavior` instead of splitting the count.

**Safety:** the ranking matcher reuses its exact prior normalizer logic, so existing FT50/ABS matches are unchanged; abbreviated inputs only *gain* matches. Verified sister journals (`… Reports` / `…: Artificial Humans`) remain separate buckets.