### PR TITLE
Apply verified profile corrections at assembly (corrections Phase 1a)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { ADMIN_EMAIL } from './lib/constants';
 import type { Author } from './types/scholar';
 import { scholarService } from './services/scholar';
 import { openAlexService, fetchOpenAlexProfile, OPENALEX_ID_PREFIX } from './services/openalex';
+import { fetchProfileOverrides, applyProfileOverrides } from './services/corrections';
 import { fetchFieldNormalizedMetrics } from './services/openalex/field-metrics';
 import { enrichWithSemanticScholar } from './services/semanticscholar';
 import { logCaughtError, logError } from './lib/errorLogger';
@@ -306,6 +307,17 @@ function AppContent() {
         setError('Unable to fetch profile data. Please try again later or contact the site administrator.');
         setShowError(true);
         return;
+      }
+
+      // Apply any verified corrections (wrong affiliation, stale title, etc.) on
+      // top of the source-derived profile. No-op for profiles without overrides.
+      try {
+        const overrides = await fetchProfileOverrides(userId ?? url);
+        if (overrides.length > 0) {
+          profileData = applyProfileOverrides(profileData, overrides);
+        }
+      } catch {
+        // Corrections are best-effort — never block a profile from rendering.
       }
 
       // Track usage (skip for direct profile links and OpenAlex fallbacks)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -309,6 +309,13 @@ function AppContent() {
         return;
       }
 
