### PR TITLE
Fix badge id parsing (Netlify :splat not interpolated into query)

### DIFF
--- a/netlify/functions/badge.ts
+++ b/netlify/functions/badge.ts
@@ -43,7 +43,15 @@ interface ScholarData {
 }
 
 const handler: Handler = async (event) => {
-  const raw = (event.queryStringParameters?.id || '').replace(/\.svg$/i, '');
+  // Netlify 200-rewrites don't reliably interpolate :splat into query params,
+  // but event.path keeps the original request path (/badge/<id>.svg).
+  const fromPath = event.path.match(/\/badge\/([^/]+?)(?:\.svg)?$/i)?.[1];
+  let raw: string;
+  try {
+    raw = decodeURIComponent(fromPath || event.queryStringParameters?.id || '').replace(/\.svg$/i, '');
+  } catch {
+    return { statusCode: 400, body: 'Invalid profile id' };
+  }
   // Scholar IDs are alnum/_/-; OpenAlex fallbacks are "openalex:A<digits>"
   if (!/^[A-Za-z0-9_-]{5,30}$/.test(raw) && !/^openalex:A\d{4,15}$/.test(raw)) {
     return { statusCode: 400, body: 'Invalid profile id' };


### PR DESCRIPTION
Live verification of #289 showed `/badge/<id>.svg` returning "Invalid profile id": Netlify 200-rewrites don't reliably interpolate `:splat` into query parameters, so the function received an empty id. Now parses the id from `event.path` (guarded `decodeURIComponent`), with the query param kept as fallback for direct calls. Verified the direct function call renders the correct SVG; re-verifying the pretty URL after deploy.