### PR TITLE
Make Privacy/Terms pages crawlable at real URLs (compliance discoverability)

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,19 @@
   </head>
   <body>
     <div id="root"></div>
+    <!-- Static, crawlable links to legal/info pages. ScholarFolio is a SPA, so
+         these ensure the policy pages are discoverable by crawlers and
+         compliance scanners that don't execute JavaScript. -->
+    <noscript>
+      <div style="max-width:640px;margin:2rem auto;padding:1rem;font-family:system-ui,-apple-system,sans-serif;line-height:1.6;">
+        <p>ScholarFolio needs JavaScript enabled to run. Legal and information pages:</p>
+        <ul>
+          <li><a href="/privacy">Privacy Policy</a> — how we collect, use, and protect your data (GDPR rights, cookies, first-party analytics)</li>
+          <li><a href="/terms">Terms of Service</a></li>
+          <li><a href="/about">About</a> · <a href="/changelog">Changelog</a></li>
+        </ul>
+      </div>
+    </noscript>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,4 @@
 https://www.scholarfolio.org/*  https://scholarfolio.org/:splat  301!
+/api/orcid-callback  /.netlify/functions/orcid-callback  200!
 /sitemap.xml  /.netlify/functions/sitemap  200!
 /*    /index.html   200

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,30 +79,34 @@ function Footer({ onNavigate, onSupport }: { onNavigate: (page: Page) => void; o
           >
             GitHub <ExternalLink className="h-3 w-3" />
           </a>
-          <button
-            onClick={() => onNavigate('about')}
+          <a
+            href="/about"
+            onClick={(e) => { e.preventDefault(); onNavigate('about'); }}
             className="text-sm text-[#3d9494] hover:text-white transition-colors"
           >
             About
-          </button>
-          <button
-            onClick={() => onNavigate('terms')}
+          </a>
+          <a
+            href="/terms"
+            onClick={(e) => { e.preventDefault(); onNavigate('terms'); }}
             className="text-sm text-[#3d9494] hover:text-white transition-colors"
           >
             Terms
-          </button>
-          <button
-            onClick={() => onNavigate('privacy')}
+          </a>
+          <a
+            href="/privacy"
+            onClick={(e) => { e.preventDefault(); onNavigate('privacy'); }}
             className="text-sm text-[#3d9494] hover:text-white transition-colors"
           >
             Privacy
-          </button>
-          <button
-            onClick={() => onNavigate('changelog')}
+          </a>
+          <a
+            href="/changelog"
+            onClick={(e) => { e.preventDefault(); onNavigate('changelog'); }}
             className="text-sm text-[#3d9494] hover:text-white transition-colors"
           >
             Changelog
-          </button>
+          </a>
           <a
             href="mailto:info@scholarfolio.org"
             className="text-sm text-[#3d9494] hover:text-white transition-colors"
@@ -163,8 +167,17 @@ function AppContent() {
       setPage('admin');
       return;
     }
-    if (params.get('page') === 'trending') {
-      setPage('trending');
+    // Deep-linkable content pages, reachable at both /privacy and ?page=privacy
+    // so they're crawlable/indexable (and can't be shadowed by a vanity slug,
+    // which is why this runs before the slug lookup below).
+    const PAGE_ROUTES: Page[] = ['about', 'terms', 'privacy', 'changelog', 'trending'];
+    const pageParam = params.get('page');
+    const pathName = window.location.pathname.replace(/^\//, '').replace(/\/$/, '').toLowerCase();
+    const routed = (pageParam && (PAGE_ROUTES as string[]).includes(pageParam))
+      ? pageParam
+      : ((PAGE_ROUTES as string[]).includes(pathName) ? pathName : null);
+    if (routed) {
+      setPage(routed as Page);
       return;
     }
     // Handle ORCID OAuth error
@@ -218,6 +231,17 @@ function AppContent() {
         .catch((err: unknown) => logCaughtError(err, 'navigation', 'App', 'load-vanity-slug', { pathSlug }));
     }
   }, [initialUrlHandled]);
+
+  // Keep the page in sync with browser back/forward for the content-page routes.
+  useEffect(() => {
+    const onPop = () => {
+      const p = window.location.pathname.replace(/^\//, '').replace(/\/$/, '').toLowerCase();
+      const PAGE_ROUTES: Page[] = ['about', 'terms', 'privacy', 'changelog', 'trending'];
+      setPage((PAGE_ROUTES as string[]).includes(p) ? (p as Page) : 'home');
+    };
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, []);
 
   // Handle payment success redirect
   useEffect(() => {
@@ -455,6 +479,12 @@ function AppContent() {
   const handleNavigate = useCallback((newPage: Page) => {
     setPage(newPage);
     window.scrollTo(0, 0);
+    // Reflect the page in the URL so content pages are shareable + deep-linkable.
+    const PATH_PAGES: Page[] = ['about', 'terms', 'privacy', 'changelog', 'trending'];
+    const path = newPage === 'home' ? '/' : (PATH_PAGES.includes(newPage) ? `/${newPage}` : window.location.pathname);
+    if (path !== window.location.pathname) {
+      window.history.pushState({}, '', path);
+    }
   }, []);
 
   const authControls = (


### PR DESCRIPTION
The Privacy Policy and Terms **already exist** (thorough — GDPR rights, cookies, first-party analytics) but were only reachable by clicking the footer (client state). So `/privacy` and `/terms` 404'd on direct load, weren't indexable by Google, and weren't detected by compliance scanners (which see only the SPA shell — this is why a scanner falsely reported 'no policy detected').

- `/privacy`, `/terms`, `/about`, `/changelog` (and `?page=<x>`) now route to their pages on load, **before** the vanity-slug lookup (so a slug can't shadow them).
- Footer links are real `<a href>` anchors; navigation updates the URL (pushState) + syncs on back/forward.
- Static crawlable links to the policy pages added to index.html (`<noscript>`) so non-JS crawlers/scanners discover them.

No new policy content — the site was already compliant; this fixes **discoverability**.