### PR TITLE
Don't cache a truncated works fetch when a parallel page comes back empty

### DIFF
--- a/src/services/openalex/works.ts
+++ b/src/services/openalex/works.ts
@@ -76,6 +76,11 @@ export function fetchAuthorEnrichmentWorks(shortId: string): Promise<OaEnrichmen
         if (!data?.results) { incomplete = true; continue; }
         all.push(...data.results);
       }
+      // An empty-but-non-null page (e.g. a stale proxy cache entry) leaves the
+      // same hole as a failed one but passes the check above. Compare against
+      // meta.count so a short total also blocks caching and allows a retry.
+      const expected = Math.min(first.meta.count, MAX_PAGES * PER_PAGE);
+      if (all.length < expected) incomplete = true;
     } else {
       // meta missing (shouldn't happen) → fall back to sequential paging.
       for (let page = 2; page <= MAX_PAGES; page++) {


### PR DESCRIPTION
Follow-up to #249, from its review: in the parallel pagination branch, only a **null** page (network/proxy failure) marked the result incomplete. An **empty-but-non-null** page that `meta.count` says should contain data (e.g. a stale proxy cache entry) slipped through — the truncated works list was then cached for the rest of the session with no retry path, under-counting OA stats and field metrics on every subsequent view.

**Fix:** after collecting all pages, compare the total against `min(meta.count, MAX_PAGES × PER_PAGE)`; any shortfall marks the result incomplete, which blocks caching so a later call retries. The partial result is still served for the current render (unchanged behavior), it just can't poison the session.