### PR TITLE
ORCID-verified profile claiming — backend (stage 1 of 2)

### DIFF
--- a/src/components/ClaimProfileModal.tsx
+++ b/src/components/ClaimProfileModal.tsx
@@ -35,7 +35,17 @@ export function ClaimProfileModal({ onClose, authorId, authorName, onClaimed }: 
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [existingClaim, setExistingClaim] = useState<string | null>(null);
+  const [needsOrcid, setNeedsOrcid] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  // Start the ORCID sign-in flow (same as the auth modal) so an account without
+  // a linked ORCID can connect one, then return to claim.
+  const connectOrcid = () => {
+    const state = crypto.randomUUID();
+    sessionStorage.setItem('orcid_oauth_state', state);
+    const redirectUri = encodeURIComponent(`${window.location.origin}/api/orcid-callback`);
+    window.location.href = `https://orcid.org/oauth/authorize?client_id=APP-R9QF1AQWVYVJW0V9&response_type=code&scope=/authenticate&redirect_uri=${redirectUri}&state=${state}`;
+  };
 
   // Check if user already claimed a profile
   useEffect(() => {
@@ -98,24 +108,33 @@ export function ClaimProfileModal({ onClose, authorId, authorName, onClaimed }: 
 
     setSubmitting(true);
     setError(null);
+    setNeedsOrcid(false);
 
-    const { error: insertError } = await supabase
-      .from('claimed_profiles')
-      .insert({
-        user_id: user.id,
-        author_id: authorId,
-        slug,
-        display_name: displayName || null,
-        bio: bio || null,
+    let data: { claimed?: boolean; reason?: string; message?: string; error?: string } = {};
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const res = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/claim-profile`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${session?.access_token || ''}` },
+        body: JSON.stringify({ action: 'claim', authorId, profileName: authorName, slug, displayName: displayName || undefined, bio: bio || undefined }),
       });
-
-    if (insertError) {
-      if (insertError.code === '23505') {
-        setError('This URL is already taken. Please choose another.');
-        setSlugStatus('taken');
-      } else {
-        setError(insertError.message);
+      data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.claimed) {
+        if (data.reason === 'no-orcid') {
+          setNeedsOrcid(true);
+        } else if (data.reason === 'not-owner') {
+          setError("We couldn't verify that this profile is yours from your ORCID iD. Make sure your ORCID is connected to your publications.");
+        } else if (res.status === 409 || /taken|duplicate|unique/i.test(data.error || '')) {
+          setError('This URL is already taken. Please choose another.');
+          setSlugStatus('taken');
+        } else {
+          setError(data.message || data.error || 'Could not claim this profile.');
+        }
+        setSubmitting(false);
+        return;
       }
+    } catch {
+      setError('Could not reach the server. Please try again.');
       setSubmitting(false);
       return;
     }
@@ -415,21 +434,38 @@ export function ClaimProfileModal({ onClose, authorId, authorName, onClaimed }: 
             </div>
           )}
 
-          {/* Submit */}
-          <button
-            onClick={handleSubmit}
-            disabled={submitting || slugStatus !== 'available' || !user}
-            className="w-full py-2.5 text-sm font-semibold rounded-lg bg-[#2d7d7d] text-white hover:bg-[#1f5c5c] shadow-md shadow-[#2d7d7d]/20 hover:shadow-lg hover:shadow-[#2d7d7d]/30 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {submitting ? (
-              <span className="inline-flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Claiming...
-              </span>
-            ) : (
-              'Claim this profile'
-            )}
-          </button>
+          {/* ORCID connect prompt (account has no linked ORCID) */}
+          {needsOrcid ? (
+            <div className="space-y-2">
+              <p className="text-xs text-gray-600">
+                To claim your profile we verify it's yours via your ORCID iD. Connect your ORCID to continue.
+              </p>
+              <button
+                onClick={connectOrcid}
+                className="w-full flex items-center justify-center gap-2 py-2.5 text-sm font-semibold rounded-lg bg-[#A6CE39] text-white hover:brightness-95 transition-all"
+              >
+                <svg className="h-4 w-4" viewBox="0 0 256 256"><path fill="#fff" d="M86.3 186.2H70.9V79.1h15.4v107.1zm22.2 0h15.4V127c0-10.9 5.1-17.4 14.9-17.4 8.3 0 12.9 5.1 12.9 15v61.6h15.4V121.1c0-17.9-10.1-28.4-26.6-28.4-11.7 0-18.7 5.1-22.2 12.6h-.3V79.1H108v107.1h.5zM86.3 65.4c-5.1 0-9.1 4-9.1 9.1s4 9.1 9.1 9.1 9.1-4 9.1-9.1-4.1-9.1-9.1-9.1z"/></svg>
+                Connect your ORCID iD
+              </button>
+            </div>
+          ) : (
+            /* Submit */
+            <button
+              onClick={handleSubmit}
+              disabled={submitting || slugStatus !== 'available' || !user}
+              className="w-full py-2.5 text-sm font-semibold rounded-lg bg-[#2d7d7d] text-white hover:bg-[#1f5c5c] shadow-md shadow-[#2d7d7d]/20 hover:shadow-lg hover:shadow-[#2d7d7d]/30 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting ? (
+                <span className="inline-flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Verifying with ORCID…
+                </span>
+              ) : (
+                'Verify with ORCID & claim'
+              )}
+            </button>
+          )}
+          <p className="text-[11px] text-gray-400 text-center">We confirm ownership via your ORCID iD before claiming.</p>
         </div>
       </div>
     </div>

