### PR TITLE
Document purchase-record retention in the delete-account flow

### DIFF
--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -76,9 +76,13 @@ Deno.serve(async (req) => {
       .delete()
       .eq('user_id', userId);
 
-    // user_credits and credit_purchases have ON DELETE CASCADE
+    // user_credits has ON DELETE CASCADE (balance goes with the account).
+    // credit_purchases has ON DELETE SET NULL: purchase rows are financial
+    // records — they survive anonymized (user link removed, only pack/amount/
+    // date remain) so the public transparency figures stay consistent with
+    // Stripe's ledger.
 
-    // Delete the auth user (this cascades to user_credits, credit_purchases)
+    // Delete the auth user (cascades to user_credits, anonymizes credit_purchases)
     const { error: deleteError } = await supabase.auth.admin.deleteUser(userId);
 
     if (deleteError) {


### PR DESCRIPTION
Companion to the prod schema change (applied via migration `credit_purchases_keep_on_account_deletion`): `credit_purchases.user_id` is now `ON DELETE SET NULL` instead of `CASCADE`, so purchase records survive account deletion anonymized (user link removed; only pack/amount/date remain) and the public transparency figures can't retroactively shrink out of sync with Stripe.

This PR updates the stale comment in `delete-account` that still claimed CASCADE. Comment-only — no redeploy needed.

Verified after the schema change: all 4 purchases still linked, every purchaser has their credit row, and all code consumers tolerate a NULL `user_id` (admin dashboard doesn't select it, export-data filters `eq('user_id')`, webhook insert unchanged).