### PR TITLE
Redirect www → non-www (fixes ORCID sign-in session split)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -32,6 +32,15 @@
   to = "/.netlify/functions/orcid-callback"
   status = 200
 
+# Canonicalize www → non-www. Auth (incl. the ORCID magic-link round-trip) and
+# the session live per-origin; serving both www and non-www split the session
+# and silently signed ORCID users out. Force a 301 to the non-www canonical host.
+[[redirects]]
+  from = "https://www.scholarfolio.org/*"
+  to = "https://scholarfolio.org/:splat"
+  status = 301
+  force = true
+
 # Sitemap redirect must come before the SPA catch-all
 [[redirects]]
   from = "/sitemap.xml"

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,3 @@
+https://www.scholarfolio.org/*  https://scholarfolio.org/:splat  301!
 /sitemap.xml  /.netlify/functions/sitemap  200!
 /*    /index.html   200

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -350,8 +350,10 @@ function AppContent() {
       setData({ ...sanitizedData, fieldMetricsLoading: true });
       trackEvent('search', { author_id: userId, cache: profileData.cacheStatus, bypass: bypassCredits });
 
-      // Fetch Open Access stats from OpenAlex (non-blocking)
-      openAlexService.fetchOpenAccessStats(sourceName, sourceAffiliation)
+      // Fetch Open Access stats from OpenAlex (non-blocking). Pass the real
+      // publication titles so OA stats exclude works misattributed to a
+      // same-named author by OpenAlex disambiguation.
+      openAlexService.fetchOpenAccessStats(sourceName, sourceAffiliation, sanitizedData.publications.map(p => p.title))
         .then(oaStats => {
           if (oaStats) {
             setData(prev => prev ? { ...prev, openAccess: oaStats } : prev);

--- a/src/services/openalex/index.ts
+++ b/src/services/openalex/index.ts
@@ -9,13 +9,23 @@ export class OpenAlexService {
    * Search OpenAlex for an author by name + affiliation, return OA stats.
    * Non-blocking — returns null on any failure.
    */
