### PR TITLE
Exclude non-publication OpenAlex work types from profiles

### DIFF
--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -656,7 +656,7 @@ export function generateNarrativeParagraphs(data: Author, pIndexResult?: PIndexR
       }
       collabParagraph = `${collabPct} of ${lastNameCap}'s publications are co-authored, with an average of **${metrics.averageAuthors}** authors per paper across **${metrics.totalCoAuthors}** unique co-author${metrics.totalCoAuthors !== 1 ? 's' : ''}.`;
       if (metrics.topCoAuthor && metrics.topCoAuthorPapers >= 2) {
-        collabParagraph += ` ${lastNameCap}'s most frequent collaborator is ${metrics.topCoAuthor}, with whom they have published **${metrics.topCoAuthorPapers}** papers.`;
+        collabParagraph += ` ${lastNameCap}'s most frequent collaborator is ${metrics.topCoAuthor}, with whom they have co-authored **${metrics.topCoAuthorPapers}** publication${metrics.topCoAuthorPapers !== 1 ? 's' : ''}.`;
       }
       const otherCoAuthors = (metrics.topCoAuthors ?? [])
         .slice(1) // skip #1 (already mentioned above)

--- a/src/services/openalex/profile.ts
+++ b/src/services/openalex/profile.ts
@@ -41,13 +41,30 @@ interface OaWork {
   cited_by_count?: number;
   doi?: string;
   id?: string;
+  type?: string;
   authorships?: Array<{ author?: { display_name?: string } }>;
   primary_location?: { source?: { display_name?: string } };
 }
 
 const SELECT_AUTHOR = 'id,display_name,works_count,cited_by_count,summary_stats,last_known_institutions,affiliations,counts_by_year,topics,x_concepts';
-const SELECT_WORK = 'title,display_name,publication_year,cited_by_count,doi,id,authorships,primary_location';
+const SELECT_WORK = 'title,display_name,publication_year,cited_by_count,doi,id,type,authorships,primary_location';
 const MAX_WORKS = 400;
+
+// OpenAlex `type` values that are not scholarly publications. These are excluded
+// from the publications list so they don't inflate publication counts, co-author
+// tallies, venue stats, or any metric derived from the works array. (h-index and
+// total citations come from OpenAlex's own author-level summary_stats, so they are
+// unaffected.) Denylist rather than allowlist so unknown/new real work types are
+// kept by default.
+const NON_PUBLICATION_TYPES = new Set([
+  'dataset',
+  'peer-review',
+  'paratext',
+  'grant',
+  'erratum',
+  'retraction',
+  'supplementary-materials',
+]);
 
 /**
  * Search OpenAlex for authors by name, returning candidates shaped like Scholar
@@ -112,7 +129,7 @@ export async function fetchOpenAlexProfile(identifier: string): Promise<Author> 
   }
 
   const publications: Publication[] = works
-    .filter(w => w.title || w.display_name)
+    .filter(w => (w.title || w.display_name) && !NON_PUBLICATION_TYPES.has(w.type ?? ''))
     .map(w => ({
       title: (w.title || w.display_name || '').trim(),
       authors: (w.authorships || [])


### PR DESCRIPTION
## Problem
OpenAlex indexes datasets, peer-reviews, paratext, grants and errata as `works`. We counted every one as a publication — inflating publication counts, co-author tallies, venue stats and any metric derived from the works array.

This surfaced via a **profile error report**: a researcher was shown as having a co-authored-publications count several times higher than their real article count, because datasets, book chapters and books were all counted as papers. They flagged it as inaccurate.

## Fix
- Fetch OpenAlex work `type` and filter out non-publication types via a **denylist** (`dataset`, `peer-review`, `paratext`, `grant`, `erratum`, `retraction`, `supplementary-materials`). Denylist so unknown/new real work types are kept by default.
- Book chapters and books are **kept** (real output) — low-regret scope, not "articles only."
- h-index and total citations are **unaffected** — they come from OpenAlex author-level `summary_stats`.
- Relabel the co-author sentence `published N papers` → `co-authored N publications`.

Build check: `npm run build` passes.