### PR TITLE
Fix wrong OpenAlex author match causing false 0% open access

### DIFF
--- a/src/services/openalex/author-lookup.ts
+++ b/src/services/openalex/author-lookup.ts
@@ -1,6 +1,7 @@
 import { timeoutSignal } from '../../utils/api';
 import { RateLimiter } from '../scholar/rate-limiter';
 import { logCaughtError } from '../../lib/errorLogger';
+import { canonicalNameKey, extractLastName, foldNamePunctuation, surnamesCompatible } from '../../utils/names';
 
 const API_URL = 'https://api.openalex.org';
 const EMAIL = 'info@scholarfolio.org';
@@ -87,12 +88,32 @@ export function findOpenAlexAuthor(
   return promise;
 }
 
+/** Overlap between two institution strings, 0–1. Substring either way scores
+ *  1; otherwise the share of the shorter name's significant words that appear
+ *  in the other ("OWL University of Applied Sciences" vs "Ostwestfalen-Lippe
+ *  University of Applied Sciences and Arts"). */
+function institutionOverlap(a: string, b: string): number {
+  const x = canonicalNameKey(a);
+  const y = canonicalNameKey(b);
+  if (!x || !y) return 0;
+  if (x.includes(y) || y.includes(x)) return 1;
+  const stop = new Set(['university', 'of', 'the', 'and', 'for', 'de', 'college', 'institute', 'school', 'center', 'centre', 'department']);
+  const words = (s: string) => new Set(s.split(/[^a-z0-9]+/).filter(w => w.length > 2 && !stop.has(w)));
+  const wx = words(x), wy = words(y);
+  if (wx.size === 0 || wy.size === 0) return 0;
+  const [small, large] = wx.size <= wy.size ? [wx, wy] : [wy, wx];
+  let hits = 0;
+  for (const w of small) if (large.has(w)) hits++;
+  return hits / small.size;
+}
+
 /**
- * Uncached author resolution:
- * 1. Searches by name (per_page=10)
- * 2. Filters by display_name match
- * 3. Refines by affiliation match
- * 4. Fetches ORCID from full author record
+ * Uncached author resolution. OpenAlex frequently holds several records for
+ * one researcher — a rich one carrying the ORCID and most works, plus sparse
+ * duplicates with a handful. Picking the wrong one silently produces wrong
+ * metrics (a 1-work duplicate reported "0% open access" for an author with 26
+ * OA papers), so candidates are scored rather than taken in relevance order:
+ * name match, affiliation overlap, ORCID presence, and works count.
  */
 async function resolveOpenAlexAuthor(
   name: string,
@@ -103,6 +124,7 @@ async function resolveOpenAlexAuthor(
       id: string;
       display_name: string;
       orcid?: string;
+      works_count?: number;
       last_known_institutions?: Array<{
         id: string;
         display_name: string;
@@ -110,7 +132,7 @@ async function resolveOpenAlexAuthor(
       }>;
       affiliations?: Array<{ institution?: { display_name?: string } }>;
     }> }>(
-      `${API_URL}/authors?search=${encodeURIComponent(name)}&per_page=10&select=id,display_name,orcid,last_known_institutions,affiliations&mailto=${EMAIL}`
+      `${API_URL}/authors?search=${encodeURIComponent(name)}&per_page=10&select=id,display_name,orcid,works_count,last_known_institutions,affiliations&mailto=${EMAIL}`
     );
 
     const results = searchData?.results;
@@ -118,27 +140,43 @@ async function resolveOpenAlexAuthor(
       return null;
     }
 
-    // Filter to results whose display_name matches the search name
-    const nameLower = name.toLowerCase().trim();
-    const nameMatches = results.filter(r =>
-      r.display_name.toLowerCase().trim() === nameLower
+    // Surname must be compatible, else it's a different person entirely —
+    // better no OpenAlex data than another researcher's.
+    const searchedLast = extractLastName(foldNamePunctuation(name));
+    const plausible = results.filter(r =>
+      surnamesCompatible(extractLastName(foldNamePunctuation(r.display_name)), searchedLast)
     );
-    const candidates = nameMatches.length > 0 ? nameMatches : results;
+    if (!plausible.length) return null;
 
-    // Try affiliation match among candidates
-    let best = candidates[0];
-    if (candidates.length > 1 && affiliation) {
-      const affLower = affiliation.toLowerCase();
-      for (const candidate of candidates) {
-        const lastInst = candidate.last_known_institutions?.[0]?.display_name?.toLowerCase() || '';
-        const allInsts = (candidate.affiliations || []).map(
-          (a: { institution?: { display_name?: string } }) => a.institution?.display_name?.toLowerCase() || ''
-        );
-        if ((lastInst && affLower.includes(lastInst)) ||
-            allInsts.some((inst: string) => inst && affLower.includes(inst))) {
-          best = candidate;
-          break;
-        }
+    // canonicalNameKey folds the Unicode hyphen OpenAlex uses ("Pein‐
+    // Hackelbusch"), which an exact string compare misses.
+    const nameKey = canonicalNameKey(name);
+    const affLower = affiliation || '';
+
+    const score = (c: typeof plausible[number]): number => {
+      let s = 0;
+      if (canonicalNameKey(c.display_name) === nameKey) s += 100;
+      if (affLower) {
+        const insts = [
+          c.last_known_institutions?.[0]?.display_name || '',
+          ...(c.affiliations || []).map(a => a.institution?.display_name || ''),
+        ].filter(Boolean);
+        const best = insts.reduce((m, i) => Math.max(m, institutionOverlap(affLower, i)), 0);
+        s += best * 50;
+      }
+      if (c.orcid) s += 20;
+      // Prefer the fuller record; capped so works count can't outweigh identity.
+      s += Math.min(c.works_count || 0, 200) / 10;
+      return s;
+    };
+
+    let best = plausible[0];
+    let bestScore = score(best);
+    for (const candidate of plausible.slice(1)) {
+      const s = score(candidate);
+      if (s > bestScore) {
+        best = candidate;
+        bestScore = s;
       }
     }
 

--- a/src/services/openalex/index.ts
+++ b/src/services/openalex/index.ts
@@ -96,13 +96,30 @@ export class OpenAlexService {
           const repoName = boa.source.display_name;
           repositoryCounts[repoName] = (repositoryCounts[repoName] || 0) + 1;
         }
-        // Tally OA buckets for the filtered total.
+        // Tally OA buckets for the filtered total. A work whose oa_status is
+        // absent is unknown, not closed — counting it as closed can only drag
+        // the percentage down.
+        if (!rawStatus) continue;
         fTotal++;
         if (rawStatus === 'gold' || rawStatus === 'diamond') fGold++;
         else if (rawStatus === 'green') fGreen++;
         else if (rawStatus === 'hybrid') fHybrid++;
         else if (rawStatus === 'bronze') fBronze++;
         else fClosed++;
+      }
+
+      // Guard against a wrong author match: if almost none of the profile's
+      // publications appear on the resolved OpenAlex record, its totals
+      // describe somebody else. Reporting "unavailable" is far better than a
+      // confident 0% — the failure mode a user hit when a sparse duplicate
+      // record (1 work) was picked over their real one (61 works).
+      // The bar is deliberately low so profiles that merely index poorly
+      // (books, non-English venues) still get stats.
+      if (titleFilter && titleFilter.size >= 5 && fTotal < titleFilter.size * 0.1) {
+        console.warn(
+          `[OpenAlex] Resolved author matches only ${fTotal}/${titleFilter.size} of the profile's publications — skipping OA stats`
+        );
+        return null;
       }
 
       // When filtering, report the counts recomputed from the matched works so


### PR DESCRIPTION
Second fix from the same user report (first: #292). She said nearly all her recent papers are open access but ScholarFolio showed **0%**. She's right — and this was our bug, not Google Scholar's or OpenAlex's data.

## Root cause
`resolveOpenAlexAuthor` picked the first candidate whose `display_name` **exactly** equalled the search name. OpenAlex holds three records for her:

| record | display_name | works | ORCID |
|---|---|---|---|
| A5051579225 | `Miriam Pein‐Hackelbusch` (**U+2010 hyphen**) | 61 | ✓ |
| A5134319643 | `Miriam Pein-Hackelbusch` (ASCII) | 1 | ✗ |
| A5123187192 | `Miriam Pein-Hackelbuschf` (typo) | 1 | ✗ |

The exact string compare **rejected her real record** over one invisible character and selected the 1-work duplicate — whose single work is closed access. Hence a confident "0%". Her real record: 13 gold + 9 green + 3 hybrid + 1 bronze = **26 of 61 OA**.

## Fix
- **Scored candidate selection** — canonical name match (Unicode-hyphen and diacritic folded), affiliation word-overlap, ORCID presence, works count (capped so it can't outweigh identity).
- **Surname guard** — candidates whose surname isn't compatible are dropped, and if none remain we return null. Previously `best = results[0]` could silently return a *completely different researcher*.
- **No more false zeros** — a work with missing `oa_status` counts as unknown rather than closed; and if <10% of the profile's publications appear on the resolved record, stats are withheld as "unavailable" rather than shown wrong. (Threshold deliberately low so poorly-indexed profiles still get stats.)

## Impact beyond OA
The lookup is shared by OA stats, **field-normalized metrics**, and **co-author geography** — a wrong match corrupted all three.

## Verification
Sampled 25 cached profiles against live OpenAlex: **3 were resolving to the wrong record**, all now correct and none lost data —
- `Salvatore Polizzi`: 13 works → 52 (+ORCID)
- `Andrew Ng`: 11 works → 31 (+ORCID)
- `Charlotte Kramer` → **Charlotte Krämer**: 1 work → 48 (diacritic folding)

Her profile end-to-end: **0% → 41%** (21 OA of 51 matched publications).