### PR TITLE
Fix authors appearing as their own top co-author

### DIFF
--- a/src/services/metrics/collaboration/co-author-metrics.ts
+++ b/src/services/metrics/collaboration/co-author-metrics.ts
@@ -1,4 +1,5 @@
 import type { Publication } from '../../../types/scholar';
+import { canonicalNameKey, foldNamePunctuation, isRealAuthorName, surnamesCompatible } from '../../../utils/names';
 
 interface CoAuthorStats {
   totalCoAuthors: number;
@@ -15,14 +16,11 @@ interface CoAuthorStats {
   topCoAuthors: Array<{ name: string; papers: number }>;
 }
 
-/** Strip diacritics, lowercase, remove punctuation except hyphens */
+/** Strip diacritics, fold Unicode punctuation, lowercase, remove punctuation
+ *  except hyphens. Folding matters: the same author appears as both
+ *  "Pein\u2010Hackelbusch" (U+2010) and "Pein-Hackelbusch" (ASCII) in Scholar data. */
 function normalizeName(name: string): string {
-  return name
-    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .trim()
-    .replace(/[.,;:'"()]/g, '')
-    .replace(/\s+/g, ' ');
+  return canonicalNameKey(name);
 }
 
 /** Parse a name into { given: string[], last: string }
@@ -43,7 +41,7 @@ function parseName(normalized: string): { given: string[]; last: string } {
   // Detect multi-word last name prefixes (van, de, von, el, al, di, du, le, la, etc.)
   const prefixes = new Set(['van', 'von', 'de', 'del', 'della', 'di', 'du', 'le', 'la', 'el', 'al', 'bin', 'ibn', 'den', 'der', 'het', 'ter', 'ten']);
   let lastStart = parts.length - 1;
-  while (lastStart > 1 && prefixes.has(parts[lastStart - 1])) {
+  while (lastStart > 1 && prefixes.has(parts[lastStart - 1].toLowerCase())) {
     lastStart--;
   }
 
@@ -51,6 +49,41 @@ function parseName(normalized: string): { given: string[]; last: string } {
     given: parts.slice(0, lastStart),
     last: parts.slice(lastStart).join(' '),
   };
+}
+
+/** Same cleaning as normalizeName but keeps casing, so initials blocks stay
+ *  detectable ("RFJ" vs "Ann"). */
+function cleanKeepCase(name: string): string {
+  return foldNamePunctuation(name)
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .replace(/[.,;:'"()]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** A compact block of initials: "R", "RFJ", "HHHW" — all caps, ≤5 letters —
+ *  or a ≤2-char token, which is an initials form regardless of casing. */
+function isInitialsBlock(token: string): boolean {
+  if (!token) return false;
+  return /^[A-Z]{1,5}$/.test(token) || token.length <= 2;
+}
+
+/** Expand given names into their initials sequence:
+ *  "Richard F.J." → [r,f,j];  "RFJ" → [r,f,j];  "Marnik" → [m].
+ *  Hyphenated given names contribute one initial per component, matching how
+ *  bylines render them ("Zhi-Qin" → [z,q], "Jean-Luc" → [j,l]). */
+function initialsSequence(given: string[]): string[] {
+  const out: string[] = [];
+  for (const token of given) {
+    for (const part of token.split('-').filter(Boolean)) {
+      if (isInitialsBlock(part)) {
+        for (const ch of part) out.push(ch.toLowerCase());
+      } else {
+        out.push(part[0].toLowerCase());
+      }
+    }
+  }
+  return out;
 }
 
 /** Check if two given-name parts are compatible.
@@ -146,11 +179,28 @@ function isProfileOwner(coAuthor: string, owner: string): boolean {
 
   const a = parseName(normalizeName(coAuthor));
   const b = parseName(normalizeName(owner));
-  if (!a.last || a.last !== b.last) return false;
-  if (a.given.length === 0 || b.given.length === 0) return false;
+  if (!a.last || a.given.length === 0 || b.given.length === 0) return false;
+  // Surnames may differ by a maiden/married component ("MK Pein" vs
+  // "M Pein-Hackelbusch"): authors keep publishing under both, and without
+  // this they rank as their own most frequent collaborator.
+  if (!surnamesCompatible(a.last, b.last)) return false;
 
-  const coAuthorIsInitialsOnly = a.given.every(part => part.length <= 2);
-  return coAuthorIsInitialsOnly && a.given[0][0] === b.given[0][0];
+  // Case-preserved parse: only the original casing distinguishes an initials
+  // block ("RFJ") from a short given name ("Ann").
+  const aOrig = parseName(cleanKeepCase(coAuthor));
+  const bOrig = parseName(cleanKeepCase(owner));
+  if (!aOrig.given.every(isInitialsBlock)) return false;
+
+  // The byline often carries more initials than the profile name
+  // ("Marnik Dekimpe" → "MGM Dekimpe", "Richard F.J. Haans" → "RFJ Haans").
+  // Treat them as the same person when one initials sequence is a prefix of
+  // the other — a different first initial still means a different person.
+  const aInitials = initialsSequence(aOrig.given);
+  const bInitials = initialsSequence(bOrig.given);
+  if (aInitials.length === 0 || bInitials.length === 0) return false;
+  const shorter = aInitials.length <= bInitials.length ? aInitials : bInitials;
+  const longer = aInitials.length <= bInitials.length ? bInitials : aInitials;
+  return shorter.every((ch, i) => ch === longer[i]);
 }
 
 // Venues that indicate non-journal output, used only for Google Scholar profiles
@@ -205,7 +255,10 @@ export function calculateCoAuthorMetrics(publications: Publication[], authorName
     totalAuthors += pub.authors.length;
 
     pub.authors.forEach(author => {
-      if (!isProfileOwner(author, cleanAuthorName)) {
+      // Truncation markers ("..." on long author lists) still count toward
+      // totalAuthors above — they stand for real hidden authors — but must
+      // never become a *named* collaborator.
+      if (isRealAuthorName(author) && !isProfileOwner(author, cleanAuthorName)) {
         const existingData = coAuthorCounts.get(author) || {
           count: 0,
           citations: 0,

--- a/src/services/openalex/coauthor-geo.ts
+++ b/src/services/openalex/coauthor-geo.ts
@@ -1,5 +1,6 @@
 import type { Publication, CoAuthorGeoData } from '../../types/scholar';
 import { findOpenAlexAuthor, oaFetchJson, OA_API_URL, OA_EMAIL } from './author-lookup';
+import { canonicalNameKey, isRealAuthorName, surnamesCompatible } from '../../utils/names';
 
 interface WorkAuthorship {
   author: { id: string; display_name: string };
@@ -54,15 +55,15 @@ export async function fetchCoAuthorGeoData(
   }
 
   // Step 3: Build co-author map with their most recent institution
-  const normalize = (name: string) => name.toLowerCase().trim();
+  const normalize = (name: string) => canonicalNameKey(name);
   const getLastName = (name: string) => {
-    const parts = name.split(/\s+/);
-    return normalize(parts[parts.length - 1]);
+    const parts = canonicalNameKey(name).split(/\s+/);
+    return parts[parts.length - 1] || '';
   };
 
   const mainAuthorFreq = new Map<string, number>();
   for (const pub of publications) {
-    for (const a of (pub.authors || []).filter(n => n && n.trim())) {
+    for (const a of (pub.authors || []).filter(isRealAuthorName)) {
       mainAuthorFreq.set(a, (mainAuthorFreq.get(a) || 0) + 1);
     }
   }
@@ -72,8 +73,16 @@ export async function fetchCoAuthorGeoData(
   const mainLastName = getLastName(mainAuthorKey);
   const mainNameVariants = new Set<string>();
   mainNameVariants.add(mainAuthorKey);
+  const firstInitial = (name: string) => canonicalNameKey(name).split(/\s+/)[0]?.[0] ?? '';
+  const mainInitial = firstInitial(mainAuthorKey);
   for (const [name] of mainAuthorFreq) {
-    if (getLastName(name) === mainLastName && name !== mainAuthorKey) {
+    if (name === mainAuthorKey) continue;
+    const last = getLastName(name);
+    if (last === mainLastName) {
+      mainNameVariants.add(name);
+    } else if (surnamesCompatible(last, mainLastName) && firstInitial(name) === mainInitial) {
+      // Maiden/married variant of the main author ("MK Pein" vs
+      // "M Pein-Hackelbusch"); the initial guard keeps relatives out.
       mainNameVariants.add(name);
     }
   }
@@ -81,7 +90,7 @@ export async function fetchCoAuthorGeoData(
   // Count shared papers/citations from ScholarFolio data
   const coAuthorStats = new Map<string, { papers: number; citations: number }>();
   for (const pub of publications) {
-    for (const a of (pub.authors || []).filter(a => a && a.trim() && !mainNameVariants.has(a))) {
+    for (const a of (pub.authors || []).filter(a => isRealAuthorName(a) && !mainNameVariants.has(a))) {
       const existing = coAuthorStats.get(a) ?? { papers: 0, citations: 0 };
       coAuthorStats.set(a, { papers: existing.papers + 1, citations: existing.citations + pub.citations });
     }

--- a/src/utils/names.ts
+++ b/src/utils/names.ts
@@ -1,4 +1,91 @@
 /**
+ * Fold the Unicode punctuation that differs between our data sources into its
+ * ASCII equivalent. OpenAlex stores "Pein‐Hackelbusch" with U+2010 HYPHEN and
+ * Google Scholar emits both that and ASCII "-" for the same author, which made
+ * exact-string name comparisons miss (author lookups resolved to the wrong
+ * record; authors appeared as their own co-authors).
+ */
+export function foldNamePunctuation(name: string): string {
+  return name
+    // hyphen/dash family → ASCII hyphen
+    .replace(/[‐‑‒–—―−﹘﹣－]/g, '-')
+    // apostrophe family → ASCII apostrophe (O’Brien vs O'Brien)
+    .replace(/[‘’‚‛ʼ′]/g, "'")
+    // soft hyphen and zero-width characters carry no meaning in a name
+    .replace(/[­​‌‍﻿]/g, '')
+    // exotic spaces → plain space
+    .replace(/[    ]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Whether an author-list entry is a real person rather than a truncation
+ * marker. Google Scholar abbreviates long author lists with a trailing "..."
+ * (and occasionally "et al."), which otherwise gets counted as a prolific
+ * collaborator and can win the top-co-author slot outright.
+ */
+export function isRealAuthorName(name: string): boolean {
+  const s = foldNamePunctuation(name || '').trim();
+  if (!s) return false;
+  if (/^[.…\s]+$/.test(s)) return false;            // "...", "…", ". . ."
+  if (/^et\.?\s*al\.?$/i.test(s)) return false;          // "et al", "et al."
+  if (/^and\s+others$/i.test(s)) return false;
+  return /\p{L}/u.test(s);                                // must contain a letter
+}
+
+/**
+ * Comparison key for author names: punctuation-folded, diacritic-stripped,
+ * lowercased, with formatting punctuation removed. Hyphens are kept so
+ * compound surnames stay distinguishable.
+ */
+export function canonicalNameKey(name: string): string {
+  return foldNamePunctuation(name)
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[.,;:'"()]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Split a surname into its meaningful components: "pein-hackelbusch" →
+ * ["pein", "hackelbusch"]. Used to recognise maiden/married name pairs, where
+ * one surname is a component of the other.
+ */
+export function surnameComponents(lastName: string): string[] {
+  return canonicalNameKey(lastName)
+    .split(/[-\s]+/)
+    .map(part => part.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Whether two surnames plausibly belong to the same person: identical, or one
+ * is a component of the other's compound form ("Pein" vs "Pein-Hackelbusch",
+ * the common maiden→married pattern). Requires the shared component to be
+ * ≥3 characters so initials and particles ("de", "van") can't bridge two
+ * unrelated surnames. Callers must additionally check given names.
+ */
+export function surnamesCompatible(lastA: string, lastB: string): boolean {
+  const a = canonicalNameKey(lastA);
+  const b = canonicalNameKey(lastB);
+  if (!a || !b) return false;
+  if (a === b) return true;
+
+  const partsA = surnameComponents(a);
+  const partsB = surnameComponents(b);
+  if (partsA.length === 0 || partsB.length === 0) return false;
+  // Only bridge when one side is a single surname contained in the other's
+  // compound form — never merge two different compounds.
+  const single = partsA.length === 1 ? partsA[0] : partsB.length === 1 ? partsB[0] : null;
+  if (!single || single.length < 3) return false;
+  const compound = partsA.length === 1 ? partsB : partsA;
+  if (compound.length < 2) return false;
+  return compound.includes(single);
+}
+
+/**
  * Extracts the last name from a full name, handling compound last names
  * with common prefixes (van, von, de, del, della, di, da, dos, das, du, den, der).
  *
@@ -84,16 +171,18 @@ export function normalizeAuthorNames(publications: { authors: string[] }[]): typ
   const nameFreq = new Map<string, number>();
   for (const pub of publications) {
     for (const a of pub.authors) {
-      if (a && a.trim()) nameFreq.set(a, (nameFreq.get(a) || 0) + 1);
+      if (isRealAuthorName(a)) nameFreq.set(a, (nameFreq.get(a) || 0) + 1);
     }
   }
 
   // Build a fuzzy key for each name: "baselastname|firstinitial" (lowercased, prefix-stripped)
   function fuzzyKey(name: string): string {
-    const trimmed = name.trim();
+    // Fold Unicode punctuation first so "Pein‐Hackelbusch" (U+2010) and
+    // "Pein-Hackelbusch" (ASCII) land in the same group.
+    const trimmed = foldNamePunctuation(name);
     if (!trimmed) return '';
     const lastName = extractLastName(trimmed);
-    const baseLast = stripLastNamePrefix(lastName).toLowerCase().replace(/[.,]/g, '');
+    const baseLast = canonicalNameKey(stripLastNamePrefix(lastName));
     const firstPart = trimmed.split(/\s+/)[0];
     const firstInitial = firstPart ? firstPart[0].toLowerCase() : '';
     return `${baseLast}|${firstInitial}`;
@@ -123,7 +212,7 @@ export function normalizeAuthorNames(publications: { authors: string[] }[]): typ
 
     // Safety check: all variants must have same base last name (prefix-stripped, case-insensitive)
     const baseLastNames = new Set(variants.map(v =>
-      stripLastNamePrefix(extractLastName(v)).toLowerCase().replace(/[.,]/g, '')
+      canonicalNameKey(stripLastNamePrefix(extractLastName(foldNamePunctuation(v))))
     ));
     if (baseLastNames.size > 1) continue;
 


### PR DESCRIPTION
From user feedback: Miriam Pein-Hackelbusch saw **"MK Pein" — her own maiden name — listed as her main co-author**. She's right, and it turned out to be three separate defects in the owner self-filter, which required exact surname equality plus initials ≤2 chars.

## Root causes
1. **Maiden/married surnames** — `MK Pein` (25 of her papers) vs `M Pein-Hackelbusch` (31): surname equality fails, so she counted as her own collaborator and won the top slot.
2. **Unicode hyphens** — OpenAlex stores `Pein‐Hackelbusch` with U+2010 HYPHEN, and Scholar emits both that and ASCII `-`. Exact string comparison missed 2 more of her papers.
3. **Extra byline initials** — `Marnik Dekimpe` → `MGM Dekimpe`, `Richard F.J. Haans` → `RFJ Haans`, `Andrew Ng` → `AYT Ng`. The ≤2-char initials cap rejected 3+ initial blocks.

## Fix
Shared helpers in `utils/names.ts`: `foldNamePunctuation` (hyphen/apostrophe/space/zero-width families → ASCII), `canonicalNameKey`, `surnamesCompatible` (one surname a component of the other's compound; ≥3-char component so particles like "de" can't bridge), `isRealAuthorName`. Owner detection now compares **initials sequences** with prefix semantics, using a case-preserved parse so "RFJ" (initials) is distinguished from "Ann" (a name). Applied to the co-author metrics and the co-author geo map.

## Plus: "..." was a co-author
Scholar truncates long author lists with `...`; we counted it as a person. **243 cached profiles** carry it (4,605 author slots) and it can win the top-co-author slot. Now excluded from named co-authors, still counted toward author totals (it stands for real hidden authors, so dropping it entirely would undercount).

## Verification
- Truth table (15 cases) covering every variant plus negative controls — all pass.
- Sweep of 300 cached profiles: ellipsis co-authors 4,605 → 0; owner self-listings 28 → 15, and every remaining case is a genuinely different person (Doina vs Cornelia Caragea; Arthur J. vs David Cropley, father and son) or an unsolvable nickname (`Ko` = Johannes de Ruyter).
- Miriam's profile now reads: top co-author **J Breitkreutz (12 papers)**.

Fixes for the same user's Open Access report follow in a separate PR.