### PR TITLE
Automate the transparency report on a quarterly basis

### DIFF
--- a/src/components/AboutPage.tsx
+++ b/src/components/AboutPage.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { ArrowLeft, ExternalLink } from 'lucide-react';
 import { Logo } from './Logo';
+import { supabase } from '../lib/supabase';
 
 interface AboutPageProps {
   onBack: () => void;
@@ -8,7 +9,31 @@ interface AboutPageProps {
   authControls?: React.ReactNode;
 }
 
+/** Aggregate-only figures from the `transparency_report` RPC — revenue through
+ *  the end of the last completed quarter, rolling over automatically. */
+interface TransparencyReport {
+  revenue_cents: number;
+  purchase_count: number;
+  first_purchase: string | null;
+  through: string;
+}
+
+function quarterLabel(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `Q${Math.floor(d.getMonth() / 3) + 1} ${d.getFullYear()}`;
+}
+
 export function AboutPage({ onBack, socialLinks, authControls }: AboutPageProps) {
+  const [report, setReport] = useState<TransparencyReport | null>(null);
+  const [reportFailed, setReportFailed] = useState(false);
+
+  useEffect(() => {
+    supabase.rpc('transparency_report').then(({ data, error }) => {
+      if (error || !data) setReportFailed(true);
+      else setReport(data as TransparencyReport);
+    });
+  }, []);
+
   return (
     <main className="flex-1 mesh-bg min-h-screen">
       <nav className="border-b border-gray-200/60 bg-white/60 dark:bg-gray-900/60 backdrop-blur-lg sticky top-0 z-10">
@@ -182,7 +207,15 @@ export function AboutPage({ onBack, socialLinks, authControls }: AboutPageProps)
                 <tbody>
                   <tr>
                     <td className="px-4 py-3 border-b border-gray-100">Total Revenue</td>
-                    <td className="px-4 py-3 border-b border-gray-100">&euro;25.00 <span className="text-[#64748b]">(4 credit-pack purchases)</span></td>
+                    <td className="px-4 py-3 border-b border-gray-100">
+                      {report ? (
+                        <>&euro;{(report.revenue_cents / 100).toFixed(2)} <span className="text-[#64748b]">({report.purchase_count} credit-pack purchase{report.purchase_count !== 1 ? 's' : ''})</span></>
+                      ) : reportFailed ? (
+                        <span className="text-[#64748b] italic">Temporarily unavailable</span>
+                      ) : (
+                        <span className="text-[#64748b] italic">Loading…</span>
+                      )}
+                    </td>
                   </tr>
                   <tr>
                     <td className="px-4 py-3 border-b border-gray-100">Total Costs (API + Hosting)</td>
@@ -201,8 +234,11 @@ export function AboutPage({ onBack, socialLinks, authControls }: AboutPageProps)
             </div>
 
             <p className="text-sm text-[#94a3b8] italic mt-4">
-              Figures as of July 2026, covering all sales since launch (first purchase March 2026).
-              Amounts are gross; Stripe&apos;s processing fees are not yet deducted. Updated as things change.
+              {report
+                ? `Figures through ${quarterLabel(report.through)}, covering all sales since launch${report.first_purchase ? ` (first purchase ${new Date(report.first_purchase).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })})` : ''}. `
+                : 'Figures cover all sales since launch through the last completed quarter. '}
+              Updated automatically each quarter, straight from the payment records.
+              Amounts are gross; Stripe&apos;s processing fees are not yet deducted.
             </p>
           </section>
         </div>

--- a/src/components/AboutPage.tsx
+++ b/src/components/AboutPage.tsx
@@ -18,9 +18,11 @@ interface TransparencyReport {
   through: string;
 }
 
+// Date-only strings parse as UTC midnight — read them back in UTC too, or a
+// negative-offset browser shifts them into the previous day/month/quarter.
 function quarterLabel(dateStr: string): string {
   const d = new Date(dateStr);
-  return `Q${Math.floor(d.getMonth() / 3) + 1} ${d.getFullYear()}`;
+  return `Q${Math.floor(d.getUTCMonth() / 3) + 1} ${d.getUTCFullYear()}`;
 }
 
 export function AboutPage({ onBack, socialLinks, authControls }: AboutPageProps) {
@@ -28,10 +30,19 @@ export function AboutPage({ onBack, socialLinks, authControls }: AboutPageProps)
   const [reportFailed, setReportFailed] = useState(false);
 
   useEffect(() => {
-    supabase.rpc('transparency_report').then(({ data, error }) => {
-      if (error || !data) setReportFailed(true);
-      else setReport(data as TransparencyReport);
-    });
+    let cancelled = false;
+    supabase.rpc('transparency_report')
+      .then(({ data, error }) => {
+        if (cancelled) return;
+        // Guard the shape so an RPC drift shows the fallback, not "€NaN".
+        if (error || !data || typeof (data as TransparencyReport).revenue_cents !== 'number') {
+          setReportFailed(true);
+        } else {
+          setReport(data as TransparencyReport);
+        }
+      })
+      .catch(() => { if (!cancelled) setReportFailed(true); });
+    return () => { cancelled = true; };
   }, []);
 
   return (
@@ -235,7 +246,7 @@ export function AboutPage({ onBack, socialLinks, authControls }: AboutPageProps)
 
             <p className="text-sm text-[#94a3b8] italic mt-4">
               {report
-                ? `Figures through ${quarterLabel(report.through)}, covering all sales since launch${report.first_purchase ? ` (first purchase ${new Date(report.first_purchase).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })})` : ''}. `
+                ? `Figures through ${quarterLabel(report.through)}, covering all sales since launch${report.first_purchase ? ` (first purchase ${new Date(report.first_purchase).toLocaleDateString('en-GB', { month: 'long', year: 'numeric', timeZone: 'UTC' })})` : ''}. `
                 : 'Figures cover all sales since launch through the last completed quarter. '}
               Updated automatically each quarter, straight from the payment records.
               Amounts are gross; Stripe&apos;s processing fees are not yet deducted.


### PR DESCRIPTION
The transparency table was hand-maintained and would drift stale. Now it's live:

**DB (already applied):** new `transparency_report()` RPC — `SECURITY DEFINER`, aggregate-only (`SUM(amount_cents)`, count, first purchase date), reporting **through the end of the last completed quarter**. The cutoff is `date_trunc('quarter', current_date)` computed at query time, so figures roll over automatically each quarter with no cron. `credit_purchases` rows stay behind RLS; `EXECUTE` granted to `anon`/`authenticated` only, `search_path` pinned.

**Frontend:** About page calls the RPC on mount; revenue row and footnote render live figures (currently €20.00 / 3 purchases through Q2 2026 — the 1 July purchase correctly appears only once Q3 closes). Failure shows "Temporarily unavailable" instead of wrong numbers.

Verified against production: RPC returns `{revenue_cents: 2000, purchase_count: 3, through: 2026-06-30}`.