### PR TITLE
Embed badge: live citation SVG replacing broken iframe embed

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -52,6 +52,12 @@
   to = "/.netlify/functions/sitemap"
   status = 200
 
+# Embeddable citation badge (SVG served by function, before catch-all)
+[[redirects]]
+  from = "/badge/*"
+  to = "/.netlify/functions/badge?id=:splat"
+  status = 200
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/netlify/functions/badge.ts
+++ b/netlify/functions/badge.ts
@@ -1,0 +1,85 @@
+import type { Handler } from '@netlify/functions';
+
+const supabaseUrl = 'https://mixaxkywkojoclgbjjur.supabase.co';
+// Publishable key — safe to embed, same as client-side
+const supabaseAnonKey = 'sb_publishable_oKej73idzSJ1eJqwmgF5WQ_m2rvKae5';
+
+// Embeddable SVG badge for personal/university pages: shields.io-style,
+// "ScholarFolio | 24,823 citations · h-index 63". Reads only the cache —
+// never triggers a paid fetch. Served at /badge/<scholarId>.svg.
+
+const CHAR_W = 6.15; // approx px per char at 11px Verdana
+const PAD = 10;
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function renderBadge(label: string, value: string): string {
+  const lw = Math.round(label.length * CHAR_W + PAD * 2);
+  const vw = Math.round(value.length * CHAR_W + PAD * 2);
+  const w = lw + vw;
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="20" role="img" aria-label="${esc(`${label}: ${value}`)}">
+  <title>${esc(`${label}: ${value}`)}</title>
+  <clipPath id="r"><rect width="${w}" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="${lw}" height="20" fill="#1e293b"/>
+    <rect x="${lw}" width="${vw}" height="20" fill="#2d7d7d"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="${lw / 2}" y="14">${esc(label)}</text>
+    <text x="${lw + vw / 2}" y="14">${esc(value)}</text>
+  </g>
+</svg>`;
+}
+
+interface ScholarData {
+  totalCitations?: number;
+  hIndex?: number;
+}
+
+const handler: Handler = async (event) => {
+  const raw = (event.queryStringParameters?.id || '').replace(/\.svg$/i, '');
+  // Scholar IDs are alnum/_/-; OpenAlex fallbacks are "openalex:A<digits>"
+  if (!/^[A-Za-z0-9_-]{5,30}$/.test(raw) && !/^openalex:A\d{4,15}$/.test(raw)) {
+    return { statusCode: 400, body: 'Invalid profile id' };
+  }
+
+  let value = 'research profile';
+  try {
+    const scholarUrl = `https://scholar.google.com/citations?user=${encodeURIComponent(raw)}`;
+    const apiUrl = `${supabaseUrl}/rest/v1/scholar_cache?url=eq.${encodeURIComponent(scholarUrl)}&select=data&limit=1`;
+    const res = await fetch(apiUrl, {
+      headers: { apikey: supabaseAnonKey, Authorization: `Bearer ${supabaseAnonKey}` },
+    });
+    if (res.ok) {
+      const rows = (await res.json()) as Array<{ data: ScholarData }>;
+      const d = rows?.[0]?.data;
+      if (d && (d.totalCitations != null || d.hIndex != null)) {
+        const parts: string[] = [];
+        if (d.totalCitations != null) parts.push(`${d.totalCitations.toLocaleString('en-US')} citations`);
+        if (d.hIndex != null) parts.push(`h-index ${d.hIndex}`);
+        value = parts.join(' · ');
+      }
+    }
+  } catch {
+    // fall through to the generic badge
+  }
+
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'image/svg+xml; charset=utf-8',
+      // Daily refresh is plenty for citation counts; SWR keeps it snappy
+      'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
+      'Access-Control-Allow-Origin': '*',
+    },
+    body: renderBadge('ScholarFolio', value),
+  };
+};
+
+export { handler };

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,4 +1,5 @@
 https://www.scholarfolio.org/*  https://scholarfolio.org/:splat  301!
 /api/orcid-callback  /.netlify/functions/orcid-callback  200!
 /sitemap.xml  /.netlify/functions/sitemap  200!
+/badge/*  /.netlify/functions/badge?id=:splat  200!
 /*    /index.html   200

--- a/src/components/ClaimProfileModal.tsx
+++ b/src/components/ClaimProfileModal.tsx
@@ -21,7 +21,7 @@ function nameToSlug(name: string): string {
 }
 
 // Path segments the router owns — a vanity slug must never occupy them.
-const RESERVED_SLUGS = ['scholar', 'about', 'terms', 'privacy', 'changelog', 'trending', 'admin', 'api', 'sitemap', 'unsubscribe'];
+const RESERVED_SLUGS = ['scholar', 'about', 'terms', 'privacy', 'changelog', 'trending', 'admin', 'api', 'sitemap', 'unsubscribe', 'badge', 'embed'];
 
 function isValidSlug(slug: string): boolean {
   return /^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$/.test(slug) && !RESERVED_SLUGS.includes(slug);

--- a/src/components/EmbedModal.tsx
+++ b/src/components/EmbedModal.tsx
@@ -5,9 +5,12 @@ interface EmbedModalProps {
   isOpen: boolean;
   onClose: () => void;
   scholarId: string;
+  authorName: string;
+  /** Canonical page URL the badge links to (vanity slug if claimed). */
+  profileUrl: string;
 }
 
