### PR TITLE
Use native OpenAlex FWCI and add Leiden-style top-10% share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Scholar Folio are documented here.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.14.0] - 2026-07-02
+
+### Added
+- Top 10% Papers metric — share of works in the top decile of their field's citation distribution (the Leiden Ranking's PP(top 10%)), from OpenAlex citation-normalized percentiles
+- Mean Journal Impact now actually renders: journal 2-year citedness is resolved via batched `/sources` lookups (the source embedded in works results is dehydrated and never carried stats, so the metric had been silently null)
+- Loading skeletons for the async Field-Normalized metrics section
+
+### Changed
+- FWCI now uses OpenAlex's native per-work field-weighted citation impact (normalized by subfield, year, and publication type), reported as the **median** across papers — previously a year-normalized percentile proxy that wasn't comparable across disciplines
+- OpenAlex enrichment consolidated into one shared, memoized works fetch: profile load does one works fetch instead of two, with pages after the first fetched in parallel
+- OpenAlex `/venues` calls migrated to `/sources` (endpoint deprecated)
+
+### Fixed
+- Metric cards no longer mangle animated values — "53%" froze as "53", "+12%" as "12", and "12 yrs" would have lost its unit; cards now snap to the exact value on the final frame
+- A partial or failed works fetch (including an empty page mid-pagination) is no longer cached for the session, so a later profile load retries instead of under-counting all works-derived metrics
+- Mean journal citedness is withheld entirely when a journal-stats batch fails, rather than rendering a systematically skewed average
+
 ## [0.10.0] - 2026-03-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Scholar Folio turns a Google Scholar profile into a shareable research portfolio
 Sign in, pick a slug, and get a permanent URL. Claimed profiles are always public and free to view — no login needed for visitors. Each claimed profile is served from cache, so it costs nothing to host.
 
 ### Research Reach
