### PR TITLE
Tighten anonymous free tier: 2 searches, cache hits count

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -260,7 +260,7 @@ function AppContent() {
     localStorage.setItem('sf_searches', String(count));
     return count;
   };
-  const ANON_FREE_LIMIT = 5;
+  const ANON_FREE_LIMIT = 2;
 
   /** Re-key S2 enrichment results to PublicationsList normalization and update state */
   const applyS2Data = (s2Result: Awaited<ReturnType<typeof enrichWithSemanticScholar>>, pubs: Array<{ title: string }>) => {
@@ -354,9 +354,9 @@ function AppContent() {
       // Track usage (skip for direct profile links and OpenAlex fallbacks)
       if (!bypassCredits && !isOpenAlex) {
         if (!user) {
-          if (profileData.cacheStatus !== 'hit') {
-            incrementAnonSearches();
-          }
+          // Cache hits count too — the free limit meters value delivered to the
+          // visitor, not upstream fetch cost.
+          incrementAnonSearches();
         } else {
           refreshCredits();
         }

--- a/src/components/AboutPage.tsx
+++ b/src/components/AboutPage.tsx
@@ -161,9 +161,9 @@ export function AboutPage({ onBack, socialLinks, authControls }: AboutPageProps)
             <h2 className="font-serif text-2xl font-bold text-[#1e293b] mb-6">Pricing</h2>
 
             <p className="mb-4">
-              You get 5 free searches without signing up, and 5 more when you create an account (which is also free).
-              If a profile was already searched by someone else in the last 7 days, viewing it costs nothing: the
-              cached version loads for free.
+              You get 2 free searches without signing up, and 5 more when you create an account (which is also free).
+              For signed-in users, viewing a profile that was already searched by someone else in the last 7 days
+              costs nothing: the cached version loads without using a credit.
             </p>
 
             <p className="mb-4">After that, there are two supporter packs:</p>

--- a/src/components/AuthHeaderControls.tsx
+++ b/src/components/AuthHeaderControls.tsx
@@ -13,7 +13,7 @@ interface AuthHeaderControlsProps {
   anonFreeLimit?: number;
 }
 
-export function AuthHeaderControls({ onBuyCredits, onAdmin, anonSearchesUsed = 0, anonFreeLimit = 3 }: AuthHeaderControlsProps) {
+export function AuthHeaderControls({ onBuyCredits, onAdmin, anonSearchesUsed = 0, anonFreeLimit = 2 }: AuthHeaderControlsProps) {
   const { user, credits, signOut } = useAuth();
   const isAdmin = user?.email === ADMIN_EMAIL;
   const [unresolvedCount, setUnresolvedCount] = useState(0);


### PR DESCRIPTION
## Why
Funnel data (last 30d): only 3.2% of searching sessions ever hit a wall, but 79% of sessions that hit one signed up. The free anonymous tier absorbs nearly all demand — this is the highest-leverage conversion change available.

## Changes
- `ANON_FREE_LIMIT` 5 → 2 (`src/App.tsx`)
- Anonymous cache hits now count toward the limit — previously cached profile views were unmetered, which is why most sessions never reached the wall. The limit meters value delivered to the visitor, not upstream fetch cost.
- Direct/shared profile links (`bypassCredits`), vanity slugs, and OpenAlex fallback profiles remain free — shared profiles are our organic distribution and must never be walled.
- Copy updated (AboutPage pricing, stale `anonFreeLimit=3` default in AuthHeaderControls). Signed-in signup grant (5 credits) and server IP backstop (5/day) unchanged.

## Notes
- Anonymous visitors with an existing `sf_searches` count ≥ 2 will see the wall on their next search — intended.
- No edge function changes; no redeploy needed.