### PR TITLE
chore: add CI workflow (lint, typecheck, test, build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Lint, Typecheck, Test, Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      # `npm run build` is `tsc && vite build`; there is no separate typecheck
+      # script, so tsc (run as part of the build step below) is the typecheck gate.
+
+      - name: Test
+        run: npm run test
+
+      - name: Build (tsc + vite build)
+        run: npm run build
+        env:
+          # Public anon values only. Real values live in Netlify; these
+          # build-safe dummies keep the bundle from throwing if the Supabase
+          # client is ever evaluated during build. NEVER put real secrets here.
+          VITE_SUPABASE_URL: https://example.supabase.co
+          VITE_SUPABASE_ANON_KEY: dummy-anon-key-for-ci-build


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` running the repo's existing local gates on push and PR to `main`.

## Pipeline (in order)
1. `npm ci`
2. `npm run lint` (eslint `--max-warnings 0`)
3. `npm run test` (vitest run, non-watch)
4. `npm run build` (`tsc && vite build` — tsc is the typecheck gate; no separate typecheck script exists)

## Notes
- `actions/checkout@v4`, `actions/setup-node@v4` (node 20, npm cache).
- Build step sets build-safe **dummy** `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` (public anon-tier vars only). No real secrets. Real values remain in Netlify.
- Only one new file added. No changes to Supabase config, edge functions, netlify.toml, or the existing `deploy-edge-functions.yml` workflow.