### PR TITLE
SEO: landing keyword content, FAQ schema, per-page titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,15 @@
     <meta name="twitter:title" content="Scholar Folio — Your research, at a glance" />
     <meta name="twitter:description" content="Publication history, collaboration network, and research reach on one page." />
     <title>Scholar Folio — Your research, at a glance</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "ScholarFolio",
+        "url": "https://scholarfolio.org/",
+        "description": "Academic portfolio pages from Google Scholar profiles: citation trends, co-author networks, and field-normalized metrics."
+      }
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -252,6 +252,26 @@ function AppContent() {
     }
   }, [initialUrlHandled]);
 
+  // Unique document titles per content page (Google renders JS, so these
+  // count for indexing). ProfileView owns the title while a profile is shown.
+  useEffect(() => {
+    const DEFAULT_TITLE = 'Scholar Folio — Your research, at a glance';
+    const PAGE_TITLES: Partial<Record<Page, string>> = {
+      about: 'About & Pricing — ScholarFolio',
+      trending: 'Trending Researchers — ScholarFolio',
+      changelog: 'Changelog — ScholarFolio',
+      privacy: 'Privacy Policy — ScholarFolio',
+      terms: 'Terms of Use — ScholarFolio',
+      unsubscribe: 'Email Preferences — ScholarFolio',
+      admin: 'Admin — ScholarFolio',
+    };
+    if (page === 'home') {
+      if (!data) document.title = DEFAULT_TITLE;
+    } else {
+      document.title = PAGE_TITLES[page] ?? DEFAULT_TITLE;
+    }
+  }, [page, data]);
+
   // Keep the page in sync with browser back/forward for the content-page routes.
   useEffect(() => {
     const onPop = () => {

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -5,6 +5,7 @@ import { ScholarSearchModal } from './ScholarSearchModal';
 import { ThemeToggle } from './ThemeToggle';
 import { Logo } from './Logo';
 import { useAuth } from '../contexts/AuthContext';
+import { LandingSeoSections } from './LandingSeoSections';
 
 interface LandingPageProps {
   onSearch: (url: string) => void;
@@ -302,6 +303,8 @@ export function LandingPage({ onSearch, loading, error, onNavigate, authControls
           </div>
         </div>
       </section>
+
+      <LandingSeoSections />
 
       {/* Bottom CTA */}
       <section className="py-20 px-6" ref={ctaRef}>

--- a/src/components/LandingSeoSections.tsx
+++ b/src/components/LandingSeoSections.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+// Indexable landing content: what the product is, in the words people
+// actually search with, plus an FAQ emitting FAQPage structured data.
+
+const FAQS: Array<{ q: string; a: string }> = [
+  {
+    q: 'What is ScholarFolio?',
+    a: 'ScholarFolio turns a Google Scholar profile into a clean academic portfolio page: citation trends over time, an interactive co-author network, field-normalized citation metrics, and a permanent shareable URL for your research profile.',
+  },
+  {
+    q: 'Is ScholarFolio free?',
+    a: 'Yes — looking up researcher profiles is free: 2 free searches without an account and 5 more when you create one. Viewing recently cached profiles never costs signed-in users a credit. Heavy users can buy affordable credit packs.',
+  },
+  {
+    q: 'How is this different from Google Scholar itself?',
+    a: 'Google Scholar lists publications; ScholarFolio tells the story around them. You get citation trend charts, a co-author collaboration map, percentile metrics normalized to your research field and career stage, and one polished page you can link from your website, CV, or email signature.',
+  },
+  {
+    q: 'What is a good h-index?',
+    a: 'It depends heavily on your field and career stage — an h-index of 15 can be outstanding in one discipline and average in another. That is why ScholarFolio shows field-normalized citation metrics that compare you to researchers in your own area rather than a single raw number.',
+  },
+  {
+    q: 'Can I claim and verify my researcher profile?',
+    a: 'Yes. Sign in, claim your profile, and verify ownership through your ORCID iD. Verified profiles get a permanent vanity URL (like scholarfolio.org/your-name), a verified badge, and the ability to correct profile details.',
+  },
+  {
+    q: 'Where does the data come from?',
+    a: 'Publication and citation data come from public Google Scholar profiles, enriched with open data from OpenAlex and Semantic Scholar for field-normalized metrics. Profiles are cached and refreshed regularly.',
+  },
+];
+
+const faqJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: FAQS.map(({ q, a }) => ({
+    '@type': 'Question',
+    name: q,
+    acceptedAnswer: { '@type': 'Answer', text: a },
+  })),
+}).replace(/</g, '\\u003c');
+
+export function LandingSeoSections() {
+  return (
+    <section className="py-20 px-6 bg-white dark:bg-gray-950">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: faqJsonLd }} />
+      <div className="max-w-3xl mx-auto">
+        <h2 className="font-serif text-2xl md:text-3xl font-bold text-[#1e293b] dark:text-gray-100 mb-6">
+          Your academic portfolio, built from your Google Scholar profile
+        </h2>
+        <div className="space-y-4 text-sm md:text-base text-gray-600 dark:text-gray-400 leading-relaxed mb-14">
+          <p>
+            ScholarFolio is a Google Scholar profile viewer and citation metrics dashboard for
+            researchers. Paste a Scholar profile link or search a name, and get a complete picture in
+            seconds: citation trends year by year, an interactive co-author network visualization,
+            h-index and i10-index in context, and field-normalized metrics that show how a research
+            record compares within its own discipline — not against a meaningless global average.
+          </p>
+          <p>
+            Researchers use ScholarFolio as a personal academic portfolio website: claim your profile,
+            verify it with your ORCID iD, and share one permanent URL on your homepage, CV, conference
+            slides, or email signature. Hiring committees, collaborators, and journalists use it to
+            understand a researcher's work at a glance — without clicking through hundreds of raw
+            publication entries.
+          </p>
+        </div>
+
+        <h2 className="font-serif text-2xl md:text-3xl font-bold text-[#1e293b] dark:text-gray-100 mb-6">
+          Frequently asked questions
+        </h2>
+        <div className="divide-y divide-gray-200 dark:divide-gray-800">
+          {FAQS.map(({ q, a }) => (
+            <details key={q} className="group py-4">
+              <summary className="cursor-pointer list-none flex items-center justify-between gap-4 text-sm md:text-base font-medium text-[#1e293b] dark:text-gray-100">
+                {q}
+                <span className="text-[#2d7d7d] transition-transform group-open:rotate-45 text-lg leading-none">+</span>
+              </summary>
+              <p className="mt-3 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">{a}</p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
SEO wave, PR 2 of 3 (PR 1: #287).

- **LandingSeoSections** component: two keyword-targeted paragraphs (Google Scholar profile viewer, citation metrics dashboard, academic portfolio website, co-author network visualization, field-normalized metrics, ORCID verification) + 6-question FAQ as `<details>` accordions with **FAQPage JSON-LD**. Placed between features and the bottom CTA.
- **Per-page `document.title`** for /about, /trending, /changelog, /privacy, /terms (Google renders JS; unique titles improve indexing). ProfileView keeps owning the title when a profile is displayed.
- **WebSite JSON-LD** in index.html.

FAQ copy reflects current product truth (2 free anon searches, 5 on signup, ORCID claim flow, cache behavior).