### PR TITLE
Fix broken profile share previews: og-meta key + cache read access

### DIFF
--- a/netlify/edge-functions/og-meta.ts
+++ b/netlify/edge-functions/og-meta.ts
@@ -1,9 +1,8 @@
 import type { Context } from '@netlify/edge-functions';
 
 const SUPABASE_URL = 'https://mixaxkywkojoclgbjjur.supabase.co';
-// Publishable anon key — safe to embed, same as client-side
-const SUPABASE_ANON_KEY =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1peGF4a3l3a29qb2NsZ2JqanVyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDIyMjg5NTcsImV4cCI6MjA1NzgwNDk1N30.sb_publishable_oKej73idzSJ1eJqwmgF5WQ_m2rvKae5';
+// Publishable key — safe to embed, same as client-side
+const SUPABASE_ANON_KEY = 'sb_publishable_oKej73idzSJ1eJqwmgF5WQ_m2rvKae5';
 
 const CRAWLER_AGENTS = [
   'facebookexternalhit',


### PR DESCRIPTION
## Problem
Profile social-share previews (LinkedIn/Twitter/WhatsApp cards) have silently shown only the default site tags — critical for organic distribution since shared profiles are the growth channel.

## Root causes (both pre-existing, surfaced while verifying #284)
1. `og-meta.ts` embedded key was a corrupt hybrid: old anon-JWT header/payload with the new publishable key pasted over the signature → Supabase returns 401 on every lookup. Broken since the 2026-07 key rotation.
2. `scholar_cache` has RLS enabled with **zero policies**, so even a valid anon key read returns no rows.

## Fix
- og-meta now uses the plain publishable key (same as `sitemap.ts`).
- Added read-only `SELECT` policy for `anon, authenticated` on `scholar_cache` (applied directly in production). The cached data is public Google Scholar content the site already serves to anonymous visitors; write access remains service-role only.

## Verified
REST read as anon returns the profile row. Will verify live crawler preview after deploy.