### PR TITLE
Exclude owner's initials-only name variant from co-author list

### DIFF
--- a/src/services/metrics/collaboration/co-author-metrics.ts
+++ b/src/services/metrics/collaboration/co-author-metrics.ts
@@ -126,6 +126,33 @@ function isSameAuthor(nameA: string, nameB: string): boolean {
   return true;
 }
 
+/** Decide whether an author string on a paper is the profile owner (and should
+ *  therefore be excluded from the co-author list).
+ *
+ *  Uses isSameAuthor(), plus a looser rule for the one case it misses: an
+ *  initials-only variant of the owner whose extra middle initial isn't present
+ *  in the owner's stored name — e.g. a profile for "Jane Doe" whose papers
+ *  list her as "JM Doe". isSameAuthor rejects that because the "m" has nothing
+ *  to match. Here we treat it as the owner when the surnames match and the
+ *  co-author side is a pure initials form (every given token ≤ 2 chars) whose
+ *  first initial matches the owner's first initial.
+ *
+ *  Capping at 2-char tokens keeps real first names out (e.g. "James Doe" stays a
+ *  co-author). Worst case this drops a same-surname co-author who both shares
+ *  the owner's first initial and publishes under two initials — rare and
+ *  low-harm — and in exchange the owner never appears as their own collaborator. */
+function isProfileOwner(coAuthor: string, owner: string): boolean {
+  if (isSameAuthor(coAuthor, owner)) return true;
+
+  const a = parseName(normalizeName(coAuthor));
+  const b = parseName(normalizeName(owner));
+  if (!a.last || a.last !== b.last) return false;
+  if (a.given.length === 0 || b.given.length === 0) return false;
+
+  const coAuthorIsInitialsOnly = a.given.every(part => part.length <= 2);
+  return coAuthorIsInitialsOnly && a.given[0][0] === b.given[0][0];
+}
+
 export function calculateCoAuthorMetrics(publications: Publication[], authorName: string): CoAuthorStats {
   const coAuthorCounts = new Map<string, {
     count: number;
@@ -151,7 +178,7 @@ export function calculateCoAuthorMetrics(publications: Publication[], authorName
     totalAuthors += pub.authors.length;
 
     pub.authors.forEach(author => {
-      if (!isSameAuthor(author, cleanAuthorName)) {
+      if (!isProfileOwner(author, cleanAuthorName)) {
         const existingData = coAuthorCounts.get(author) || {
           count: 0,
           citations: 0,


### PR DESCRIPTION
## Problem
A profile could list the owner as their own co-author when their papers spell their name in initials form (owner stored as a full first name; works list an initials variant carrying an extra middle initial). `isSameAuthor` rejected the match because the extra initial had nothing to match in the stored name, so the initials form was counted as a separate co-author.

Root cause is ours, not the source: the combined-initials check requires *every* initial in the abbreviated token to match a given-name part of the owner's stored name.

## Fix
Add `isProfileOwner()` (used only for owner-exclusion in the co-author aggregation):
- `isSameAuthor()` as before, **plus** a looser rule: same surname + co-author side is a pure initials-only form (every given token ≤ 2 chars) + first initials match.
- The **2-char cap** keeps real first names as genuine co-authors.
- Only owner-exclusion is affected; co-author-to-co-author merging (`normalizeAuthorNames`) is untouched.

## Verification
Standalone logic test (synthetic names), all pass — initials variants fold into the owner; distinct same-surname colleagues and different first names stay as co-authors.

Build check: `npm run build` passes.