-  public async fetchOpenAccessStats(name: string, affiliation: string): Promise<OpenAccessStats | null> {
+  public async fetchOpenAccessStats(name: string, affiliation: string, publicationTitles?: string[]): Promise<OpenAccessStats | null> {
     try {
       // Use shared author lookup (cached across services)
       const author = await findOpenAlexAuthor(name, affiliation);
       if (!author) return null;
       const authorId = author.id;
       const shortId = authorId.replace('https://openalex.org/', '');
+
+      // When the profile's real publication list is provided, restrict OA stats
+      // to works whose title matches it. OpenAlex author disambiguation can merge
+      // a different same-named person's works (e.g. an unrelated book) into the
+      // record; without this filter those show up in the totals and the
+      // repository breakdown. Keyed on the same alphanumeric normalization used
+      // for publicationOa below.
+      const titleFilter = publicationTitles && publicationTitles.length
+        ? new Set(publicationTitles.map(t => (t || '').toLowerCase().replace(/[^a-z0-9]/g, '')).filter(Boolean))
+        : null;
 
       // Kick off the (multi-page) shared works fetch immediately so it runs
       // concurrently with the cheap group_by request below. Also consumed by
@@ -55,13 +65,19 @@ export class OpenAlexService {
       const repositoryCounts: Record<string, number> = {};
       let preprintCount = 0;
 
+      // Filtered OA-status tallies (used instead of the group_by totals when a
+      // publication list is supplied, so misattributed works don't count).
+      let fTotal = 0, fGold = 0, fGreen = 0, fHybrid = 0, fBronze = 0, fClosed = 0;
+
       const works = await worksPromise;
       for (const work of works) {
         if (!work.title) continue;
         const normalizedTitle = work.title.toLowerCase().replace(/[^a-z0-9]/g, '');
-        const status: OaStatus = work.open_access?.oa_status === 'diamond'
+        if (titleFilter && !titleFilter.has(normalizedTitle)) continue; // skip misattributed works
+        const rawStatus = work.open_access?.oa_status;
+        const status: OaStatus = rawStatus === 'diamond'
           ? 'gold'
-          : ((work.open_access?.oa_status as OaStatus) || 'closed');
+          : ((rawStatus as OaStatus) || 'closed');
         publicationOa[normalizedTitle] = {
           status,
           oaUrl: work.open_access?.oa_url || undefined,
@@ -80,17 +96,35 @@ export class OpenAlexService {
           const repoName = boa.source.display_name;
           repositoryCounts[repoName] = (repositoryCounts[repoName] || 0) + 1;
         }
+        // Tally OA buckets for the filtered total.
+        fTotal++;
+        if (rawStatus === 'gold' || rawStatus === 'diamond') fGold++;
+        else if (rawStatus === 'green') fGreen++;
+        else if (rawStatus === 'hybrid') fHybrid++;
+        else if (rawStatus === 'bronze') fBronze++;
+        else fClosed++;
       }
 
+      // When filtering, report the counts recomputed from the matched works so
+      // the headline totals and % exclude misattributed records.
+      const useFiltered = !!titleFilter && fTotal > 0;
+      const oTotal = useFiltered ? fTotal : total;
+      const oGold = useFiltered ? fGold : gold;
+      const oGreen = useFiltered ? fGreen : green;
+      const oHybrid = useFiltered ? fHybrid : hybrid;
+      const oBronze = useFiltered ? fBronze : bronze;
+      const oClosed = useFiltered ? fClosed : closed;
+      const oOa = oGold + oGreen + oHybrid + oBronze;
+
       return {
-        total,
-        oa,
-        gold,
-        green,
-        hybrid,
-        bronze,
-        closed,
-        oaPercent: Math.round((oa / total) * 100),
+        total: oTotal,
+        oa: oOa,
+        gold: oGold,
+        green: oGreen,
+        hybrid: oHybrid,
+        bronze: oBronze,
+        closed: oClosed,
+        oaPercent: oTotal > 0 ? Math.round((oOa / oTotal) * 100) : 0,
         orcid,
         publicationOa,
         doiMap,

--- a/src/services/scholar/index.ts
+++ b/src/services/scholar/index.ts
@@ -147,50 +147,90 @@ function stripTitleSuffix(name: string): string {
   return name.replace(/\s*[-–—]\s*(Full|Associate|Assistant|Emeritus|Adjunct|Visiting|Research|Senior|Junior|Distinguished|Clinical|Tenured)?\s*(Professor|Lecturer|Fellow|Director|Dean|Chair|Researcher|Scientist|Engineer|Doctor|PhD|Dr|MD|Instructor|Postdoc|PostDoc)\b.*/i, '').trim() || name;
 }
 
-/** Normalized title key for exact-duplicate detection. */
+/** Normalized title key (lowercase, alphanumeric words). */
 function normalizeTitleKey(title: string): string {
   return (title || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
 }
 
+/** Journal/venue reduced to its alphabetic words, dropping volume/issue/page
+ *  noise (e.g. "Journal of Service Research 26 (1), 3-20, 2023" → "journal of
+ *  service research"). Used to confirm two title-variants are the same outlet. */
+function normalizeVenueKey(venue: string): string {
+  return (venue || '').toLowerCase().replace(/[^a-z]+/g, ' ').trim();
+}
+
+/** Extract a bare DOI from a work URL, if present. */
+function extractDoi(url: string): string {
+  const m = (url || '').toLowerCase().match(/doi\.org\/(10\.\S+)/);
+  return m ? m[1] : '';
+}
+
+interface DedupeEntry { pub: Publication; nt: string; doi: string; venue: string; }
+
+/** Is `a` a duplicate of already-kept `b`? Three tiers, each strictly guarded so
+ *  genuinely distinct works are never merged. */
+function isDuplicatePub(a: DedupeEntry, b: DedupeEntry): boolean {
+  if (!a.nt || !b.nt) return false;
+  // 1. Exact: same normalized title + same year.
+  if (a.nt === b.nt && (a.pub.year || 0) === (b.pub.year || 0)) return true;
+  // 2. Same DOI ⇒ same work (independent of title/year formatting).
+  if (a.doi && a.doi === b.doi) return true;
+  // 3. Version / early-access: one title is a clean prefix of the other, in the
+  //    same venue, within a few years (final vs online-first of one article).
+  //    Guarded by a length floor so generic prefixes ("Introduction") never match.
+  if (a.venue && a.venue === b.venue && Math.abs((a.pub.year || 0) - (b.pub.year || 0)) <= 3) {
+    const [short, long] = a.nt.length <= b.nt.length ? [a.nt, b.nt] : [b.nt, a.nt];
+    if (short.length >= 20 && (long === short || long.startsWith(short + ' '))) return true;
+  }
+  return false;
+}
+
+/** Prefer the richer record when merging duplicates: more citations, then the
+ *  longer (usually final/complete) title, then the later year. */
+function betterPub(a: Publication, b: Publication): Publication {
+  if ((a.citations || 0) !== (b.citations || 0)) return (a.citations || 0) > (b.citations || 0) ? a : b;
+  if ((a.title || '').length !== (b.title || '').length) return (a.title || '').length > (b.title || '').length ? a : b;
+  return (a.year || 0) >= (b.year || 0) ? a : b;
+}
+
 /**
- * Remove exact-duplicate publication records: same normalized title AND same
- * year. These come from sources indexing one work twice (e.g. a preprint and
- * the published version, or a double-listed record) and inflate publication and
- * citation counts. Deliberately keyed on title+year, NOT title alone — collapsing
- * same-title-different-year works would wrongly merge genuinely distinct outputs
- * (e.g. two different "Introduction" book chapters, or revised editions). When a
- * duplicate is found, the record with more citations (then more authors) is kept.
+ * Collapse duplicate publication records so every downstream surface (narrative
+ * counts, publication list, metrics, co-author stats, OA-tab title matching, CV
+ * export) sees one canonical entry per work. Runs once here, the single assembly
+ * point for both Google Scholar and OpenAlex profiles. Tiers: exact title+year,
+ * same DOI, and version/early-access (same-venue title-prefix). See isDuplicatePub
+ * for the guards that prevent merging genuinely distinct works.
  */
-function dedupeExactPublications(pubs: Publication[]): Publication[] {
-  const byKey = new Map<string, Publication>();
-  const out: Publication[] = [];
+function dedupePublications(pubs: Publication[]): Publication[] {
+  const kept: DedupeEntry[] = [];
   for (const pub of pubs) {
-    const nt = normalizeTitleKey(pub.title);
-    if (!nt) { out.push(pub); continue; } // no title — can't safely dedupe
-    const key = `${nt}|${pub.year || 0}`;
-    const existing = byKey.get(key);
-    if (!existing) {
-      byKey.set(key, pub);
-      out.push(pub);
+    const entry: DedupeEntry = {
+      pub,
+      nt: normalizeTitleKey(pub.title),
+      doi: extractDoi(pub.url),
+      venue: normalizeVenueKey(pub.venue),
+    };
+    if (!entry.nt) { kept.push(entry); continue; } // no title — can't safely dedupe
+    const dupIdx = kept.findIndex(k => isDuplicatePub(entry, k));
+    if (dupIdx === -1) {
+      kept.push(entry);
     } else {
-      const better =
-        (pub.citations || 0) > (existing.citations || 0) ||
-        ((pub.citations || 0) === (existing.citations || 0) &&
-          (pub.authors?.length || 0) > (existing.authors?.length || 0));
-      if (better) {
-        const idx = out.indexOf(existing);
-        if (idx >= 0) out[idx] = pub;
-        byKey.set(key, pub);
-      }
+      const winner = betterPub(kept[dupIdx].pub, pub);
+      kept[dupIdx] = {
+        pub: winner,
+        nt: normalizeTitleKey(winner.title),
+        doi: extractDoi(winner.url) || kept[dupIdx].doi,
+        venue: normalizeVenueKey(winner.venue) || kept[dupIdx].venue,
+      };
     }
   }
-  return out;
+  return kept.map(k => k.pub);
 }
 
 export function buildAuthorResult(data: any): Author {
   const cleanName = stripTitleSuffix(data.name || '');
 
-  const publications = dedupeExactPublications(
+  const publications = dedupePublications(
     (data.publications || []).map(pub => ({
       ...pub,
       journalRanking: pub.journalRanking || findJournalRanking(pub.venue)


### PR DESCRIPTION
The site served on both www and non-www with no canonical redirect. Sessions + the ORCID magic-link CSRF state are per-origin, so signing in via ORCID (which returns to the non-www callback) while on **www** left www anonymous — 'Sign in', no credits, and a state-mismatch sign-out. Confirmed in auth logs (bad-JWT + logout from www.scholarfolio.org). Forces a 301 www→non-www in netlify.toml + _redirects.