### PR TITLE
Consolidate OpenAlex enrichment into one shared works fetch

### DIFF
--- a/src/services/openalex/author-lookup.ts
+++ b/src/services/openalex/author-lookup.ts
@@ -60,24 +60,44 @@ export interface OpenAlexAuthor {
   }>;
 }
 
-// In-memory cache: keyed by "name|affiliation", valid for the page session
-const authorCache = new Map<string, OpenAlexAuthor | null>();
+// In-memory cache keyed by "name|affiliation", valid for the page session.
+// Caches the Promise (not just the result) so concurrent callers — OA stats,
+// field metrics, co-author geo — share ONE lookup instead of each searching.
+const authorCache = new Map<string, Promise<OpenAlexAuthor | null>>();
 
 /**
- * Single consolidated OpenAlex author lookup.
- * 1. Searches by name (per_page=10)
- * 2. Filters by display_name match
- * 3. Refines by affiliation match
- * 4. Fetches ORCID from full author record
- * Results are cached per session so all 3 services share one lookup.
+ * Single consolidated OpenAlex author lookup, shared per session so all services
+ * (including concurrent callers) reuse one lookup. Successful results are cached;
+ * null/failed results are dropped so a later call can retry rather than being
+ * poisoned by a transient OpenAlex hiccup.
  */