-Citation counts, h-index, g-index, i10-index, h5-index, growth trends, and per-year citation breakdowns. Field-normalized impact (FWCI) and Relative Citation Ratio (RCR) for cross-discipline comparison.
+Citation counts, h-index, g-index, i10-index, h5-index, growth trends, and per-year citation breakdowns. For cross-discipline comparison: median Field-Weighted Citation Impact (OpenAlex's native per-work FWCI), the share of papers in their field's top 10% most-cited (Leiden PP(top 10%)), and mean journal impact.
 
 ### P-Index
 Publication-level percentile metric (Pham, Wu & Wang, 2024) that ranks papers within their own journal and publication year. Includes a review step so researchers control which publications are included.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "research-portfolio",
   "private": true,
-  "version": "0.13.0-beta",
+  "version": "0.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/MetricsCard.tsx
+++ b/src/components/MetricsCard.tsx
@@ -38,7 +38,7 @@ interface MetricsCardProps {
   icon: 'citations' | 'hIndex' | 'gIndex' | 'publications' | 'i10Index' | 'scr' | 'hpIndex' |
         'sIndex' | 'rcr' | 'pubsPerYear' | 'network' | 'coAuthors' | 'avgAuthors' | 'soloAuthor' |
         'h5Index' | 'acc5' | 'citationsPerYear' | 'topCoAuthor' | 'avgCitationsPerPaper' |
-        'citationGrowth' | 'peak' | 'trend' | 'fwci' | 'halfLife' | 'gini' | 'ageNormalized' |
+        'citationGrowth' | 'peak' | 'trend' | 'fwci' | 'topDecile' | 'halfLife' | 'gini' | 'ageNormalized' |
         'oaPercent' | 'goldOa' | 'greenOa' | 'hybridOa' | 'bronzeOa' | 'closedAccess' | 'meanIF' |
         'pindex' | 'owpi' | 'weightedCitations' | 'influential' | 'preprint' | 'repository';
 }
@@ -55,6 +55,10 @@ function useCountUp(target: number | string, duration = 600) {
       setDisplay(String(target));
       return;
     }
+    // Preserve a leading "+" and any non-numeric suffix (e.g. "%") through the
+    // animation — parseFloat strips them, which used to freeze "53%" as "53".
+    const prefix = typeof target === 'string' && target.trim().startsWith('+') ? '+' : '';
+    const suffix = typeof target === 'string' ? (target.match(/[^\d.,\s+-]+\s*$/)?.[0] ?? '') : '';
 
     const observer = new IntersectionObserver(([entry]) => {
       if (!entry.isIntersecting || hasRun.current) return;
@@ -71,11 +75,11 @@ function useCountUp(target: number | string, duration = 600) {
         const current = numericTarget * eased;
 
         if (isDecimal) {
-          setDisplay(current.toFixed(1));
+          setDisplay(prefix + current.toFixed(1) + suffix);
         } else if (typeof target === 'string' && target.includes(',')) {
-          setDisplay(Math.round(current).toLocaleString());
+          setDisplay(prefix + Math.round(current).toLocaleString() + suffix);
         } else {
-          setDisplay(String(Math.round(current)));
+          setDisplay(prefix + String(Math.round(current)) + suffix);
         }
 
         if (progress < 1) requestAnimationFrame(animate);
@@ -129,6 +133,7 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
       // Field metrics
       case 'rcr': return <Scale className="h-3.5 w-3.5" />;
       case 'fwci': return <Gauge className="h-3.5 w-3.5" />;
+      case 'topDecile': return <Crown className="h-3.5 w-3.5" />;
       case 'meanIF': return <TrendingUp className="h-3.5 w-3.5" />;
       
       // Publication metrics
@@ -188,6 +193,7 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
       case 'sIndex': return 'sIndex';
       case 'rcr': return 'rcr';
       case 'fwci': return 'fwci';
+      case 'topDecile': return 'topDecile';
       case 'meanIF': return 'meanIF';
       case 'pubsPerYear': return 'pubsPerYear';
       case 'network': return 'collaborationScore';
@@ -237,7 +243,7 @@ export function MetricsCard({ title, value, subtitle, icon }: MetricsCardProps) 
       case 'pindex': case 'owpi': case 'weightedCitations':
         return 'from-violet-500 to-purple-600';
       // Field-normalized → indigo
-      case 'fwci': case 'rcr': case 'meanIF':
+      case 'fwci': case 'topDecile': case 'rcr': case 'meanIF':
         return 'from-cat-field-from to-cat-field-to';
       // Open access → green
       case 'oaPercent': case 'goldOa': case 'greenOa': case 'hybridOa': case 'bronzeOa': case 'closedAccess':

--- a/src/components/MetricsCard.tsx
+++ b/src/components/MetricsCard.tsx
@@ -55,10 +55,11 @@ function useCountUp(target: number | string, duration = 600) {
       setDisplay(String(target));
       return;
     }
-    // Preserve a leading "+" and any non-numeric suffix (e.g. "%") through the
-    // animation — parseFloat strips them, which used to freeze "53%" as "53".
+    // Preserve a leading "+" and any non-numeric suffix (e.g. "%", " yrs")
+    // through the animation — parseFloat strips them, which used to freeze
+    // "53%" as "53". The leading \s* keeps the space in "12 yrs".
     const prefix = typeof target === 'string' && target.trim().startsWith('+') ? '+' : '';
-    const suffix = typeof target === 'string' ? (target.match(/[^\d.,\s+-]+\s*$/)?.[0] ?? '') : '';
+    const suffix = typeof target === 'string' ? (target.match(/\s*[^\d.,\s+-]+\s*$/)?.[0] ?? '') : '';
 
     const observer = new IntersectionObserver(([entry]) => {
       if (!entry.isIntersecting || hasRun.current) return;
@@ -74,15 +75,21 @@ function useCountUp(target: number | string, duration = 600) {
         const eased = 1 - Math.pow(1 - progress, 3);
         const current = numericTarget * eased;
 
-        if (isDecimal) {
-          setDisplay(prefix + current.toFixed(1) + suffix);
-        } else if (typeof target === 'string' && target.includes(',')) {
-          setDisplay(prefix + Math.round(current).toLocaleString() + suffix);
+        if (progress < 1) {
+          if (isDecimal) {
+            setDisplay(prefix + current.toFixed(1) + suffix);
+          } else if (typeof target === 'string' && target.includes(',')) {
+            setDisplay(prefix + Math.round(current).toLocaleString() + suffix);
+          } else {
+            setDisplay(prefix + String(Math.round(current)) + suffix);
+          }
+          requestAnimationFrame(animate);
         } else {
-          setDisplay(prefix + String(Math.round(current)) + suffix);
+          // Final frame: snap to the exact original value so no format the
+          // interpolation branches mishandle (2-decimal FWCI, "12 yrs", …)
+          // sticks on screen in a mangled form.
+          setDisplay(String(target));
         }
-
-        if (progress < 1) requestAnimationFrame(animate);
       };
       requestAnimationFrame(animate);
     }, { threshold: 0.3 });

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -579,7 +579,7 @@ export function ProfileView({
                   <MetricsCardSkeleton />
                 </div>
               </div>
-            ) : (data.fieldMetrics && (data.fieldMetrics.fwci !== null || data.fieldMetrics.meanCitedness !== null || data.fieldMetrics.rcrMean !== null)) ? (
+            ) : (data.fieldMetrics && (data.fieldMetrics.fwci !== null || data.fieldMetrics.topDecileShare !== null || data.fieldMetrics.meanCitedness !== null || data.fieldMetrics.rcrMean !== null)) ? (
               <div>
                 <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-cat-field-from"></span>Field-Normalized Metrics</h3>
                 <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
@@ -587,8 +587,16 @@ export function ProfileView({
                     <MetricsCard
                       title="FWCI"
                       value={data.fieldMetrics.fwci}
-                      subtitle={data.fieldMetrics.fwci >= 1.5 ? 'Well above average' : data.fieldMetrics.fwci >= 1.0 ? 'Above world average' : 'Below world average'}
+                      subtitle={`Median · ${data.fieldMetrics.fwci >= 1.5 ? 'well above avg' : data.fieldMetrics.fwci >= 1.0 ? 'above world avg' : 'below world avg'}`}
                       icon="fwci"
+                    />
+                  )}
+                  {data.fieldMetrics.topDecileShare !== null && (
+                    <MetricsCard
+                      title="Top 10% Papers"
+                      value={`${data.fieldMetrics.topDecileShare}%`}
+                      subtitle="In field's most-cited decile"
+                      icon="topDecile"
                     />
                   )}
                   {data.fieldMetrics.meanCitedness !== null && (

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -595,7 +595,7 @@ export function ProfileView({
                     <MetricsCard
                       title="Top 10% Papers"
                       value={`${data.fieldMetrics.topDecileShare}%`}
-                      subtitle="In field's most-cited decile"
+                      subtitle={`Of ${data.fieldMetrics.topDecileCount} classified paper${data.fieldMetrics.topDecileCount !== 1 ? 's' : ''}`}
                       icon="topDecile"
                     />
                   )}

--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -768,11 +768,16 @@ function generateFieldMetricsParagraph(fieldMetrics?: FieldNormalizedMetrics | n
 
   if (fieldMetrics.fwci !== null) {
     const fwci = fieldMetrics.fwci.toFixed(2);
+    const meanSuffix = fieldMetrics.fwciMean !== null ? ` (mean: ${fieldMetrics.fwciMean.toFixed(2)})` : '';
     if (fieldMetrics.fwci >= 1.0) {
-      parts.push(`Their Field-Weighted Citation Impact (FWCI) is ${fwci}, meaning their publications receive ${fwci} times the world average citations for their field and publication year.`);
+      parts.push(`Their median Field-Weighted Citation Impact (FWCI) is ${fwci}${meanSuffix}, meaning a typical publication of theirs receives ${fwci} times the world-average citations for its field, year, and publication type.`);
     } else {
-      parts.push(`Their Field-Weighted Citation Impact (FWCI) is ${fwci}, relative to the world average of 1.00 for their field and publication year.`);
+      parts.push(`Their median Field-Weighted Citation Impact (FWCI) is ${fwci}${meanSuffix}, relative to the world average of 1.00 for their field, year, and publication type.`);
     }
+  }
+
+  if (fieldMetrics.topDecileShare !== null) {
+    parts.push(`${fieldMetrics.topDecileShare}% of their publications rank among the top 10% most-cited papers in their field (world baseline: 10%).`);
   }
 
   if (fieldMetrics.meanCitedness !== null) {

--- a/src/data/metricInfo.ts
+++ b/src/data/metricInfo.ts
@@ -156,10 +156,16 @@ export const metricInfo = {
     link: "https://en.wikipedia.org/wiki/Open_access#Bronze_OA"
   },
   fwci: {
-    description: "Field-Weighted Citation Impact — a normalized measure of citation impact relative to the world average for the same field and publication year. Calculated from OpenAlex citation percentiles.\n\nA value of 1.0 means the researcher's papers are cited at the world average for their fields. Values above 1.0 indicate above-average impact.",
-    pros: "Accounts for field-specific citation norms, making it meaningful to compare researchers across disciplines. Based on per-paper percentiles, not raw counts.",
+    description: "Field-Weighted Citation Impact — OpenAlex's per-paper FWCI, normalized by subfield, publication year, and publication type. Shown as the MEDIAN across the researcher's papers.\n\nA value of 1.0 means a typical paper is cited at the world average for its field. Values above 1.0 indicate above-average impact. The median is used because a single highly-cited paper can inflate a mean far beyond what is typical.",
+    pros: "Directly comparable across disciplines — a 1.5 means the same thing in history as in medicine. Median is robust to one-hit outliers. Same concept as Scopus/SciVal's FWCI, but from open data.",
     cons: "Depends on OpenAlex field classification accuracy. May differ from Elsevier's proprietary FWCI calculation in Scopus/SciVal.",
     link: "https://en.wikipedia.org/wiki/Field-weighted_citation_impact"
+  },
+  topDecile: {
+    description: "Share of the researcher's papers ranking in the top 10% most-cited works of their field, publication year, and publication type — the PP(top 10%) indicator used by the CWTS Leiden Ranking.\n\nBased on OpenAlex's citation-normalized percentiles. The world baseline is 10%: a value above that means the researcher places papers in their field's top decile more often than average.",
+    pros: "Field-normalized and robust — unaffected by how extreme the top papers are, only by how many reach the top decile. A standard indicator in research evaluation (Leiden Ranking).",
+    cons: "Insensitive to impact differences within the top 10%. Recent papers have had less time to accumulate citations, which can understate the share for early-career researchers.",
+    link: "https://www.leidenranking.com/information/indicators"
   },
   rcr: {
     description: "Relative Citation Ratio — developed by NIH, measures how a paper's citation rate compares to the average for its field and age. An RCR of 1.0 means average; 2.0 means twice the expected citations.\n\nData sourced from NIH's iCite database. Only available for papers indexed in PubMed.",

--- a/src/services/openalex/field-metrics.ts
+++ b/src/services/openalex/field-metrics.ts
@@ -55,7 +55,8 @@ async function resolveSourceCitedness(sourceIds: string[]): Promise<{
 
 /**
  * Fetches field-normalized metrics for an author from OpenAlex:
- * - FWCI-like: average citation percentile across papers
+ * - FWCI: median (+ mean) of OpenAlex's native per-work FWCI
+ * - Top-decile share: % of works in the top 10% most-cited of their field
  * - Mean journal citedness (proxy for mean IF)
  * Reuses the shared author works fetch (also consumed by the OA enrichment).
  */
@@ -71,15 +72,33 @@ export async function fetchFieldNormalizedMetrics(
     const allWorks = await fetchAuthorEnrichmentWorks(shortId);
     if (allWorks.length === 0) return null;
 
-    // FWCI-like metric (average citation percentile / 50)
-    // 50th percentile = 1.0 (world average), >1.0 = above average
-    const percentiles: number[] = [];
-    for (const work of allWorks) {
-      const pct = work.cited_by_percentile_year?.min;
-      if (pct != null) percentiles.push(pct);
+    // Native OpenAlex FWCI (normalized by subfield × year × publication type;
+    // 1.0 = world average in that field). Median as the headline value — a
+    // single viral paper can drag the mean far above what's typical — with the
+    // mean kept as context for the narrative.
+    const fwciValues = allWorks
+      .map(w => w.fwci)
+      .filter((v): v is number => typeof v === 'number')
+      .sort((a, b) => a - b);
+    let fwci: number | null = null;
+    let fwciMean: number | null = null;
+    if (fwciValues.length > 0) {
+      const mid = Math.floor(fwciValues.length / 2);
+      const median = fwciValues.length % 2 === 1
+        ? fwciValues[mid]
+        : (fwciValues[mid - 1] + fwciValues[mid]) / 2;
+      fwci = Number(median.toFixed(2));
+      fwciMean = Number((fwciValues.reduce((a, b) => a + b, 0) / fwciValues.length).toFixed(2));
     }
-    const fwci = percentiles.length > 0
-      ? Number((percentiles.reduce((a, b) => a + b, 0) / percentiles.length / 50).toFixed(2))
+
+    // Share of works in the top 10% most-cited of their field/year/type —
+    // the Leiden Ranking's PP(top 10%), robust to single-hit outliers.
+    const classified = allWorks.filter(w => w.citation_normalized_percentile != null);
+    const topDecileShare = classified.length > 0
+      ? Math.round(
+          (classified.filter(w => w.citation_normalized_percentile?.is_in_top_10_percent).length /
+            classified.length) * 100
+        )
       : null;
 
     // Mean journal citedness (proxy for mean IF). The embedded work source is
@@ -109,6 +128,8 @@ export async function fetchFieldNormalizedMetrics(
 
     return {
       fwci,
+      fwciMean,
+      topDecileShare,
       meanCitedness,
       paperCount: allWorks.length,
       rcrMean: null,

--- a/src/services/openalex/field-metrics.ts
+++ b/src/services/openalex/field-metrics.ts
@@ -130,6 +130,7 @@ export async function fetchFieldNormalizedMetrics(
       fwci,
       fwciMean,
       topDecileShare,
+      topDecileCount: classified.length,
       meanCitedness,
       paperCount: allWorks.length,
       rcrMean: null,

--- a/src/services/openalex/works.ts
+++ b/src/services/openalex/works.ts
@@ -9,7 +9,13 @@ export interface OaEnrichmentWork {
   doi?: string;
   publication_year?: number;
   cited_by_count?: number;
-  cited_by_percentile_year?: { min?: number; max?: number };
+  /** Native field/year/type-normalized citation impact; 1.0 = world average. */
+  fwci?: number | null;
+  citation_normalized_percentile?: {
+    value?: number;
+    is_in_top_1_percent?: boolean;
+    is_in_top_10_percent?: boolean;
+  } | null;
   open_access?: { oa_status?: string; oa_url?: string };
   best_oa_location?: {
     version?: string;
@@ -27,7 +33,7 @@ export interface OaEnrichmentWork {
 }
 
 const SELECT =
-  'title,open_access,best_oa_location,publication_year,doi,cited_by_count,cited_by_percentile_year,primary_location';
+  'title,open_access,best_oa_location,publication_year,doi,cited_by_count,fwci,citation_normalized_percentile,primary_location';
 
 const PER_PAGE = 200;
 const MAX_PAGES = 10;

--- a/src/types/scholar.ts
+++ b/src/types/scholar.ts
@@ -89,6 +89,8 @@ export interface FieldNormalizedMetrics {
   fwciMean: number | null;
   /** % of classified works in the top 10% most-cited of their field (Leiden-style PP-top10%) */
   topDecileShare: number | null;
+  /** Denominator of topDecileShare: works OpenAlex classified with a citation percentile */
+  topDecileCount: number;
   meanCitedness: number | null;
   paperCount: number;
   rcrMean: number | null;

--- a/src/types/scholar.ts
+++ b/src/types/scholar.ts
@@ -83,7 +83,12 @@ export interface OpenAccessStats {
 }
 
 export interface FieldNormalizedMetrics {
+  /** Median of OpenAlex's native per-work FWCI (field/year/type-normalized; 1.0 = world average) */
   fwci: number | null;
+  /** Mean of per-work FWCI — skew-prone (one viral paper dominates), shown as context only */
+  fwciMean: number | null;
+  /** % of classified works in the top 10% most-cited of their field (Leiden-style PP-top10%) */
+  topDecileShare: number | null;
   meanCitedness: number | null;
   paperCount: number;
   rcrMean: number | null;


### PR DESCRIPTION
Makes the Field-Normalized Metrics section actually field-normalized — meaningful beyond business/biomed disciplines.

**FWCI (replaced):** the previous value was a homegrown proxy — mean `cited_by_percentile_year.min / 50` — which is year-normalized but **not field-normalized**, so authors in low-citation fields (math, humanities) looked systematically weak. Now uses OpenAlex's native per-work `fwci` (normalized by subfield × year × publication type; the SciVal-style measure). Headline value is the **median** — one viral paper can drag a mean far above what's typical — with the mean shown as context in the narrative.

**Top 10% Papers (new):** share of works in the top decile of their field's citation distribution, from `citation_normalized_percentile.is_in_top_10_percent` — the CWTS Leiden Ranking's PP(top 10%) indicator. Robust to outliers, world baseline 10%.

Both fields ride the existing shared works fetch (`select` extended, `cited_by_percentile_year` dropped as now unused) — **zero additional API calls**.

**Bundled root-cause fix:** `useCountUp` in MetricsCard dropped non-numeric affixes after animating — "Solo Author Rate" froze as "53" instead of "53%", "Citation Growth" lost its "+". The new percent card needs the suffix, so the animation now preserves a leading "+" and trailing suffix.

**Displayed values will shift** for existing profiles since the FWCI methodology changes — that's the point: the old number wasn't field-comparable. Tooltips (`metricInfo`) updated to document both metrics honestly.