--- a/src/components/ProfileCorrectionModal.tsx
+++ b/src/components/ProfileCorrectionModal.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { X, Check, AlertCircle, Loader2, BadgeCheck } from 'lucide-react';
+import { supabase } from '../lib/supabase';
+
+interface ProfileCorrectionModalProps {
+  onClose: () => void;
+  authorId: string;
+  currentName: string;
+  currentAffiliation: string;
+}
+
+/**
+ * Self-service corrections for an ORCID-verified profile owner. Submits
+ * descriptive corrections (affiliation, display name) through the claim-profile
+ * edge function, which re-checks the verified claim server-side before writing a
+ * profile_overrides row (verified_via = 'orcid'). Metrics are never editable.
+ */
+export function ProfileCorrectionModal({ onClose, authorId, currentName, currentAffiliation }: ProfileCorrectionModalProps) {
+  const [affiliation, setAffiliation] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const submit = async () => {
+    const edits: { field: string; value: string }[] = [];
+    if (affiliation.trim()) edits.push({ field: 'affiliation', value: affiliation.trim() });
+    if (displayName.trim()) edits.push({ field: 'display_name', value: displayName.trim() });
+    if (edits.length === 0) { setError('Enter at least one correction.'); return; }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const token = session?.access_token || '';
+      for (const edit of edits) {
+        const res = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/claim-profile`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+          body: JSON.stringify({ action: 'correct', authorId, field: edit.field, value: edit.value }),
+        });
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok || !body.ok) {
+          setError(body.error || 'Could not save your correction.');
+          setSaving(false);
+          return;
+        }
+      }
+      setDone(true);
+      setTimeout(onClose, 1800);
+    } catch {
+      setError('Could not reach the server. Please try again.');
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4" role="dialog" aria-modal="true" aria-labelledby="correct-title" onClick={onClose} onKeyDown={e => { if (e.key === 'Escape') onClose(); }}>
+      <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-md w-full overflow-hidden" onClick={e => e.stopPropagation()}>
+        <div className="relative bg-gradient-to-br from-[#2d7d7d] to-[#1a5c5c] px-6 pt-6 pb-5 text-white">
+          <button onClick={onClose} className="absolute top-4 right-4 text-white/70 hover:text-white transition-colors" aria-label="Close"><X className="h-5 w-5" /></button>
+          <div className="flex items-center gap-2 mb-2">
+            <BadgeCheck className="h-5 w-5 text-amber-300" />
+            <span className="text-xs font-medium uppercase tracking-wider text-white/80">Correct your details</span>
+          </div>
+          <h2 id="correct-title" className="text-lg font-bold">Fix what the data got wrong</h2>
+          <p className="text-sm text-white/80 mt-1">Corrections you make as the verified owner show for everyone. Metrics stay as computed from the source.</p>
+        </div>
+
+        {done ? (
+          <div className="p-8 text-center">
+            <div className="w-14 h-14 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4"><Check className="h-7 w-7 text-emerald-600" /></div>
+            <p className="text-sm text-gray-700 dark:text-gray-200">Saved. Your corrections will show on the profile shortly.</p>
+          </div>
+        ) : (
+          <div className="px-6 py-5 space-y-4">
+            <div>
+              <label htmlFor="corr-aff" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Affiliation</label>
+              <input id="corr-aff" type="text" value={affiliation} onChange={e => setAffiliation(e.target.value)} placeholder={currentAffiliation || 'e.g. Professor, University of …'} maxLength={300}
+                className="w-full px-3 py-2.5 text-sm text-gray-900 rounded-lg border border-gray-300 focus:border-[#2d7d7d] focus:ring-1 focus:ring-[#2d7d7d] outline-none transition-colors" />
+              <p className="text-[11px] text-gray-400 mt-1">Currently: {currentAffiliation || '—'}</p>
+            </div>
+            <div>
+              <label htmlFor="corr-name" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Display name</label>
+              <input id="corr-name" type="text" value={displayName} onChange={e => setDisplayName(e.target.value)} placeholder={currentName} maxLength={300}
+                className="w-full px-3 py-2.5 text-sm text-gray-900 rounded-lg border border-gray-300 focus:border-[#2d7d7d] focus:ring-1 focus:ring-[#2d7d7d] outline-none transition-colors" />
+            </div>
+
+            {error && (
+              <div className="text-xs text-red-600 bg-red-50 px-3 py-2 rounded-lg flex items-center gap-1.5"><AlertCircle className="h-3.5 w-3.5 flex-shrink-0" />{error}</div>
+            )}
+
+            <button onClick={submit} disabled={saving}
+              className="w-full py-2.5 text-sm font-semibold rounded-lg bg-[#2d7d7d] text-white hover:bg-[#1f5c5c] shadow-md shadow-[#2d7d7d]/20 transition-all disabled:opacity-50 disabled:cursor-not-allowed">
+              {saving ? <span className="inline-flex items-center gap-2"><Loader2 className="h-4 w-4 animate-spin" />Saving…</span> : 'Save corrections'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useCallback, lazy, Suspense } from 
 import { Search, ArrowLeft, BookOpen, Users, LineChart, Network, BarChart as ChartBar, User, Share2, Check, Code, Download, Unlock, ExternalLink, Heart, BadgeCheck, Link, Globe, FileText, MessageSquare, Mail, MapPin } from 'lucide-react';
 import { EmbedModal } from './EmbedModal';
 import { ClaimProfileModal } from './ClaimProfileModal';
+import { ProfileCorrectionModal } from './ProfileCorrectionModal';
 // pdfExport is dynamically imported on click to avoid bundling jsPDF (344KB)
 import { ScholarSearchModal } from './ScholarSearchModal';
 import { TopicsList } from './TopicsList';
@@ -103,6 +104,8 @@ export function ProfileView({
   }, [updateIndicator]);
   const [claimedSlug, setClaimedSlug] = useState<string | null>(null);
   const [claimedByCurrentUser, setClaimedByCurrentUser] = useState(false);
+  const [claimedVerified, setClaimedVerified] = useState(false);
+  const [showCorrectModal, setShowCorrectModal] = useState(false);
   const [prefetchedGeo, setPrefetchedGeo] = useState<{ mainAuthor: CoAuthorGeoData | null; coAuthors: CoAuthorGeoData[] } | null>(null);
   const [pIndexResult, setPIndexResult] = useState<PIndexResult | null>(null);
 
@@ -125,26 +128,31 @@ export function ProfileView({
     || '';
   const isOpenAlexProfile = rawUserId.startsWith('openalex:') || (!!profileUrl && profileUrl.startsWith('openalex:'));
   const scholarId = isOpenAlexProfile ? '' : rawUserId;
+  // Identity for claiming/correcting — works for both Scholar (bare id) and
+  // OpenAlex ("openalex:<id>"). ORCID verification makes claiming safe for both.
+  const claimAuthorId = isOpenAlexProfile ? rawUserId : scholarId;
 
   // Check if this profile has been claimed
   useEffect(() => {
-    if (!scholarId) return;
+    if (!claimAuthorId) return;
     const checkClaim = async () => {
       const { data: claim } = await supabase
         .from('claimed_profiles')
-        .select('slug, user_id')
-        .eq('author_id', scholarId)
+        .select('slug, user_id, verified')
+        .eq('author_id', claimAuthorId)
         .maybeSingle();
       if (claim) {
         setClaimedSlug(claim.slug);
         setClaimedByCurrentUser(user?.id === claim.user_id);
+        setClaimedVerified(!!claim.verified);
       } else {
         setClaimedSlug(null);
         setClaimedByCurrentUser(false);
+        setClaimedVerified(false);
       }
     };
     checkClaim();
-  }, [scholarId, user?.id]);
+  }, [claimAuthorId, user?.id]);
 
   // Track profile views for feedback prompt + trending leaderboard
   useEffect(() => {
@@ -381,7 +389,7 @@ export function ProfileView({
                         'Verified profile'
                       )}
                     </span>
-                  ) : user && scholarId ? (
+                  ) : user && claimAuthorId ? (
                     <button
                       onClick={() => setShowClaimModal(true)}
                       className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] dark:text-[#5bbdbd] hover:text-[#1a5c5c] bg-[#eaf4f4] dark:bg-[#2d7d7d]/20 hover:bg-[#d5ecec] dark:hover:bg-[#2d7d7d]/30 px-2.5 py-1 rounded-full transition-colors"
@@ -390,6 +398,15 @@ export function ProfileView({
                       Claim profile
                     </button>
                   ) : null}
+                  {claimedByCurrentUser && claimedVerified && (
+                    <button
+                      onClick={() => setShowCorrectModal(true)}
+                      className="inline-flex items-center gap-1.5 text-xs text-[#2d7d7d] dark:text-[#5bbdbd] hover:text-[#1a5c5c] bg-[#eaf4f4] dark:bg-[#2d7d7d]/20 hover:bg-[#d5ecec] dark:hover:bg-[#2d7d7d]/30 px-2.5 py-1 rounded-full transition-colors"
+                    >
+                      <FileText className="h-3 w-3" />
+                      Correct details
+                    </button>
+                  )}
                   {data.openAccess?.orcid && (
                     <a
                       href={`https://orcid.org/${data.openAccess.orcid}`}
@@ -724,12 +741,21 @@ export function ProfileView({
         />
       )}
 
-      {showClaimModal && scholarId && data && (
+      {showClaimModal && claimAuthorId && data && (
         <ClaimProfileModal
           onClose={() => setShowClaimModal(false)}
-          authorId={scholarId}
+          authorId={claimAuthorId}
           authorName={data.name}
           onClaimed={handleClaimed}
+        />
+      )}
+
+      {showCorrectModal && claimAuthorId && data && (
+        <ProfileCorrectionModal
+          onClose={() => setShowCorrectModal(false)}
+          authorId={claimAuthorId}
+          currentName={data.name}
+          currentAffiliation={data.affiliation}
         />
       )}
 

--- a/supabase/claimed_profiles.sql
+++ b/supabase/claimed_profiles.sql
@@ -1,0 +1,19 @@
+-- Reference DDL snapshot for claimed_profiles (applied via SQL, not the CLI).
+-- Documents the ORCID-verification columns added for ORCID-controlled claiming.
+-- See supabase/functions/claim-profile/ for the verification logic.
+
+-- Columns added 2026-07-08 for ORCID-verified claiming (additive, nullable/defaulted):
+alter table public.claimed_profiles
+  add column if not exists verified boolean not null default false,  -- true once ORCID-verified
+  add column if not exists orcid text,                                -- the verifying ORCID iD (URL form)
+  add column if not exists verified_via text;                         -- 'orcid' | 'admin'
+
+-- SECURITY FOLLOW-UP (not yet applied — do this when the ORCID claim flow ships,
+-- so the current claim path isn't broken in the meantime):
+-- The existing INSERT policy allows any signed-in user to claim any author_id:
+--     "Users can claim profiles"  INSERT  with check (auth.uid() = user_id)
+-- Once claiming goes exclusively through the claim-profile edge function (which
+-- writes with the service role after ORCID verification), drop that policy so the
+-- client can no longer insert unverified claims directly:
+--   drop policy "Users can claim profiles" on public.claimed_profiles;
+--   drop policy "Users can update own claims" on public.claimed_profiles;  -- if edits also move server-side

--- a/supabase/functions/claim-profile/index.ts
+++ b/supabase/functions/claim-profile/index.ts
@@ -1,0 +1,160 @@
+import { createClient } from "npm:@supabase/supabase-js@2.39.3";
+
+/**
+ * ORCID-verified profile claiming.
+ *
+ * Replaces the previous unverified claim path (any logged-in user could claim
+ * any profile). To claim a profile a signed-in user must prove, via their linked
+ * ORCID iD, that the profile is theirs:
+ *   - OpenAlex profiles carry an ORCID directly → compare to the user's ORCID.
+ *   - Google Scholar profiles have no ORCID → resolve the user's ORCID to its
+ *     OpenAlex author record and require the display name to match the profile.
+ * Profiles that cannot be matched this way are NOT self-claimable here; they fall
+ * back to admin review (unchanged). Only users with an account + a linked ORCID
+ * can reach this path.
+ *
+ * Deploy with: supabase functions deploy claim-profile --no-verify-jwt
+ */
+
+const OPENALEX_BASE = "https://api.openalex.org";
+const OA_MAILTO = "info@scholarfolio.org";
+
+const ALLOWED_ORIGINS = [
+  "https://scholarfolio.org",
+  "https://www.scholarfolio.org",
+  "https://scholarfolio.netlify.app",
+  "http://localhost:5173",
+];
+
+function isAllowedOrigin(origin: string): boolean {
+  if (ALLOWED_ORIGINS.includes(origin)) return true;
+  if (/^https:\/\/[a-z0-9-]+--scholarfolio\.netlify\.app$/.test(origin)) return true;
+  return false;
+}
+
+function corsHeaders(req: Request) {
+  const origin = req.headers.get("Origin") || "";
+  const allowed = isAllowedOrigin(origin) ? origin : ALLOWED_ORIGINS[0];
+  return {
+    "Access-Control-Allow-Origin": allowed,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  };
+}
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL") ?? "",
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+);
+
+// OpenAlex API key: env secret first, then the RLS-locked app_config table
+// (same resolution as the scholar function).
+let _oaKeyCache: string | null = null;
+async function getOpenAlexKey(): Promise<string> {
+  const envKey = Deno.env.get("OPENALEX_API_KEY");
+  if (envKey) return envKey;
+  if (_oaKeyCache !== null) return _oaKeyCache;
+  try {
+    const { data } = await supabase.from("app_config").select("value").eq("key", "openalex_api_key").maybeSingle();
+    _oaKeyCache = data?.value ?? "";
+  } catch {
+    _oaKeyCache = "";
+  }
+  return _oaKeyCache;
+}
+
+async function oaFetch(path: string): Promise<any | null> {
+  const key = await getOpenAlexKey();
+  const url = new URL(OPENALEX_BASE + path);
+  if (key) url.searchParams.set("api_key", key);
+  else url.searchParams.set("mailto", OA_MAILTO);
+  const res = await fetch(url.toString(), { signal: AbortSignal.timeout(12000) });
+  if (!res.ok) return null;
+  return await res.json();
+}
+
+/** Extract the bare 16-digit ORCID (0000-0000-0000-0000) from any ORCID form. */
+function normalizeOrcid(raw: string | null | undefined): string {
+  if (!raw) return "";
+  const m = String(raw).match(/(\d{4}-\d{4}-\d{4}-\d{3}[\dX])/i);
+  return m ? m[1].toUpperCase() : "";
+}
+
+/** Loose person-name match (last name equal, first initials compatible). */
+function namesMatch(a: string, b: string): boolean {
+  const norm = (s: string) =>
+    s.normalize("NFD").replace(/[̀-ͯ]/g, "").toLowerCase().replace(/[.,]/g, "").trim().split(/\s+/).filter(Boolean);
+  const an = norm(a), bn = norm(b);
+  if (an.length === 0 || bn.length === 0) return false;
+  if (an[an.length - 1] !== bn[bn.length - 1]) return false; // last names must match
+  return an[0][0] === bn[0][0]; // first initials must match
+}
+
+Deno.serve(async (req) => {
+  const cors = corsHeaders(req);
+  if (req.method === "OPTIONS") return new Response(null, { headers: cors });
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status, headers: { ...cors, "Content-Type": "application/json" } });
+
+  try {
+    // Authenticate — an account is required.
+    const jwt = (req.headers.get("Authorization") || "").replace("Bearer ", "");
+    const { data: { user }, error: authErr } = await supabase.auth.getUser(jwt);
+    if (authErr || !user) return json({ error: "Sign in to claim a profile." }, 401);
+
+    const userOrcid = normalizeOrcid(user.user_metadata?.orcid_id);
+    if (!userOrcid) {
+      return json({ verified: false, reason: "no-orcid", message: "Connect your ORCID iD to claim your profile." });
+    }
+
+    const body = await req.json();
+    const { action, authorId, profileName, slug } = body as {
+      action?: string; authorId?: string; profileName?: string; slug?: string;
+    };
+    if (!authorId) return json({ error: "authorId is required" }, 400);
+
+    // --- Verify ownership via ORCID -------------------------------------------
+    let verified = false;
+    if (authorId.startsWith("openalex:")) {
+      const shortId = authorId.replace("openalex:", "").replace("https://openalex.org/", "").trim();
+      if (!/^A\d+$/.test(shortId)) return json({ error: "Invalid OpenAlex id" }, 400);
+      const author = await oaFetch(`/authors/${shortId}?select=orcid`);
+      verified = normalizeOrcid(author?.orcid) === userOrcid;
+    } else {
+      // Google Scholar profile: resolve the user's ORCID to its OpenAlex author
+      // and require the display name to match the claimed profile.
+      if (!profileName) return json({ error: "profileName is required for this profile" }, 400);
+      const found = await oaFetch(`/authors?filter=orcid:${userOrcid}&select=display_name&per_page=1`);
+      const oaName = found?.results?.[0]?.display_name;
+      verified = !!oaName && namesMatch(oaName, profileName);
+    }
+
+    if (action === "verify") {
+      return json({ verified });
+    }
+
+    if (action === "claim") {
+      if (!verified) {
+        return json({ verified: false, reason: "not-owner", message: "We couldn't verify that this profile belongs to your ORCID iD." });
+      }
+      // Enforce one claim per account and unique slug at the app layer already;
+      // here we upsert a verified claim owned by this user.
+      const row: Record<string, unknown> = {
+        user_id: user.id,
+        author_id: authorId,
+        verified: true,
+        orcid: `https://orcid.org/${userOrcid}`,
+        verified_via: "orcid",
+      };
+      if (slug) row.slug = slug;
+      const { error: upErr } = await supabase.from("claimed_profiles").upsert(row, { onConflict: "user_id" });
+      if (upErr) return json({ error: upErr.message }, 400);
+      return json({ verified: true, claimed: true });
+    }
+
+    return json({ error: 'Invalid action. Use "verify" or "claim".' }, 400);
+  } catch (e) {
+    console.error("claim-profile error:", e);
+    return json({ error: "Internal server error" }, 500);
+  }
+});

--- a/supabase/functions/claim-profile/index.ts
+++ b/supabase/functions/claim-profile/index.ts
@@ -108,10 +108,35 @@ Deno.serve(async (req) => {
     }
 
     const body = await req.json();
-    const { action, authorId, profileName, slug } = body as {
+    const { action, authorId, profileName, slug, displayName, bio, field, value } = body as {
       action?: string; authorId?: string; profileName?: string; slug?: string;
+      displayName?: string; bio?: string; field?: string; value?: string;
     };
     if (!authorId) return json({ error: "authorId is required" }, 400);
+
+    // --- Owner self-service correction (requires an existing verified claim) ---
+    if (action === "correct") {
+      const { data: claim } = await supabase
+        .from("claimed_profiles")
+        .select("id")
+        .eq("user_id", user.id).eq("author_id", authorId).eq("verified", true)
+        .maybeSingle();
+      if (!claim) return json({ error: "You can only correct a profile you have verified as yours." }, 403);
+
+      const allowed = ["affiliation", "display_name"];
+      if (!field || !allowed.includes(field)) return json({ error: "Unsupported field" }, 400);
+      const text = (value ?? "").trim();
+      if (!text || text.length > 300) return json({ error: "Provide a value (max 300 chars)" }, 400);
+
+      // Deactivate any prior self-correction for this field, then insert the new one.
+      await supabase.from("profile_overrides").update({ active: false })
+        .eq("author_id", authorId).eq("field", field).eq("created_by", user.id);
+      const { error: ovErr } = await supabase.from("profile_overrides").insert({
+        author_id: authorId, field, value: text, verified_via: "orcid", created_by: user.id, active: true,
+      });
+      if (ovErr) return json({ error: ovErr.message }, 400);
+      return json({ ok: true });
+    }
 
     // --- Verify ownership via ORCID -------------------------------------------
     let verified = false;
@@ -147,6 +172,8 @@ Deno.serve(async (req) => {
         verified_via: "orcid",
       };
       if (slug) row.slug = slug;
+      if (displayName) row.display_name = displayName;
+      if (bio) row.bio = bio;
       const { error: upErr } = await supabase.from("claimed_profiles").upsert(row, { onConflict: "user_id" });
       if (upErr) return json({ error: upErr.message }, 400);
       return json({ verified: true, claimed: true });


### PR DESCRIPTION
Backend core for **ORCID-controlled profile claiming**, closing the hole where any signed-in user can claim any profile. **Draft — not deployed, not wired in.** Needs your ORCID login to test end-to-end before shipping.

## What this stage adds
- New `claim-profile` edge function. A signed-in user must prove they own a profile via their linked ORCID iD:
  - **OpenAlex profiles** — compare the author's ORCID (OpenAlex exposes it) to the user's `user_metadata.orcid_id`.
  - **Google Scholar profiles** (no ORCID) — resolve the user's ORCID to its OpenAlex author record and require a display-name match.
  - Unverifiable → not self-claimable here (falls back to admin review, per the agreed approach).
  - Requires an account **and** a linked ORCID.
- `claimed_profiles` gains `verified` / `orcid` / `verified_via` columns (applied; documented in `supabase/claimed_profiles.sql`).

## Verified against real data
- OpenAlex path: author ORCID normalizes and matches the user's ✓
- GS path: user ORCID → OpenAlex author "Jillian J. Turanovic" → name-match ✓

## NOT done yet (stage 2)
- Frontend: rewire `ClaimProfileModal` to call this function; show verify/claim states.
- ORCID-verified **self-service corrections** for owners (write `profile_overrides` with `verified_via='orcid'` via an edge function that checks the verified claim).
- **Security tightening:** drop the public INSERT policy on `claimed_profiles` once claiming goes through the function (kept for now so current claiming isn't broken).
- Deploy `claim-profile` with `--no-verify-jwt`.

## Testing note
I can't simulate an ORCID-authenticated session, so the auth flow needs your hands to verify. That's why this is a draft and not auto-deployed.