+      // Preserve the source-derived identity for the OpenAlex metric lookups
+      // below. A display correction (name/affiliation) must not change which
+      // OpenAlex author the field-normalized metrics are computed against —
+      // corrections are display-only, metrics stay purely source-derived.
+      const sourceName = profileData.name;
+      const sourceAffiliation = profileData.affiliation;
+
       // Apply any verified corrections (wrong affiliation, stale title, etc.) on
       // top of the source-derived profile. No-op for profiles without overrides.
       try {
@@ -344,7 +351,7 @@ function AppContent() {
       trackEvent('search', { author_id: userId, cache: profileData.cacheStatus, bypass: bypassCredits });
 
       // Fetch Open Access stats from OpenAlex (non-blocking)
-      openAlexService.fetchOpenAccessStats(sanitizedData.name, sanitizedData.affiliation)
+      openAlexService.fetchOpenAccessStats(sourceName, sourceAffiliation)
         .then(oaStats => {
           if (oaStats) {
             setData(prev => prev ? { ...prev, openAccess: oaStats } : prev);
@@ -389,7 +396,7 @@ function AppContent() {
         });
 
       // Fetch field-normalized metrics from OpenAlex + iCite (non-blocking)
-      fetchFieldNormalizedMetrics(sanitizedData.name, sanitizedData.affiliation)
+      fetchFieldNormalizedMetrics(sourceName, sourceAffiliation)
         .then(fieldMetrics => {
           if (fieldMetrics) {
             setData(prev => prev ? { ...prev, fieldMetrics } : prev);

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -291,6 +291,15 @@ export function ProfileView({
                   )}
                 </h2>
                 <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">{data.affiliation}</p>
+                {data.corrections && data.corrections.length > 0 && (
+                  <p
+                    className="text-[11px] text-[#2d7d7d] dark:text-[#5ab5a5] mb-2 inline-flex items-center gap-1"
+                    title={`Corrected at the author's request: ${data.corrections.map(c => c.field.replace(/_/g, ' ')).join(', ')}`}
+                  >
+                    <BadgeCheck className="h-3 w-3" />
+                    Corrected at the author&rsquo;s request
+                  </p>
+                )}
                 <div className="flex flex-wrap items-center gap-2">
                   <div className="relative">
                     <button

--- a/src/services/corrections/index.ts
+++ b/src/services/corrections/index.ts
@@ -1,0 +1,64 @@
+import type { Author } from '../../types/scholar';
+import { supabase } from '../../lib/supabase';
+
+/**
+ * Verified profile corrections.
+ *
+ * Researchers report errors on their public profiles (wrong affiliation, stale
+ * title, a misattributed paper). Admin-reviewed corrections are stored as
+ * field-level overrides in `profile_overrides` and applied here, on top of the
+ * source-derived profile, every time it's assembled — so a correction persists
+ * across the source cache refreshing and is seen by every viewer.
+ *
+ * Scope is deliberately narrow: only descriptive, source-underivable fields.
+ * Computed metrics (h-index, counts, co-author stats) are NEVER overridable —
+ * they stay source-derived, so the correction layer can't be used to inflate a
+ * number. Reads go through the `get_profile_overrides` SECURITY DEFINER function
+ * so the browser (anon key) never touches the locked overrides table directly.
+ */
+
+export interface ProfileOverride {
+  field: 'affiliation' | 'display_name' | 'title' | 'hide_work' | string;
+  value: unknown;
+  note: string | null;
+  verified_via: 'admin' | 'orcid' | string;
+}
+
+/** Fetch active corrections for one author id (Scholar id or `openalex:<id>`). */
+export async function fetchProfileOverrides(authorId: string): Promise<ProfileOverride[]> {
+  if (!authorId) return [];
+  const { data, error } = await supabase.rpc('get_profile_overrides', { p_author_id: authorId });
+  if (error || !data) return [];
+  return data as ProfileOverride[];
+}
+
+/** Coerce a jsonb override value to a display string (stored either as a bare
+ *  JSON string or an object like `{ "text": "…" }`). */
+function asText(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (value && typeof value === 'object' && 'text' in value) {
+    const t = (value as { text?: unknown }).text;
+    return typeof t === 'string' ? t.trim() : '';
+  }
+  return '';
+}
+
+/**
+ * Apply verified corrections to a profile. Phase 1 handles the descriptive
+ * string fields (affiliation, display name); metric-affecting corrections such
+ * as `hide_work` are applied earlier in the pipeline (before metrics are
+ * computed) and are ignored here. Returns the input unchanged when there are no
+ * overrides, so this is a no-op for the overwhelming majority of profiles.
+ */
+export function applyProfileOverrides(profile: Author, overrides: ProfileOverride[]): Author {
+  if (!overrides || overrides.length === 0) return profile;
+
+  let next = profile;
+  for (const o of overrides) {
+    const text = asText(o.value);
+    if (!text) continue;
+    if (o.field === 'affiliation') next = { ...next, affiliation: text };
+    else if (o.field === 'display_name') next = { ...next, name: text };
+  }
+  return next;
+}

--- a/src/services/corrections/index.ts
+++ b/src/services/corrections/index.ts
@@ -44,11 +44,12 @@ function asText(value: unknown): string {
 }
 
 /**
- * Apply verified corrections to a profile. Phase 1 handles the descriptive
- * string fields (affiliation, display name); metric-affecting corrections such
- * as `hide_work` are applied earlier in the pipeline (before metrics are
- * computed) and are ignored here. Returns the input unchanged when there are no
- * overrides, so this is a no-op for the overwhelming majority of profiles.
+ * Apply verified corrections to a profile. Phase 1 handles only the descriptive
+ * string fields (affiliation, display name). Metric-affecting corrections such
+ * as `hide_work` are not implemented yet and are ignored here (they will need a
+ * hook before metrics are computed, not a post-assembly patch). Returns the
+ * input unchanged when there are no overrides, so this is a no-op for the
+ * overwhelming majority of profiles.
  */
 export function applyProfileOverrides(profile: Author, overrides: ProfileOverride[]): Author {
   if (!overrides || overrides.length === 0) return profile;

--- a/src/services/corrections/index.ts
+++ b/src/services/corrections/index.ts
@@ -54,11 +54,14 @@ export function applyProfileOverrides(profile: Author, overrides: ProfileOverrid
   if (!overrides || overrides.length === 0) return profile;
 
   let next = profile;
+  const applied: Author['corrections'] = [];
   for (const o of overrides) {
     const text = asText(o.value);
     if (!text) continue;
     if (o.field === 'affiliation') next = { ...next, affiliation: text };
     else if (o.field === 'display_name') next = { ...next, name: text };
+    else continue; // unhandled field (e.g. hide_work, applied elsewhere) — no marker
+    applied.push({ field: o.field, note: o.note, verifiedVia: o.verified_via });
   }
-  return next;
+  return applied.length > 0 ? { ...next, corrections: applied } : next;
 }

--- a/src/types/scholar.ts
+++ b/src/types/scholar.ts
@@ -128,6 +128,14 @@ export interface Author {
   s2Data?: Record<string, S2PublicationData>;
   s2Stats?: S2Stats;
   cacheStatus?: 'hit' | 'miss';
+  /** Verified corrections applied on top of the source data (for provenance UI). */
+  corrections?: AppliedCorrection[];
+}
+
+export interface AppliedCorrection {
+  field: string;
+  note: string | null;
+  verifiedVia: string;
 }
 
 export interface CoAuthorGeoData {

--- a/supabase/profile_overrides.sql
+++ b/supabase/profile_overrides.sql
@@ -1,0 +1,62 @@
+-- Reference DDL for the profile-corrections feature.
+--
+-- These objects were applied to the project directly (Supabase SQL editor / MCP),
+-- NOT via the migrations CLI. This file is a documentation snapshot so the schema
+-- is visible in the repo — running it is not required and it is not picked up by
+-- the CLI. Keep it in sync by hand if the objects change (same convention as
+-- profile_views.sql).
+--
+-- What it powers: admin-reviewed corrections applied on top of source-derived
+-- profiles at render time (wrong affiliation, stale title, misattributed work).
+-- Descriptive fields only — computed metrics are never overridable.
+
+create table if not exists public.profile_overrides (
+  id               uuid primary key default gen_random_uuid(),
+  author_id        text not null,        -- Scholar id ('NOSPtp8AAAAJ') or 'openalex:A5012349832'
+  field            text not null check (field in ('affiliation','title','display_name','hide_work')),
+  value            jsonb not null,       -- e.g. "University of Example" (jsonb string) | {"work_url":"…"}
+  note             text,                 -- rationale, shown in provenance/audit
+  source_report_id uuid references public.profile_reports(id) on delete set null,
+  verified_via     text not null default 'admin' check (verified_via in ('admin','orcid')),
+  created_by       uuid references auth.users(id) on delete set null,
+  active           boolean not null default true,
+  created_at       timestamptz not null default now()
+);
+
+create index if not exists profile_overrides_author_idx
+  on public.profile_overrides (author_id) where active;
+
+-- Locked down: RLS on, no anon access. Reads for display go through the
+-- SECURITY DEFINER function below; writes are admin-only (policies mirror the
+-- existing profile_reports admin pattern).
+alter table public.profile_overrides enable row level security;
+
+create policy "Admin can view overrides" on public.profile_overrides
+  for select to authenticated
+  using ((auth.jwt() ->> 'email') = 'jonasheller89@gmail.com');
+
+create policy "Admin can insert overrides" on public.profile_overrides
+  for insert to authenticated
+  with check ((auth.jwt() ->> 'email') = 'jonasheller89@gmail.com');
+
+create policy "Admin can update overrides" on public.profile_overrides
+  for update to authenticated
+  using ((auth.jwt() ->> 'email') = 'jonasheller89@gmail.com')
+  with check ((auth.jwt() ->> 'email') = 'jonasheller89@gmail.com');
+
+-- Public/display read: returns only the display-safe columns for active rows,
+-- so the browser (anon key) never touches the locked table and created_by /
+-- source_report_id are never exposed. search_path pinned against hijacking.
+create or replace function public.get_profile_overrides(p_author_id text)
+returns table (field text, value jsonb, note text, verified_via text)
+language sql
+security definer
+set search_path = public
+as $$
+  select field, value, note, verified_via
+  from public.profile_overrides
+  where author_id = p_author_id and active
+$$;
+
+revoke all on function public.get_profile_overrides(text) from public;
+grant execute on function public.get_profile_overrides(text) to anon, authenticated, service_role;


### PR DESCRIPTION
First of the code changes for the profile-corrections feature (spec approved separately). The DB objects already exist on the project.

## What this adds
Render-time application of admin-verified corrections on top of source-derived profiles.

- New `src/services/corrections/index.ts`: `fetchProfileOverrides(authorId)` + `applyProfileOverrides(profile, overrides)`.
- Hooked in `App.tsx` right after `profileData`/`userId` resolve — the single point where **both** Google Scholar and OpenAlex profiles converge with their id token. (OpenAlex profiles are assembled client-side, so this client hook is the true single choke point — no redeploy of the central scholar function.)
- Corrections flow into render **and** PDF/CV export for free.
- Provenance: a subtle "Corrected at the author's request" badge; the source-derived name/affiliation still feed the OpenAlex metric lookups, so corrections stay display-only.

## Safety
- **Descriptive fields only** (affiliation, display name). Computed metrics are never overridable — the correction layer cannot inflate a number.
- Reads go through `get_profile_overrides`, a `SECURITY DEFINER` function returning only display-safe columns for active rows, so the browser (anon key) never touches the locked `profile_overrides` table.
- Best-effort: a corrections fetch failure never blocks a profile from rendering. No-op for profiles without overrides.

## DB objects (already applied)
- `profile_overrides` table — field-level patches, FK to `profile_reports`, check constraints, partial index, RLS on / service-role + admin only.
- `get_profile_overrides(text)` — SECURITY DEFINER read of active, display-safe columns.

Verified the DB→client shape end-to-end with a temporary override, then removed it — table is empty.

Build: `npm run build` passes.