### PR TITLE
Route /api/orcid-callback to its function (fixes ORCID login)

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,4 @@
 https://www.scholarfolio.org/*  https://scholarfolio.org/:splat  301!
+/api/orcid-callback  /.netlify/functions/orcid-callback  200!
 /sitemap.xml  /.netlify/functions/sitemap  200!
 /*    /index.html   200


### PR DESCRIPTION
**Root cause of ORCID login silently doing nothing.** `public/_redirects` (applied before netlify.toml) had `/* → /index.html` but no `/api/orcid-callback` rule, so the OAuth callback rendered the SPA instead of running the Netlify function — auth code never exchanged, no session created (callback URL showed the landing page; zero magic-link events in auth logs). Adds the function route before the catch-all.