-export async function findOpenAlexAuthor(
+export function findOpenAlexAuthor(
   name: string,
   affiliation: string
 ): Promise<OpenAlexAuthor | null> {
   const cacheKey = `${name.toLowerCase().trim()}|${affiliation.toLowerCase().trim()}`;
-  if (authorCache.has(cacheKey)) return authorCache.get(cacheKey)!;
+  const cached = authorCache.get(cacheKey);
+  if (cached) return cached;
+  const promise = resolveOpenAlexAuthor(name, affiliation);
+  authorCache.set(cacheKey, promise);
+  promise.then(
+    (author) => { if (!author) authorCache.delete(cacheKey); },
+    () => { authorCache.delete(cacheKey); }
+  );
+  return promise;
+}
 
+/**
+ * Uncached author resolution:
+ * 1. Searches by name (per_page=10)
+ * 2. Filters by display_name match
+ * 3. Refines by affiliation match
+ * 4. Fetches ORCID from full author record
+ */
+async function resolveOpenAlexAuthor(
+  name: string,
+  affiliation: string
+): Promise<OpenAlexAuthor | null> {
   try {
     const searchData = await oaFetchJson<{ results: Array<{
       id: string;
@@ -95,7 +115,6 @@ export async function findOpenAlexAuthor(
 
     const results = searchData?.results;
     if (!results?.length) {
-      authorCache.set(cacheKey, null);
       return null;
     }
 
@@ -140,11 +159,9 @@ export async function findOpenAlexAuthor(
       lastKnownInstitutions: best.last_known_institutions || [],
     };
 
-    authorCache.set(cacheKey, author);
     return author;
   } catch (err) {
     logCaughtError(err, 'openalex', 'author-lookup', 'find-author', { name, affiliation });
-    authorCache.set(cacheKey, null);
     return null;
   }
 }

--- a/src/services/openalex/field-metrics.ts
+++ b/src/services/openalex/field-metrics.ts
@@ -1,25 +1,15 @@
-import { findOpenAlexAuthor, oaFetchJson, OA_API_URL, OA_EMAIL } from './author-lookup';
+import { findOpenAlexAuthor } from './author-lookup';
+import { fetchAuthorEnrichmentWorks } from './works';
 import { logCaughtError } from '../../lib/errorLogger';
 import type { FieldNormalizedMetrics } from '../../types/scholar';
 
 export type { FieldNormalizedMetrics };
 
-interface OpenAlexWork {
-  doi?: string;
-  cited_by_count?: number;
-  cited_by_percentile_year?: { min?: number; max?: number };
-  primary_location?: {
-    source?: {
-      display_name?: string;
-      summary_stats?: { '2yr_mean_citedness'?: number };
-    };
-  };
-}
-
 /**
  * Fetches field-normalized metrics for an author from OpenAlex:
  * - FWCI-like: average citation percentile across papers
  * - Mean journal citedness (proxy for mean IF)
+ * Reuses the shared author works fetch (also consumed by the OA enrichment).
  */
 export async function fetchFieldNormalizedMetrics(
   authorName: string,
@@ -30,20 +20,7 @@ export async function fetchFieldNormalizedMetrics(
     if (!author) return null;
 
     const shortId = author.id.replace('https://openalex.org/', '');
-
-    // Fetch works with citation percentiles and source stats
-    const allWorks: OpenAlexWork[] = [];
-    let page = 1;
-    while (page <= 5) {
-      const data = await oaFetchJson<{ results: OpenAlexWork[] }>(
-        `${OA_API_URL}/works?filter=authorships.author.id:${shortId}&per_page=200&page=${page}&select=doi,cited_by_count,cited_by_percentile_year,primary_location&mailto=${OA_EMAIL}`
-      );
-      if (!data?.results?.length) break;
-      allWorks.push(...data.results);
-      if (data.results.length < 200) break;
-      page++;
-    }
-
+    const allWorks = await fetchAuthorEnrichmentWorks(shortId);
     if (allWorks.length === 0) return null;
 
     // FWCI-like metric (average citation percentile / 50)

--- a/src/services/openalex/index.ts
+++ b/src/services/openalex/index.ts
@@ -1,5 +1,6 @@
 import type { JournalRanking, OpenAccessStats, OaStatus } from '../../types/scholar';
 import { findOpenAlexAuthor, oaFetchJson, OA_API_URL, OA_EMAIL } from './author-lookup';
+import { fetchAuthorEnrichmentWorks } from './works';
 
 export { searchOpenAlexAuthors, fetchOpenAlexProfile, OPENALEX_ID_PREFIX, toOpenAlexShortId } from './profile';
 
@@ -14,6 +15,14 @@ export class OpenAlexService {
       const author = await findOpenAlexAuthor(name, affiliation);
       if (!author) return null;
       const authorId = author.id;
+      const shortId = authorId.replace('https://openalex.org/', '');
+
+      // Kick off the (multi-page) shared works fetch immediately so it runs
+      // concurrently with the cheap group_by request below. Also consumed by
+      // the field-normalized metrics, so profile load does one works fetch
+      // instead of two. oaFetchJson never rejects, so this can safely float
+      // across the early returns.
+      const worksPromise = fetchAuthorEnrichmentWorks(shortId);
 
       // Get works grouped by OA status
       const worksUrl = `${OA_API_URL}/works?filter=authorships.author.id:${authorId}&group_by=open_access.oa_status&per_page=10&mailto=${OA_EMAIL}`;
@@ -39,47 +48,38 @@ export class OpenAlexService {
       // ORCID is already fetched by shared author lookup
       const orcid = author.orcid;
 
-      // Fetch per-publication OA status + DOIs + location data (paginated, up to 200 works per page)
+      // Per-publication OA status + DOIs + repository/preprint info from the
+      // shared works fetch started above.
       const publicationOa: Record<string, { status: OaStatus; oaUrl?: string }> = {};
       const doiMap: Record<string, string> = {};
       const repositoryCounts: Record<string, number> = {};
       let preprintCount = 0;
-      let page = 1;
-      const maxPages = 10;
-      while (page <= maxPages) {
-        const pubsUrl = `${OA_API_URL}/works?filter=authorships.author.id:${authorId}&select=title,open_access,best_oa_location,publication_year,doi&per_page=200&page=${page}&mailto=${OA_EMAIL}`;
-        const pubsData = await oaFetchJson<{ results?: any[] }>(pubsUrl);
-        if (!pubsData) break;
-        const results = pubsData.results || [];
-        if (results.length === 0) break;
 
-        for (const work of results) {
-          if (work.title) {
-            const normalizedTitle = work.title.toLowerCase().replace(/[^a-z0-9]/g, '');
-            const status: OaStatus = work.open_access?.oa_status === 'diamond' ? 'gold' : (work.open_access?.oa_status || 'closed');
-            publicationOa[normalizedTitle] = {
-              status,
-              oaUrl: work.open_access?.oa_url || undefined,
-            };
-            // Extract DOI for Semantic Scholar batch lookup
-            if (work.doi) {
-              const doi = work.doi.replace('https://doi.org/', '');
-              if (doi) doiMap[normalizedTitle] = doi;
-            }
-            // Extract preprint/repository info from best_oa_location
-            const boa = work.best_oa_location;
-            if (boa?.version === 'submittedVersion') {
-              preprintCount++;
-            }
-            if (boa?.source?.display_name && boa?.is_oa) {
-              const repoName = boa.source.display_name;
-              repositoryCounts[repoName] = (repositoryCounts[repoName] || 0) + 1;
-            }
-          }
+      const works = await worksPromise;
+      for (const work of works) {
+        if (!work.title) continue;
+        const normalizedTitle = work.title.toLowerCase().replace(/[^a-z0-9]/g, '');
+        const status: OaStatus = work.open_access?.oa_status === 'diamond'
+          ? 'gold'
+          : ((work.open_access?.oa_status as OaStatus) || 'closed');
+        publicationOa[normalizedTitle] = {
+          status,
+          oaUrl: work.open_access?.oa_url || undefined,
+        };
+        // Extract DOI for Semantic Scholar batch lookup
+        if (work.doi) {
+          const doi = work.doi.replace('https://doi.org/', '');
+          if (doi) doiMap[normalizedTitle] = doi;
         }
-
-        if (results.length < 200) break;
-        page++;
+        // Extract preprint/repository info from best_oa_location
+        const boa = work.best_oa_location;
+        if (boa?.version === 'submittedVersion') {
+          preprintCount++;
+        }
+        if (boa?.source?.display_name && boa?.is_oa) {
+          const repoName = boa.source.display_name;
+          repositoryCounts[repoName] = (repositoryCounts[repoName] || 0) + 1;
+        }
       }
 
       return {

--- a/src/services/openalex/works.ts
+++ b/src/services/openalex/works.ts
@@ -1,0 +1,102 @@
+import { oaFetchJson, OA_API_URL, OA_EMAIL } from './author-lookup';
+
+/**
+ * A single OpenAlex work carrying the union of fields needed by BOTH the Open
+ * Access enrichment and the field-normalized metrics, so one fetch serves both.
+ */
+export interface OaEnrichmentWork {
+  title?: string;
+  doi?: string;
+  publication_year?: number;
+  cited_by_count?: number;
+  cited_by_percentile_year?: { min?: number; max?: number };
+  open_access?: { oa_status?: string; oa_url?: string };
+  best_oa_location?: {
+    version?: string;
+    is_oa?: boolean;
+    source?: { display_name?: string };
+  };
+  primary_location?: {
+    source?: {
+      display_name?: string;
+      summary_stats?: { '2yr_mean_citedness'?: number };
+    };
+  };
+}
+
+const SELECT =
+  'title,open_access,best_oa_location,publication_year,doi,cited_by_count,cited_by_percentile_year,primary_location';
+
+const PER_PAGE = 200;
+const MAX_PAGES = 10;
+
+interface WorksPage {
+  meta?: { count?: number };
+  results?: OaEnrichmentWork[];
+}
+
+// Memoize the in-flight/resolved works fetch per author so the OA-stats and
+// field-normalized metric calls — which run concurrently on profile load —
+// share ONE network fetch instead of each paginating the same works. Keyed by
+// short author id (e.g. "A5077827457").
+const worksCache = new Map<string, Promise<OaEnrichmentWork[]>>();
+
+/**
+ * Fetch all of an author's works (paginated, up to 2000) with the fields both
+ * enrichment consumers need. Concurrent callers share one fetch. A failed,
+ * partial, or empty result is NOT cached, so a later call can retry.
+ *
+ * Page 1 is fetched first to learn the total from `meta.count`; the remaining
+ * pages are then fetched in PARALLEL, so a many-works author costs two
+ * round-trip "hops" through the proxy instead of up to ten sequential ones.
+ */
+export function fetchAuthorEnrichmentWorks(shortId: string): Promise<OaEnrichmentWork[]> {
+  const cached = worksCache.get(shortId);
+  if (cached) return cached;
+
+  // Marks a result we should NOT keep cached (a page failed → data has holes).
+  let incomplete = false;
+
+  const pageUrl = (page: number) =>
+    `${OA_API_URL}/works?filter=authorships.author.id:${shortId}&per_page=${PER_PAGE}&page=${page}&select=${SELECT}&mailto=${OA_EMAIL}`;
+
+  const promise = (async () => {
+    const first = await oaFetchJson<WorksPage>(pageUrl(1));
+    if (!first) incomplete = true;
+    const all: OaEnrichmentWork[] = [...(first?.results ?? [])];
+    if (all.length < PER_PAGE) return all;
+
+    if (first?.meta?.count != null) {
+      // Total known → fetch every remaining page concurrently.
+      const totalPages = Math.min(Math.ceil(first.meta.count / PER_PAGE), MAX_PAGES);
+      const rest = await Promise.all(
+        Array.from({ length: totalPages - 1 }, (_, i) => oaFetchJson<WorksPage>(pageUrl(i + 2)))
+      );
+      for (const data of rest) {
+        if (!data?.results) { incomplete = true; continue; }
+        all.push(...data.results);
+      }
+    } else {
+      // meta missing (shouldn't happen) → fall back to sequential paging.
+      for (let page = 2; page <= MAX_PAGES; page++) {
+        const data = await oaFetchJson<WorksPage>(pageUrl(page));
+        if (!data?.results?.length) {
+          if (!data) incomplete = true;
+          break;
+        }
+        all.push(...data.results);
+        if (data.results.length < PER_PAGE) break;
+      }
+    }
+    return all;
+  })();
+
+  worksCache.set(shortId, promise);
+  // Don't let a failed/partial/empty fetch poison the session cache — allow a
+  // retry, while concurrent callers still share this in-flight promise.
+  promise.then(
+    (works) => { if (works.length === 0 || incomplete) worksCache.delete(shortId); },
+    () => { worksCache.delete(shortId); }
+  );
+  return promise;
+}


### PR DESCRIPTION
**Problem:** on profile load, `fetchOpenAccessStats` and `fetchFieldNormalizedMetrics` each did an author lookup and independently paginated the *same* works with different field selections — ~5 OpenAlex calls, the two heavy works fetches sequential within each.

**Fix (no change to displayed values):**
- `findOpenAlexAuthor` is now **promise-memoized** → concurrent callers share one lookup; null/failed results are dropped so a transient OpenAlex hiccup can't poison the session.
- New `fetchAuthorEnrichmentWorks()` fetches each author's works **once** with the union of both consumers' fields, page 1 first (to read `meta.count`) then the rest **in parallel**; partial/empty results aren't cached (safe retry).
- OA-stats starts the works fetch **concurrently** with its `group_by` call.

Net: one author lookup + one parallelized works fetch shared by both enrichers. Verified the union select returns both OA (`open_access`, `best_oa_location`) and field-metric (`cited_by_percentile_year`) fields in one response. Pairs with the earlier loading-skeleton PR (#248) so the section shows progress *and* resolves faster.