-export function EmbedModal({ isOpen, onClose, scholarId }: EmbedModalProps) {
+export function EmbedModal({ isOpen, onClose, scholarId, authorName, profileUrl }: EmbedModalProps) {
   const [copied, setCopied] = useState(false);
   const copyTimeoutRef = useRef<number>();
 
@@ -21,16 +24,13 @@ export function EmbedModal({ isOpen, onClose, scholarId }: EmbedModalProps) {
   if (!isOpen) return null;
 
   // Sanitize scholarId to prevent XSS when embed code is pasted into other sites
-  const safeScholarId = scholarId.replace(/[^a-zA-Z0-9_-]/g, '');
+  const safeScholarId = scholarId.replace(/[^a-zA-Z0-9_:-]/g, '');
+  const badgeUrl = `https://scholarfolio.org/badge/${safeScholarId}.svg`;
+  const safeName = authorName.replace(/[<>"&]/g, '');
 
-  const embedCode = `<iframe
-  src="https://scholarfolio.org/embed/${safeScholarId}"
-  width="100%"
-  height="600"
-  frameborder="0"
-  scrolling="no"
-  allowtransparency="true"
-></iframe>`;
+  const embedCode = `<a href="${profileUrl}">
+  <img src="${badgeUrl}" alt="${safeName} on ScholarFolio" height="20">
+</a>`;
 
   const handleCopy = async () => {
     try {
@@ -56,7 +56,7 @@ export function EmbedModal({ isOpen, onClose, scholarId }: EmbedModalProps) {
         <div className="sticky top-0 bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-700 p-4 flex items-center justify-between rounded-t-xl">
           <div className="flex items-center space-x-2">
             <Code className="h-5 w-5 text-[#2d7d7d]" />
-            <h2 id="embed-modal-title" className="text-lg font-semibold text-gray-900 dark:text-gray-100">Embed Metrics</h2>
+            <h2 id="embed-modal-title" className="text-lg font-semibold text-gray-900 dark:text-gray-100">Embed badge</h2>
           </div>
           <button
             onClick={onClose}
@@ -69,8 +69,13 @@ export function EmbedModal({ isOpen, onClose, scholarId }: EmbedModalProps) {
 
         <div className="p-6 space-y-4">
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            Copy and paste this code into your website to embed your Scholar Folio:
+            Add a live citation badge to your personal or university page — it links back to this
+            profile and updates automatically as citations change:
           </p>
+
+          <div className="flex items-center justify-center py-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
+            <img src={badgeUrl} alt={`${safeName} on ScholarFolio`} height={20} />
+          </div>
 
           <div className="relative">
             <pre className="bg-gray-50 dark:bg-gray-800 rounded-lg p-4 text-sm text-gray-800 dark:text-gray-200 font-mono overflow-x-auto">
@@ -96,11 +101,10 @@ export function EmbedModal({ isOpen, onClose, scholarId }: EmbedModalProps) {
           </div>
 
           <div className="bg-[#eaf4f4] dark:bg-[#2d7d7d]/10 rounded-lg p-4 text-sm text-[#1e293b] dark:text-gray-200">
-            <h3 className="font-medium mb-2">Customization Options:</h3>
             <ul className="list-disc list-inside space-y-1 text-[#334155] dark:text-gray-300">
-              <li>Adjust the width and height attributes to fit your layout</li>
-              <li>The embed automatically adapts to light/dark themes</li>
-              <li>Metrics are updated in real-time as citations change</li>
+              <li>Plain HTML — works on university CMS pages, WordPress, Notion, and GitHub READMEs (Markdown: <code className="text-xs">[![ScholarFolio]({badgeUrl})]({profileUrl})</code>)</li>
+              <li>Citation counts refresh about once a day</li>
+              <li>The badge links readers to your full ScholarFolio profile</li>
             </ul>
           </div>
         </div>

--- a/src/components/ProfileView.tsx
+++ b/src/components/ProfileView.tsx
@@ -752,6 +752,10 @@ export function ProfileView({
           isOpen={showEmbed}
           onClose={() => setShowEmbed(false)}
           scholarId={scholarId}
+          authorName={data.name}
+          profileUrl={claimedSlug
+            ? `https://scholarfolio.org/${claimedSlug}`
+            : `https://scholarfolio.org/scholar/${encodeURIComponent(scholarId)}`}
         />
       )}
 


### PR DESCRIPTION
SEO wave, PR 3 of 3 (PR 1: #287, PR 2: #288).

## Found along the way
The existing **Embed button was broken**: it emitted an iframe for `/embed/<id>`, a route that doesn't exist — the SPA catch-all served the whole landing page inside the iframe.

## Changes
- **`/badge/<id>.svg`** Netlify function: shields-style SVG — `ScholarFolio | 24,823 citations · h-index 63` — from `scholar_cache` only (never a paid fetch), `Cache-Control: max-age=86400` + SWR, strict id validation, XML-escaped output.
- **EmbedModal** now shows a live badge preview + copy-paste `<a><img>` snippet (plus a Markdown variant for GitHub READMEs). Links to the canonical profile URL — vanity slug when claimed.
- Redirect rule `/badge/* → function` in `_redirects` + `netlify.toml` (before the catch-all); `badge`/`embed` added to reserved slugs.

## Why it matters for SEO
Every researcher who embeds the badge on a university personal page creates a followed **.edu/.nl/.ac.uk backlink** — the highest-authority link profile this site could acquire, growing automatically with adoption.