### PR TITLE
Loading skeletons for async Field-Normalized metrics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -326,7 +326,9 @@ function AppContent() {
       };
 
       setProfileUrl(url);
-      setData(sanitizedData);
+      // Mark field-normalized metrics as loading so the metrics tab can show a
+      // skeleton for that section while the (async) OpenAlex fetch runs.
+      setData({ ...sanitizedData, fieldMetricsLoading: true });
       trackEvent('search', { author_id: userId, cache: profileData.cacheStatus, bypass: bypassCredits });
 
       // Fetch Open Access stats from OpenAlex (non-blocking)
@@ -381,7 +383,8 @@ function AppContent() {
             setData(prev => prev ? { ...prev, fieldMetrics } : prev);
           }
         })
-        .catch((err) => logCaughtError(err, 'openalex', 'App', 'fetch-field-metrics', { name: sanitizedData.name }));
+        .catch((err) => logCaughtError(err, 'openalex', 'App', 'fetch-field-metrics', { name: sanitizedData.name }))
+        .finally(() => setData(prev => prev ? { ...prev, fieldMetricsLoading: false } : prev));
 
       // Update browser URL with shareable link (preserve vanity URL if loaded via slug)
       const pathSlug = window.location.pathname.replace(/^\//, '').replace(/\/$/, '');

--- a/src/components/MetricsCard.tsx
+++ b/src/components/MetricsCard.tsx
@@ -90,6 +90,24 @@ function useCountUp(target: number | string, duration = 600) {
   return { display, ref };
 }
 
+/** Placeholder card shown while an async metric section is still loading. */
+export function MetricsCardSkeleton() {
+  return (
+    <div className="bg-white dark:bg-slate-800 p-3 rounded-xl border border-gray-100 dark:border-slate-700 shadow-card w-full">
+      <div className="flex items-start gap-2.5 animate-pulse">
+        <div className="p-1.5 bg-gray-200 dark:bg-slate-700 rounded-lg mt-0.5 flex-shrink-0">
+          <div className="h-3.5 w-3.5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="h-2 w-16 bg-gray-200 dark:bg-slate-700 rounded" />
+          <div className="h-3 w-10 bg-gray-200 dark:bg-slate-700 rounded mt-2" />
+          <div className="h-2 w-14 bg-gray-100 dark:bg-slate-700/60 rounded mt-1.5" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) {
   const { display, ref: countRef } = useCountUp(value);
   const getIcon = () => {

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -6,7 +6,7 @@ import { ClaimProfileModal } from './ClaimProfileModal';
 import { ScholarSearchModal } from './ScholarSearchModal';
 import { TopicsList } from './TopicsList';
 import { PublicationsList } from './PublicationsList';
-import { MetricsCard } from './MetricsCard';
+import { MetricsCard, MetricsCardSkeleton } from './MetricsCard';
 import { ResearcherNarrative } from './ResearcherNarrative';
 import { PIndexSection } from './PIndexSection';
 
@@ -571,7 +571,15 @@ export function ProfileView({
               )}
             </div>
 
-            {data.fieldMetrics && (data.fieldMetrics.fwci !== null || data.fieldMetrics.meanCitedness !== null || data.fieldMetrics.rcrMean !== null) && (
+            {data.fieldMetricsLoading && !data.fieldMetrics ? (
+              <div>
+                <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-cat-field-from"></span>Field-Normalized Metrics</h3>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+                  <MetricsCardSkeleton />
+                  <MetricsCardSkeleton />
+                </div>
+              </div>
+            ) : (data.fieldMetrics && (data.fieldMetrics.fwci !== null || data.fieldMetrics.meanCitedness !== null || data.fieldMetrics.rcrMean !== null)) ? (
               <div>
                 <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-cat-field-from"></span>Field-Normalized Metrics</h3>
                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
@@ -604,7 +612,7 @@ export function ProfileView({
                   )}
                 </div>
               </div>
-            )}
+            ) : null}
 
             {data && (
               <PIndexSection authorName={data.name} affiliation={data.affiliation} scrapedPublications={data.publications} onResult={setPIndexResult} />

--- a/src/types/scholar.ts
+++ b/src/types/scholar.ts
@@ -115,6 +115,8 @@ export interface Author {
   openAccess?: OpenAccessStats;
   openAccessFailed?: boolean;
   fieldMetrics?: FieldNormalizedMetrics;
+  /** True while the OpenAlex field-normalized metrics are still being fetched. */
+  fieldMetricsLoading?: boolean;
   /** Semantic Scholar per-publication data, keyed by normalized title */
   s2Data?: Record<string, S2PublicationData>;
   s2Stats?: S2Stats;


### PR DESCRIPTION
**Problem:** on the landing Impact Metrics tab, the base metrics render instantly (computed client-side), but the **Field-Normalized** section (FWCI / mean journal impact) is fetched from OpenAlex *after* the profile loads and just popped in late with no indication.

**Fix:** a `fieldMetricsLoading` flag (set on profile load, cleared in the fetch's `finally`) drives skeleton placeholder cards for that section while it loads. Once loaded it shows the real cards, or renders nothing if the author isn't in OpenAlex — no perpetual spinner.

Base metrics are untouched (already instant). Follow-up option: consolidate the two OpenAlex works fetches (OA stats + field metrics) into one to cut first-load latency.