### PR TITLE
Add canonical /scholar/<id> profile URLs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -26,6 +26,11 @@
   path = "/"
   function = "og-meta"
 
+# Canonical profile paths (/scholar/<id>) need the same crawler OG injection
+[[edge_functions]]
+  path = "/scholar/*"
+  function = "og-meta"
+
 # ORCID OAuth callback
 [[redirects]]
   from = "/api/orcid-callback"

--- a/netlify/edge-functions/og-meta.ts
+++ b/netlify/edge-functions/og-meta.ts
@@ -69,7 +69,7 @@ function buildOgTags(data: ScholarData, userId: string): string {
   }
 
   const image = data.imageUrl || DEFAULT_IMAGE;
-  const url = `https://scholarfolio.org/?user=${userId}`;
+  const url = `https://scholarfolio.org/scholar/${encodeURIComponent(userId)}`;
 
   return `
     <meta property="og:title" content="${escapeAttr(title)}" />
@@ -103,7 +103,17 @@ function injectOgTags(html: string, tags: string): string {
 
 export default async function handler(req: Request, context: Context): Promise<Response> {
   const url = new URL(req.url);
-  const userId = url.searchParams.get('user');
+  // Profile id from either the canonical path (/scholar/<id>) or the legacy
+  // query form (?user=<id>) still present in previously shared links.
+  let userId: string | null = url.searchParams.get('user');
+  const pathMatch = url.pathname.match(/^\/scholar\/([^/]+)\/?$/);
+  if (pathMatch) {
+    try {
+      userId = decodeURIComponent(pathMatch[1]);
+    } catch {
+      userId = null; // malformed percent-encoding — serve the plain shell
+    }
+  }
   const userAgent = req.headers.get('user-agent') || '';
 
   // Pass through non-crawler requests immediately

--- a/netlify/functions/sitemap.ts
+++ b/netlify/functions/sitemap.ts
@@ -8,8 +8,11 @@ const supabaseAnonKey = 'sb_publishable_oKej73idzSJ1eJqwmgF5WQ_m2rvKae5';
 const handler: Handler = async () => {
   const staticPages = [
     { loc: 'https://scholarfolio.org/', changefreq: 'weekly', priority: '1.0' },
-    { loc: 'https://scholarfolio.org/?page=changelog', changefreq: 'weekly', priority: '0.5' },
-    { loc: 'https://scholarfolio.org/?page=privacy', changefreq: 'monthly', priority: '0.3' },
+    { loc: 'https://scholarfolio.org/about', changefreq: 'monthly', priority: '0.6' },
+    { loc: 'https://scholarfolio.org/trending', changefreq: 'daily', priority: '0.6' },
+    { loc: 'https://scholarfolio.org/changelog', changefreq: 'weekly', priority: '0.5' },
+    { loc: 'https://scholarfolio.org/privacy', changefreq: 'monthly', priority: '0.3' },
+    { loc: 'https://scholarfolio.org/terms', changefreq: 'monthly', priority: '0.3' },
   ];
 
   // Fetch claimed profiles from Supabase

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -214,6 +214,25 @@ function AppContent() {
       return;
     }
 
+    // Real profile path (/scholar/<id>), the canonical shareable form.
+    // Checked before the vanity-slug lookup; a slug can never contain "/".
+    const scholarPathMatch = window.location.pathname.match(/^\/scholar\/([^/]+)\/?$/);
+    if (scholarPathMatch && handleSearchRef.current) {
+      let pathId: string;
+      try {
+        pathId = decodeURIComponent(scholarPathMatch[1]);
+      } catch {
+        return; // malformed percent-encoding in a mangled link — treat as not found
+      }
+      if (pathId.startsWith(OPENALEX_ID_PREFIX)) {
+        handleSearchRef.current(pathId, true);
+      } else {
+        const scholarUrl = `https://scholar.google.com/citations?user=${encodeURIComponent(pathId)}`;
+        handleSearchRef.current(scholarUrl, true);
+      }
+      return;
+    }
+
     // Check for vanity slug in the path (e.g. /jonas-heller)
     const pathSlug = window.location.pathname.replace(/^\//, '').replace(/\/$/, '');
     if (pathSlug && /^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$/.test(pathSlug)) {
@@ -435,7 +454,7 @@ function AppContent() {
       const pathSlug = window.location.pathname.replace(/^\//, '').replace(/\/$/, '');
       const isVanityUrl = pathSlug && /^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$/.test(pathSlug);
       if (!isVanityUrl && userId) {
-        window.history.replaceState({}, '', `?user=${encodeURIComponent(userId)}`);
+        window.history.replaceState({}, '', `/scholar/${encodeURIComponent(userId)}`);
       }
     } catch (err) {
       let errorMessage: string;
@@ -473,7 +492,7 @@ function AppContent() {
     requestInProgressRef.current = false;
     setShowError(false);
     setPage('home');
-    window.history.replaceState({}, '', window.location.pathname);
+    window.history.replaceState({}, '', '/');
   }, []);
 
   const handleNavigate = useCallback((newPage: Page) => {

--- a/src/components/ClaimProfileModal.tsx
+++ b/src/components/ClaimProfileModal.tsx
@@ -19,8 +19,11 @@ function nameToSlug(name: string): string {
     .slice(0, 40);
 }
 
+// Path segments the router owns — a vanity slug must never occupy them.
+const RESERVED_SLUGS = ['scholar', 'about', 'terms', 'privacy', 'changelog', 'trending', 'admin', 'api', 'sitemap'];
+
 function isValidSlug(slug: string): boolean {
-  return /^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$/.test(slug);
+  return /^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$/.test(slug) && !RESERVED_SLUGS.includes(slug);
 }
 
 type SlugStatus = 'idle' | 'checking' | 'available' | 'taken' | 'invalid';

--- a/src/components/CoAuthorMap.tsx
+++ b/src/components/CoAuthorMap.tsx
@@ -624,7 +624,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
                 onClick={async () => {
                   if (scholarIdLookup.loading) return;
                   if (scholarIdLookup.scholarId) {
-                    window.open(`${window.location.origin}/?user=${scholarIdLookup.scholarId}`, '_blank');
+                    window.open(`${window.location.origin}/scholar/${encodeURIComponent(scholarIdLookup.scholarId)}`, '_blank');
                     return;
                   }
                   if (scholarIdLookup.notFound) {
@@ -647,7 +647,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
                     if (cached?.scholar_id) {
                       setScholarIdLookup({ loading: false, scholarId: cached.scholar_id, notFound: false });
                       if (newWindow) {
-                        newWindow.location.href = `${window.location.origin}/?user=${encodeURIComponent(cached.scholar_id)}`;
+                        newWindow.location.href = `${window.location.origin}/scholar/${encodeURIComponent(cached.scholar_id)}`;
                       }
                       return;
                     }
@@ -670,7 +670,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
                       saveCoAuthorLink({ name: searchName, scholarId: match.authorId, openalexId: clickedCoAuthor.openalexId, institution: clickedCoAuthor.institution }).catch(() => {});
                       setScholarIdLookup({ loading: false, scholarId: match.authorId, notFound: false });
                       if (newWindow) {
-                        newWindow.location.href = `${window.location.origin}/?user=${encodeURIComponent(match.authorId)}`;
+                        newWindow.location.href = `${window.location.origin}/scholar/${encodeURIComponent(match.authorId)}`;
                       }
                     } else {
                       setScholarIdLookup({ loading: false, scholarId: null, notFound: true });
@@ -726,7 +726,7 @@ export function CoAuthorMap({ publications, authorName, authorAffiliation, prefe
                         }).catch(() => {});
                         setScholarIdLookup({ loading: false, scholarId, notFound: false });
                         setShowUrlInput(false);
-                        window.open(`${window.location.origin}/?user=${encodeURIComponent(scholarId)}`, '_blank');
+                        window.open(`${window.location.origin}/scholar/${encodeURIComponent(scholarId)}`, '_blank');
                       }}
                       className="flex-1 flex items-center justify-center gap-1.5 py-1.5 text-xs font-medium rounded bg-[#2d7d7d] text-white hover:bg-[#1f5c5c] transition-colors"
                     >

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -173,7 +173,7 @@ export function ProfileView({
     // (openalex:<id>) so link-preview crawlers get a URL that resolves.
     const url = claimedSlug
       ? `https://scholarfolio.org/${claimedSlug}`
-      : `https://scholarfolio.org/?user=${scholarId || rawUserId}`;
+      : `https://scholarfolio.org/scholar/${encodeURIComponent(scholarId || rawUserId)}`;
 
     document.title = title;
 
@@ -703,7 +703,7 @@ export function ProfileView({
               }
               scholarService.searchAuthors(name).then(results => {
                 if (results.length >= 1 && newWindow) {
-                  newWindow.location.href = `${window.location.origin}?user=${encodeURIComponent(results[0].authorId)}`;
+                  newWindow.location.href = `${window.location.origin}/scholar/${encodeURIComponent(results[0].authorId)}`;
                 } else if (newWindow) {
                   newWindow.location.href = `https://scholar.google.com/citations?view_op=search_authors&mauthors=${encodeURIComponent(name)}`;
                 }

--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -912,8 +912,7 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
     try {
       const results = await scholarService.searchAuthors(authorName);
       if (results.length >= 1 && newWindow) {
-        const userId = encodeURIComponent(results[0].authorId);
-        newWindow.location.href = `${window.location.origin}?user=${userId}`;
+        newWindow.location.href = `${window.location.origin}/scholar/${encodeURIComponent(results[0].authorId)}`;
       } else {
         newWindow?.close();
       }


### PR DESCRIPTION
## Why
Shared profiles are ScholarFolio's organic distribution. Real path URLs share better, look better, and are indexable; the OG edge function previously only ran on `/` so path-shared links kept working by accident of the SPA catch-all but had no per-profile previews beyond the query form.

## Changes
- **Routing (`src/App.tsx`):** `/scholar/<id>` is the canonical profile URL (works for Google Scholar IDs and `openalex:` fallback tokens). Legacy `?user=<id>` links keep working. Precedence: content pages → `?user=` → `/scholar/` path → vanity slug; each branch early-returns. After a search the address bar now shows `/scholar/<id>` instead of `?user=`.
- **Crawler previews:** `og-meta` edge function parses both URL forms and is now wired for `/scholar/*` in `netlify.toml`; `og:url` emits the canonical path.
- **Internal links:** ProfileView share URL, CoAuthorMap (4 sites), ResearcherNarrative all emit `/scholar/` links.
- **Sitemap:** static pages now use real paths (`/about`, `/trending`, `/changelog`, `/privacy`, `/terms`). Deliberately NOT adding all cached profiles — crawler-rendered uncached profiles would trigger paid SerpAPI fetches.
- **Reserved slugs:** vanity slug validation now rejects router-owned segments (`scholar`, `about`, `admin`, `api`, …).
- **Hardening (review findings):** `decodeURIComponent` guarded in both the SPA router and the edge function — a malformed shared link now degrades to not-found/plain shell instead of crashing; removed a double-encode in ResearcherNarrative.

## Review
Reviewer pass done: 1 blocker (decode crash) and 1 minor (double-encode) found and fixed; non-blocking notes: server-side reserved-slug enforcement and OpenAlex OG cache lookup are pre-existing gaps, left for follow-up.