### PR TITLE
Modernize design tokens (v1.1 foundation)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,14 @@
   --muted: #94a3b8;
   --gradient-start: #2d7d7d;
   --gradient-end: #1f5c5c;
+  --teal-faint-hover: #d5ecec;
+  /* Status tokens (v1.1) */
+  --success: #059669;
+  --success-bg: #ecfdf5;
+  --warning: #b45309;
+  --warning-bg: #fef3c7;
+  --orcid: #a6ce39;
+  --orcid-bg: #f3f9e8;
 }
 
 body {
@@ -152,6 +160,19 @@ body {
 .btn-lift:hover {
   transform: translateY(-2px);
   box-shadow: 0 4px 12px -2px rgba(45, 125, 125, 0.3);
+}
+
+/* Translucent sticky nav / header (v1.1) — frosted warm glass over the mesh bg */
+.nav-glass {
+  background-color: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(229, 231, 235, 0.6);
+}
+
+.dark .nav-glass {
+  background-color: rgba(15, 23, 42, 0.6);
+  border-bottom-color: rgba(51, 65, 85, 0.6);
 }
 
 /* Nav link underline animation */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,11 @@ export default {
         sans: ['"DM Sans"', 'system-ui', '-apple-system', 'sans-serif'],
         serif: ['"Playfair Display"', 'Georgia', 'serif'],
       },
+      // Design-system v1.1 type scale — small text nudged up for a lighter, airier feel.
+      fontSize: {
+        xs: ['13px', '18px'],   // v1.1: was 12px/16px
+        sm: ['15px', '22px'],   // v1.1: was 14px/20px
+      },
       colors: {
         primary: {
           start: '#2d7d7d',
@@ -31,6 +36,7 @@ export default {
           DEFAULT: '#2d7d7d',
           light: '#3d9494',
           faint: '#eaf4f4',
+          'faint-hover': '#d5ecec',
         },
         muted: '#94a3b8',
         surface: {
@@ -38,25 +44,33 @@ export default {
           100: '#f1f5f9',
           200: '#e2e8f0',
         },
-        // Semantic category colors (muted, academic tone)
+        // Status colors — verified marks, beta tags, ORCID links.
+        success: { DEFAULT: '#059669', bg: '#ecfdf5' },
+        warning: { DEFAULT: '#b45309', bg: '#fef3c7' },
+        orcid: { DEFAULT: '#a6ce39', bg: '#f3f9e8' },
+        // Semantic category colors (muted, academic tone) + soft tinted backgrounds.
         cat: {
-          impact: { from: '#b08d57', to: '#8b6f47' },       // warm amber/gold
-          collab: { from: '#2d7d7d', to: '#1f5c5c' },       // teal (brand)
-          trend: { from: '#4a6fa5', to: '#3a5a8a' },         // slate blue
-          field: { from: '#6b5b8a', to: '#554870' },         // muted indigo
-          oa: { from: '#4a8c6f', to: '#3a7059' },            // sage green
+          impact: { from: '#b08d57', to: '#8b6f47', bg: '#faf6ef' },  // warm amber/gold
+          collab: { from: '#2d7d7d', to: '#1f5c5c', bg: '#eaf4f4' },  // teal (brand)
+          trend: { from: '#4a6fa5', to: '#3a5a8a', bg: '#eef3fa' },    // slate blue
+          field: { from: '#6b5b8a', to: '#554870', bg: '#f3f0f8' },    // muted indigo
+          oa: { from: '#4a8c6f', to: '#3a7059', bg: '#eef7f2' },       // sage green
         },
       },
       backgroundImage: {
         'gradient-primary': 'linear-gradient(135deg, #2d7d7d, #1f5c5c)',
       },
+      // Design-system v1.1 radii — softened for a more modern, rounded surface language.
       borderRadius: {
-        '2xl': '16px',
+        lg: '10px',      // v1.1: was 8px — buttons, inputs, dropdowns
+        xl: '14px',      // v1.1: was 12px — metric cards, banners
+        '2xl': '18px',   // v1.1: was 16px — summary cards, feature cards, modals
       },
       boxShadow: {
-        'card': '0 1px 3px 0 rgb(0 0 0 / 0.04), 0 1px 2px -1px rgb(0 0 0 / 0.04)',
+        'card': '0 1px 3px 0 rgb(0 0 0 / 0.05), 0 1px 2px -1px rgb(0 0 0 / 0.05)',
         'card-hover': '0 4px 6px -1px rgb(0 0 0 / 0.06), 0 2px 4px -2px rgb(0 0 0 / 0.04)',
         'elevated': '0 10px 25px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.04)',
+        'btn-lift': '0 4px 12px -2px rgba(45, 125, 125, 0.3)',
       },
     },
   },


### PR DESCRIPTION
First of a staged front-end modernization, implementing the **ScholarFolio Design System v1.1** (claude.ai/design). This PR is the token foundation — the following PRs build on it (landing page, then profile/components).

## What changed
`tailwind.config.js` + `src/index.css` only:
- **Radii up:** `rounded-lg` 8→10px, `rounded-xl` 12→14px, `rounded-2xl` 16→18px
- **Type up:** `text-xs` 12→13px, `text-sm` 14→15px (with matching line-heights)
- **New semantic tokens:** category `-bg` tints (`cat-impact-bg`, …), `success`/`warning`/`orcid` status colors + bg, `teal-faint-hover`
- **`.nav-glass`** frosted translucent sticky-nav helper (light + dark)
- Card shadow alpha 0.04→0.05

## Why token-level
The app uses these utilities ~660 times (172 `rounded-lg`, 413 `text-xs`/`text-sm`, etc.). Overriding the scale values shifts the whole app to the refined look consistently, with no per-component edits.

## Rollout
Staged per the one-change-per-deploy rule. Left as **draft for a visual eyeball** before merge (no visual test infra). Build passes (`npm run build`).