### PR TITLE
Match umlaut and double-surname name variants, add author-name audit

### DIFF
--- a/scripts/name-audit/README.md
+++ b/scripts/name-audit/README.md
@@ -1,0 +1,89 @@
+# Author-name audit
+
+Author identity is the hardest correctness problem in ScholarFolio: the same
+researcher reaches us spelled several ways, and two different researchers often
+look nearly identical. Getting it wrong is highly visible — a user reported
+seeing her own maiden name listed as her top co-author, and a wrong OpenAlex
+author match reported "0% open access" for someone with 26 open-access papers.
+
+These two scripts make that behaviour measurable instead of anecdotal.
+
+## `cases.ts` — the identity matrix
+
+```bash
+npx tsx scripts/name-audit/cases.ts            # per-class summary
+npx tsx scripts/name-audit/cases.ts --verbose  # every case
+```
+
+Hand-written cases grouped by the ways names vary, each asking the question the
+product asks: *is this byline the same person as the profile owner?* Every class
+carries **negative controls** — a matcher that merges everything fails this file
+rather than passing it.
+
+Classes covered: hyphenated/compound surnames (including Unicode hyphens),
+maiden↔married names, German umlauts and ß, Nordic characters (ø å æ),
+Spanish/Portuguese double surnames, multiple given names and initials blocks,
+surname particles (van/de/von), CJK names and romanisation, apostrophes,
+truncation markers, plus real-world pairs of distinct people who share a
+surname.
+
+Cases marked `xfail` are **known, accepted limitations**, asserted to still
+fail. If a change fixes one, the run reports "unexpectedly fixed" and the case
+should be promoted out of `xfail`. The exit code is non-zero only on real
+regressions, so this is safe to wire into CI.
+
+### Known limitations (currently `xfail`)
+
+| case | why it's hard |
+|---|---|
+| `Muller` ↔ `Mueller` (neither spelled with the umlaut) | Bridging them requires collapsing `ue`→`u`, which measurably conflates real distinct surnames — Yu/Yue, Cho/Choe, Sun/Suen, Baur/Bauer. Handling `Müller` against either spelling is safe and *is* supported; only the two-ASCII-variants case is not. |
+| `J García` ↔ `Juan García López` | Matching on one surname of a double surname would merge anyone sharing it. |
+| `S O Brien` ↔ `Sean O'Brien` | Dropping the apostrophe makes the surname split into two tokens, indistinguishable from a genuine two-token name. |
+
+## `run.ts` — regression sweep over real profiles
+
+```bash
+npx tsx scripts/name-audit/run.ts            # summary
+npx tsx scripts/name-audit/run.ts --verbose  # per profile
+npx tsx scripts/name-audit/run.ts --json     # machine-readable
+```
+
+Replays the live pipeline over the 100 cached profiles in `profiles.json` and
+checks four invariants:
+
+- **self-listed** — the owner must never rank as their own collaborator
+- **truncation-marker** — Scholar's `...` is not a person
+- **duplicate-co-authors** — one list must not contain two entries for one person
+- **no-co-authors** — a collaborative profile must still yield collaborators
+  (catches over-filtering, the failure mode of fixing the first invariant too
+  aggressively)
+
+It reads `scholar_cache` directly, so it costs nothing and never touches the
+paid fetch path. Profiles that have since been evicted are reported as missing
+rather than failing the run.
+
+## `profiles.json` — the sample
+
+100 profiles chosen deterministically (seed 42) from the cache, stratified so
+the rare structural cases are all present rather than left to chance:
+
+| reason | n | why |
+|---|---|---|
+| `negative-control` | 20 | profiles whose bylines contain a *different* person with the same surname |
+| `dotted-initials` | 18 | `Richard F.J. Haans` style |
+| `hyphen-surname` | 13 | compound surnames |
+| `non-ascii-name` | 11 | diacritics, umlauts, CJK |
+| `heavy-ellipsis` | 8 | ≥20 truncated author slots |
+| `particle-surname` | 8 | van / de / von |
+| `unicode-dash-authors` | 7 | bylines containing U+2010 |
+| `baseline` | 7 | ordinary profiles, to catch over-filtering |
+| `long-name` | 4 | four or more name tokens |
+| `known-failure` | 4 | the profiles that currently exhibit a tracked limitation |
+
+Per-profile `knownHardSelfListed` / `knownHardDuplicatePairs` entries record
+exactly which findings are accepted, so a *new* problem on the same profile
+still fails the run.
+
+To regenerate the sample after the cache has grown substantially, re-derive it
+from `scholar_cache` with the same stratification; keep the seed so the set
+stays stable between runs.

--- a/scripts/name-audit/cases.ts
+++ b/scripts/name-audit/cases.ts
@@ -1,0 +1,178 @@
+/**
+ * Author-identity test matrix.
+ *
+ *   npx tsx scripts/name-audit/cases.ts            # per-class pass/fail summary
+ *   npx tsx scripts/name-audit/cases.ts --verbose  # every case
+ *
+ * Each case asks the question the product actually asks: "is this byline the
+ * same person as the profile owner?" — the check that decides whether someone
+ * is listed as their own top co-author. Every class carries negative controls;
+ * a matcher that merges everything must fail this file, not pass it.
+ *
+ * Cases marked `xfail` are known, accepted limitations. They are asserted to
+ * STILL FAIL, so if a change happens to fix one the run reports it as
+ * "unexpectedly fixed" and the case should be promoted to a normal
+ * expectation. Exit code is non-zero only on real regressions.
+ */
+import { calculateCoAuthorMetrics } from '../../src/services/metrics/collaboration/co-author-metrics';
+import { isRealAuthorName, normalizeAuthorNames } from '../../src/utils/names';
+
+interface Case {
+  /** byline as it appears in an author list */
+  byline: string;
+  /** the profile owner's display name */
+  owner: string;
+  /** true when byline and owner are the same human */
+  same: boolean;
+  note: string;
+  xfail?: boolean;
+}
+
+const MATRIX: Record<string, Case[]> = {
+  'hyphenated & compound surnames': [
+    { byline: 'M Pein-Hackelbusch', owner: 'Miriam Pein-Hackelbusch', same: true, note: 'plain initial' },
+    { byline: 'M Pein‐Hackelbusch', owner: 'Miriam Pein-Hackelbusch', same: true, note: 'U+2010 hyphen' },
+    { byline: 'M Pein–Hackelbusch', owner: 'Miriam Pein-Hackelbusch', same: true, note: 'en dash' },
+    { byline: 'G Odekerken-Schröder', owner: 'Gaby Odekerken-Schröder', same: true, note: 'compound + umlaut' },
+    { byline: 'M Pein-Mueller', owner: 'Miriam Pein-Hackelbusch', same: false, note: 'different compound' },
+    { byline: 'J Hackelbusch', owner: 'Miriam Pein-Hackelbusch', same: false, note: 'component, wrong initial' },
+  ],
+
+  'maiden / married names': [
+    { byline: 'MK Pein', owner: 'Miriam Pein-Hackelbusch', same: true, note: 'maiden name + initials' },
+    { byline: 'M Pein', owner: 'Miriam Pein-Hackelbusch', same: true, note: 'maiden name' },
+    { byline: 'M Hackelbusch', owner: 'Miriam Pein-Hackelbusch', same: true, note: 'married component' },
+    { byline: 'Thomas Pein', owner: 'Miriam Pein-Hackelbusch', same: false, note: 'relative, full given name' },
+    { byline: 'T Pein', owner: 'Miriam Pein-Hackelbusch', same: false, note: 'relative, wrong initial' },
+  ],
+
+  'german umlauts & eszett': [
+    { byline: 'M Müller', owner: 'Michael Muller', same: true, note: 'umlaut vs stripped' },
+    { byline: 'M Mueller', owner: 'Michael Müller', same: true, note: 'digraph vs umlaut' },
+    { byline: 'M Muller', owner: 'Michael Mueller', same: true, note: 'stripped vs digraph', xfail: true },
+    { byline: 'S Schäfer', owner: 'Stefan Schaefer', same: true, note: 'ä/ae' },
+    { byline: 'K Köhler', owner: 'Klaus Koehler', same: true, note: 'ö/oe' },
+    { byline: 'J Hübner', owner: 'Jan Huebner', same: true, note: 'ü/ue' },
+    { byline: 'F Strauß', owner: 'Franz Strauss', same: true, note: 'ß/ss' },
+    { byline: 'M Bauer', owner: 'Michael Baur', same: false, note: 'DIFFERENT surnames' },
+    { byline: 'A Schmitt', owner: 'Andreas Schmidt', same: false, note: 'DIFFERENT surnames' },
+  ],
+
+  'nordic characters': [
+    { byline: 'L Møller', owner: 'Lars Moeller', same: true, note: 'ø/oe' },
+    { byline: 'A Åkesson', owner: 'Anna Aakesson', same: true, note: 'å/aa' },
+    { byline: 'E Ærø', owner: 'Erik Aeroe', same: true, note: 'æ/ae + ø/oe' },
+    { byline: 'T Törnqvist', owner: 'Tomas Toernqvist', same: true, note: 'ö/oe swedish' },
+    { byline: 'N Sørensen', owner: 'Nils Sorenson', same: false, note: 'DIFFERENT surnames' },
+  ],
+
+  'spanish / portuguese double surnames': [
+    { byline: 'MA García-Benau', owner: 'María Antonia García Benau', same: true, note: 'hyphen vs space' },
+    { byline: 'J Diaz Calafat', owner: 'Joan Díaz-Calafat', same: true, note: 'space vs hyphen + accent' },
+    { byline: 'J García', owner: 'Juan García López', same: true, note: 'paternal surname only', xfail: true },
+    { byline: 'JC Pérez Rodríguez', owner: 'Juan Carlos Pérez Rodríguez', same: true, note: 'full double surname' },
+    { byline: 'A García López', owner: 'Juan García López', same: false, note: 'DIFFERENT person, same surnames' },
+    { byline: 'J Lopez', owner: 'Juan García López', same: true, note: 'maternal surname only' },
+  ],
+
+  'multiple given names': [
+    { byline: 'JC Pérez', owner: 'Juan Carlos Pérez', same: true, note: 'combined initials' },
+    { byline: 'J Pérez', owner: 'Juan Carlos Pérez', same: true, note: 'first initial only' },
+    { byline: 'AM Schmidt', owner: 'Anna Maria Schmidt', same: true, note: 'two given names' },
+    { byline: 'RFJ Haans', owner: 'Richard F.J. Haans', same: true, note: 'dotted initials in profile' },
+    { byline: 'MGM Dekimpe', owner: 'Marnik Dekimpe', same: true, note: 'byline has more initials' },
+    { byline: 'HHHW Schmidt', owner: 'Harald H.H.W. Schmidt', same: true, note: 'four initials' },
+    { byline: 'AB Schmidt', owner: 'Anna Maria Schmidt', same: false, note: 'DIFFERENT second initial' },
+    { byline: 'Peter Schmidt', owner: 'Anna Maria Schmidt', same: false, note: 'DIFFERENT given name' },
+  ],
+
+  'surname particles': [
+    { byline: 'K de Ruyter', owner: 'Ko de Ruyter', same: true, note: 'de particle' },
+    { byline: 'E van Miltenburg', owner: 'Emiel van Miltenburg', same: true, note: 'van particle' },
+    { byline: 'J van der Berg', owner: 'Jan van der Berg', same: true, note: 'two particles' },
+    { byline: 'M von Grafenstein', owner: 'Max von Grafenstein', same: true, note: 'von particle' },
+    { byline: 'P de Vries', owner: 'Ko de Ruyter', same: false, note: 'DIFFERENT surname, same particle' },
+  ],
+
+  'CJK & romanisation': [
+    { byline: 'ZQJ Xu', owner: 'Zhi-Qin John Xu', same: true, note: 'hyphenated given name → initials' },
+    { byline: 'JH QIN', owner: 'Jiahu Qin', same: true, note: 'uppercase surname' },
+    { byline: 'X Yue', owner: 'Xiang Yu', same: false, note: 'DIFFERENT chinese surnames' },
+    { byline: 'S Choe', owner: 'Sung Cho', same: false, note: 'DIFFERENT korean surnames' },
+    { byline: 'L Suen', owner: 'Li Sun', same: false, note: 'DIFFERENT surnames' },
+  ],
+
+  'apostrophes & punctuation': [
+    { byline: "S O'Brien", owner: 'Sean O’Brien', same: true, note: 'curly vs straight apostrophe' },
+    { byline: 'S O Brien', owner: "Sean O'Brien", same: true, note: 'apostrophe dropped', xfail: true },
+    { byline: 'M D’Angelo', owner: "Marco D'Angelo", same: true, note: 'italian apostrophe' },
+  ],
+
+  'truncation markers': [
+    { byline: '...', owner: 'Miriam Pein-Hackelbusch', same: false, note: 'ellipsis is not a person' },
+    { byline: '…', owner: 'Miriam Pein-Hackelbusch', same: false, note: 'unicode ellipsis' },
+  ],
+
+  'unrelated people (global negative controls)': [
+    { byline: 'D Caragea', owner: 'Cornelia Caragea', same: false, note: 'real colleagues, same surname' },
+    { byline: 'AJ Cropley', owner: 'David Cropley', same: false, note: 'father and son' },
+    { byline: 'A Richter', owner: 'Shahper Richter', same: false, note: 'different researchers' },
+    { byline: 'J Breitkreutz', owner: 'Miriam Pein-Hackelbusch', same: false, note: 'genuine co-author' },
+  ],
+};
+
+/** Does the production pipeline treat `byline` as the profile owner? */
+function treatedAsOwner(byline: string, owner: string): boolean {
+  // A truncation marker is dropped for not being a person at all, which is a
+  // different question from "is this the owner" — never report it as a match.
+  if (!isRealAuthorName(byline)) return false;
+  const pubs = [
+    { authors: [byline, owner], citations: 1, year: 2020, title: 'a' },
+    { authors: [byline, owner], citations: 1, year: 2021, title: 'b' },
+  ];
+  normalizeAuthorNames(pubs);
+  const metrics = calculateCoAuthorMetrics(pubs as never, owner);
+  // Filtered out of the co-author list ⇒ recognised as the owner. Compare on
+  // the post-normalisation list, since merging may have rewritten the byline.
+  return metrics.topCoAuthors.length === 0;
+}
+
+const verbose = process.argv.includes('--verbose');
+let regressions = 0;
+let unexpectedlyFixed = 0;
+let pass = 0;
+let known = 0;
+
+console.log('\nAuthor-identity matrix\n');
+for (const [className, cases] of Object.entries(MATRIX)) {
+  const results = cases.map(c => {
+    const actual = treatedAsOwner(c.byline, c.owner);
+    const correct = actual === c.same;
+    return { ...c, actual, correct };
+  });
+  const failures = results.filter(r => !r.correct && !r.xfail);
+  const knownFails = results.filter(r => !r.correct && r.xfail);
+  const fixed = results.filter(r => r.correct && r.xfail);
+  regressions += failures.length;
+  unexpectedlyFixed += fixed.length;
+  known += knownFails.length;
+  pass += results.filter(r => r.correct && !r.xfail).length;
+
+  const status = failures.length ? 'FAIL' : knownFails.length ? 'partial' : 'ok';
+  console.log(
+    `  ${status.padEnd(8)} ${className}  (${results.length - failures.length - knownFails.length}/${results.length} correct` +
+    `${knownFails.length ? `, ${knownFails.length} known-hard` : ''})`
+  );
+  for (const r of results) {
+    const show = verbose || (!r.correct);
+    if (!show) continue;
+    const mark = r.correct ? (r.xfail ? '↑' : '·') : (r.xfail ? '~' : '✗');
+    console.log(`       ${mark} "${r.byline}" vs "${r.owner}" → same=${r.actual}, expected ${r.same}  [${r.note}]`);
+  }
+}
+
+console.log(
+  `\n${pass} passing, ${known} known-hard (tracked), ${regressions} regressions` +
+  `${unexpectedlyFixed ? `, ${unexpectedlyFixed} unexpectedly fixed — promote these out of xfail` : ''}\n`
+);
+process.exit(regressions > 0 ? 1 : 0);

--- a/scripts/name-audit/profiles.json
+++ b/scripts/name-audit/profiles.json
@@ -1,0 +1,1133 @@
+{
+  "_comment": "Regression sample for author-name matching. See README.md. Generated 2026-07-22 from cached profiles; deterministic (seed 42).",
+  "profiles": [
+    {
+      "scholarId": "VJTDvJQAAAAJ",
+      "name": "Blair Wang",
+      "publications": 15,
+      "reason": "baseline",
+      "traits": [
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "nC_yAqUAAAAJ",
+      "name": "Dr Maksym Koghut",
+      "publications": 10,
+      "reason": "baseline",
+      "traits": [
+        "unicode-dash-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "YxupCr0AAAAJ",
+      "name": "Fabio Tollon",
+      "publications": 32,
+      "reason": "baseline",
+      "traits": [
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "Zpn08WoAAAAJ",
+      "name": "Jason Bennett Thatcher",
+      "publications": 210,
+      "reason": "baseline",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "6rA6A90AAAAJ",
+      "name": "Mohammad Aghajohari",
+      "publications": 7,
+      "reason": "baseline",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "JVVhfCQAAAAJ",
+      "name": "Paul L. Christ",
+      "publications": 16,
+      "reason": "baseline",
+      "traits": [
+        "dotted-initials",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "gwqQamEAAAAJ",
+      "name": "Temitope Farinloye",
+      "publications": 33,
+      "reason": "baseline",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "FTl3bwUAAAAJ",
+      "name": "Arnold B. Bakker",
+      "publications": 1000,
+      "reason": "dotted-initials",
+      "traits": [
+        "unicode-dash-authors",
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "SQLUVSEAAAAJ",
+      "name": "Benedikt M. Brand",
+      "publications": 20,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "3BsdBosAAAAJ",
+      "name": "Daniel S. Quintana",
+      "publications": 169,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "IPSRo_cAAAAJ",
+      "name": "EDIDIONG N. OROK",
+      "publications": 31,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "JHcPqTAAAAAJ",
+      "name": "Frederic R. Hopp",
+      "publications": 48,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "Ru5nuPYAAAAJ",
+      "name": "Grant E. Donnelly",
+      "publications": 40,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "4KCWk_YAAAAJ",
+      "name": "Harald H.H.W. Schmidt",
+      "publications": 419,
+      "reason": "dotted-initials",
+      "traits": [
+        "unicode-dash-authors",
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "TF4817UAAAAJ",
+      "name": "J.W.B. Bos",
+      "publications": 173,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "iS4HAEMAAAAJ",
+      "name": "James A. Densley",
+      "publications": 170,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "CtQqj9kAAAAJ",
+      "name": "Mathew S. Isaac",
+      "publications": 61,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "uTWBmVMAAAAJ",
+      "name": "Michail D. Kokkoris",
+      "publications": 33,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "o_vJLUkAAAAJ",
+      "name": "Oleg V. Petrenko",
+      "publications": 52,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "kplx7AUAAAAJ",
+      "name": "Rogier A. Kievit",
+      "publications": 176,
+      "reason": "dotted-initials",
+      "traits": [
+        "unicode-dash-authors",
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "DTjXb64AAAAJ",
+      "name": "Sebastian J. Goerg",
+      "publications": 62,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "Cp5t7D4AAAAJ",
+      "name": "Simon J. Blanchard",
+      "publications": 47,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "jVZ6rbMAAAAJ",
+      "name": "Y. S. Scharp",
+      "publications": 24,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "lUkV58wAAAAJ",
+      "name": "Yochanan E. Bigman",
+      "publications": 34,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "O_YXPFsAAAAJ",
+      "name": "Yuosre F. Badir",
+      "publications": 90,
+      "reason": "dotted-initials",
+      "traits": [
+        "dotted-initials",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "mG4imMEAAAAJ",
+      "name": "Andrew Ng",
+      "publications": 530,
+      "reason": "heavy-ellipsis",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "BdwP-3QAAAAJ",
+      "name": "Chris Biemann",
+      "publications": 420,
+      "reason": "heavy-ellipsis",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "fH3wcA8AAAAJ",
+      "name": "Frank Teuteberg",
+      "publications": 535,
+      "reason": "heavy-ellipsis",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "3IeyXt4AAAAJ",
+      "name": "Ganesh Jeevanandan",
+      "publications": 245,
+      "reason": "heavy-ellipsis",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "nIYeV-wAAAAJ",
+      "name": "Harald Reiterer",
+      "publications": 418,
+      "reason": "heavy-ellipsis",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "DWhZ5wwAAAAJ",
+      "name": "Johan Stahre",
+      "publications": 235,
+      "reason": "heavy-ellipsis",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "hpEmhxwAAAAJ",
+      "name": "Marija Boskovic Cabrol",
+      "publications": 184,
+      "reason": "heavy-ellipsis",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "xtH9QNgAAAAJ",
+      "name": "Stijn Viaene",
+      "publications": 340,
+      "reason": "heavy-ellipsis",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "5Om6NYoAAAAJ",
+      "name": "Aires Oliva-Teles",
+      "publications": 332,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "Epn5U-0AAAAJ",
+      "name": "Annouk Lievens - Full Professor",
+      "publications": 106,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "ellipsis-authors",
+        "long-name"
+      ]
+    },
+    {
+      "scholarId": "h8LFExAAAAAJ",
+      "name": "David Simchi-Levi",
+      "publications": 533,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "W7_jNk0AAAAJ",
+      "name": "Eline CHM Haijen-Bongers",
+      "publications": 21,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "yYJ8kgsAAAAJ",
+      "name": "Enrique A. Lopez-Poveda",
+      "publications": 134,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "unicode-dash-authors",
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "4A1g8oIAAAAJ",
+      "name": "Ezgi Merdin-Uygur",
+      "publications": 27,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "B6-bWG0AAAAJ",
+      "name": "Jorge García-Márquez",
+      "publications": 49,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "unicode-dash-authors",
+        "non-ascii-name",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "tEMuAlAAAAAJ",
+      "name": "Jorge Serrano-Malebrán (ORCID: 0000-0001-6932-1556)",
+      "publications": 34,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "non-ascii-name",
+        "ellipsis-authors",
+        "long-name"
+      ]
+    },
+    {
+      "scholarId": "d8j0F2UAAAAJ",
+      "name": "Lilian Kloft-Heller",
+      "publications": 36,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "C65V52sAAAAJ",
+      "name": "Mariana Kovacic-Lukic",
+      "publications": 4,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "2wqk2I8AAAAJ",
+      "name": "Milda Aleknonyte-Resch",
+      "publications": 27,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "F0aVUUsAAAAJ",
+      "name": "Miriam Pein-Hackelbusch",
+      "publications": 62,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "EjLvG5cAAAAJ",
+      "name": "Zhi-Qin John Xu",
+      "publications": 89,
+      "reason": "hyphen-surname",
+      "traits": [
+        "hyphen-surname",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "3R9ZhooAAAAJ",
+      "name": "Christopher Jr. Galgo",
+      "publications": 13,
+      "reason": "known-failure",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ],
+      "knownHardDuplicatePairs": [
+        "GA Nuhoff-Isakhanyan ~ G Isakhanyan"
+      ]
+    },
+    {
+      "scholarId": "MQYmyq8AAAAJ",
+      "name": "Cristóbal Rodríguez Montoya",
+      "publications": 16,
+      "reason": "known-failure",
+      "traits": [
+        "non-ascii-name",
+        "owner-variant-in-bylines"
+      ],
+      "knownHardDuplicatePairs": [
+        "DF Rodríguez ~ D Frias-Rodriguez"
+      ]
+    },
+    {
+      "scholarId": "RpnPbawAAAAJ",
+      "name": "Dr. Nicolás Gambetta",
+      "publications": 38,
+      "reason": "known-failure",
+      "traits": [
+        "unicode-dash-authors",
+        "non-ascii-name",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ],
+      "knownHardDuplicatePairs": [
+        "MA García-Benau ~ MA García Benau"
+      ]
+    },
+    {
+      "scholarId": "shvUseUAAAAJ",
+      "name": "Joan Díaz-Calafat",
+      "publications": 35,
+      "reason": "known-failure",
+      "traits": [
+        "hyphen-surname",
+        "unicode-dash-authors",
+        "non-ascii-name",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "dqylc-oAAAAJ",
+      "name": "Bruce D. McDonald, III",
+      "publications": 133,
+      "reason": "long-name",
+      "traits": [
+        "dotted-initials",
+        "ellipsis-authors",
+        "long-name",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "yHRow5QAAAAJ",
+      "name": "Henry Surendra, MPH, PhD, FRSPH",
+      "publications": 52,
+      "reason": "long-name",
+      "traits": [
+        "ellipsis-authors",
+        "long-name"
+      ]
+    },
+    {
+      "scholarId": "sPE5wx0AAAAJ",
+      "name": "Hussain Bakhsh Magsi, PhD",
+      "publications": 15,
+      "reason": "long-name",
+      "traits": [
+        "long-name"
+      ]
+    },
+    {
+      "scholarId": "Sh1lWK8AAAAJ",
+      "name": "Sudipta Bose PhD (UNSW), MBA, BBA (HONS) in AIS, FULT (UNSW), CA, FCMA",
+      "publications": 79,
+      "reason": "long-name",
+      "traits": [
+        "long-name"
+      ]
+    },
+    {
+      "scholarId": "n1JYiwQAAAAJ",
+      "name": "Agnes Koschmider",
+      "publications": 192,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "qc6CJjYAAAAJ",
+      "name": "Albert Einstein",
+      "publications": 787,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "187v9RoAAAAJ",
+      "name": "Alexander Richter",
+      "publications": 230,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "mzZgjzQAAAAJ",
+      "name": "Bankole Ositadimma Awuzie",
+      "publications": 224,
+      "reason": "negative-control",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "61DvKEIAAAAJ",
+      "name": "Chris Easthope Awai",
+      "publications": 128,
+      "reason": "negative-control",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "vkX6VV4AAAAJ",
+      "name": "Cornelia Caragea",
+      "publications": 265,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "21lh8nMAAAAJ",
+      "name": "David Cropley",
+      "publications": 286,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "adnaVp0AAAAJ",
+      "name": "Dhruv Grewal",
+      "publications": 540,
+      "reason": "negative-control",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "09P2NX4AAAAJ",
+      "name": "Dominik Mahr",
+      "publications": 165,
+      "reason": "negative-control",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "OYOyw_gAAAAJ",
+      "name": "Dr. Erose Sthapit",
+      "publications": 149,
+      "reason": "negative-control",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "JicYPdAAAAAJ",
+      "name": "Geoffrey Hinton",
+      "publications": 766,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "E3oBkwwAAAAJ",
+      "name": "Ioannis Pavlidis",
+      "publications": 195,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "xYIyKJ0AAAAJ",
+      "name": "Joan Alexander",
+      "publications": 347,
+      "reason": "negative-control",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "3C6mgNUAAAAJ",
+      "name": "Kai Sassenberg",
+      "publications": 306,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "75YwWu4AAAAJ",
+      "name": "Mohamed Zaki",
+      "publications": 143,
+      "reason": "negative-control",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "vMdOAHIAAAAJ",
+      "name": "Nawi Ng",
+      "publications": 273,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "Dkra6uYAAAAJ",
+      "name": "Peter Seele",
+      "publications": 352,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "B7vSqZsAAAAJ",
+      "name": "Richard Feynman",
+      "publications": 152,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "l0VKMyEAAAAJ",
+      "name": "Yulin Fang",
+      "publications": 195,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "KnM_DK0AAAAJ",
+      "name": "Zoltan Nagy",
+      "publications": 206,
+      "reason": "negative-control",
+      "traits": [
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "T5X72hwAAAAJ",
+      "name": "André Bittermann",
+      "publications": 67,
+      "reason": "non-ascii-name",
+      "traits": [
+        "non-ascii-name",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "aty2ycAAAAAJ",
+      "name": "Carl Cederström",
+      "publications": 48,
+      "reason": "non-ascii-name",
+      "traits": [
+        "non-ascii-name",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "JCxWTyYAAAAJ",
+      "name": "David M. Woisetschläger",
+      "publications": 186,
+      "reason": "non-ascii-name",
+      "traits": [
+        "non-ascii-name",
+        "dotted-initials",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "QvBkWlIAAAAJ",
+      "name": "Elisabeth Brüggen",
+      "publications": 80,
+      "reason": "non-ascii-name",
+      "traits": [
+        "non-ascii-name",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "X1AcSacAAAAJ",
+      "name": "Enric Junqué de Fortuny",
+      "publications": 24,
+      "reason": "non-ascii-name",
+      "traits": [
+        "non-ascii-name",
+        "particle-surname",
+        "ellipsis-authors",
+        "long-name",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "YLiYwbgAAAAJ",
+      "name": "Joachim Hüffmeier",
+      "publications": 140,
+      "reason": "non-ascii-name",
+      "traits": [
+        "unicode-dash-authors",
+        "non-ascii-name",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "oOwp60UAAAAJ",
+      "name": "Rui Magalhães",
+      "publications": 83,
+      "reason": "non-ascii-name",
+      "traits": [
+        "unicode-dash-authors",
+        "non-ascii-name",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "circGHIAAAAJ",
+      "name": "Simon Hazée",
+      "publications": 13,
+      "reason": "non-ascii-name",
+      "traits": [
+        "non-ascii-name",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "a97doIsScwwC",
+      "name": "Thomas Gültzow",
+      "publications": 63,
+      "reason": "non-ascii-name",
+      "traits": [
+        "non-ascii-name",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "r74adIwAAAAJ",
+      "name": "Tim Döring",
+      "publications": 15,
+      "reason": "non-ascii-name",
+      "traits": [
+        "non-ascii-name",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "5izLickAAAAJ",
+      "name": "Torbjörn Törnqvist",
+      "publications": 257,
+      "reason": "non-ascii-name",
+      "traits": [
+        "non-ascii-name",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "UGVOZHcAAAAJ",
+      "name": "Eelke de Vries",
+      "publications": 8,
+      "reason": "particle-surname",
+      "traits": [
+        "particle-surname",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "qamp828AAAAJ",
+      "name": "Emiel van Miltenburg",
+      "publications": 73,
+      "reason": "particle-surname",
+      "traits": [
+        "particle-surname",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "P0LCVa0AAAAJ",
+      "name": "Freya De Keyzer",
+      "publications": 34,
+      "reason": "particle-surname",
+      "traits": [
+        "particle-surname",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "Zjjb6TAAAAAJ",
+      "name": "Hans De Witte",
+      "publications": 1000,
+      "reason": "particle-surname",
+      "traits": [
+        "unicode-dash-authors",
+        "particle-surname",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "2WLDJQoAAAAJ",
+      "name": "Henrico van Roekel",
+      "publications": 19,
+      "reason": "particle-surname",
+      "traits": [
+        "particle-surname",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "THsg1_IAAAAJ",
+      "name": "Ko de Ruyter",
+      "publications": 898,
+      "reason": "particle-surname",
+      "traits": [
+        "particle-surname",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "6Zl4y4AAAAAJ",
+      "name": "Leander De Schutter",
+      "publications": 34,
+      "reason": "particle-surname",
+      "traits": [
+        "particle-surname",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "Of6j1JoAAAAJ",
+      "name": "Zeph M. C. van Berlo",
+      "publications": 45,
+      "reason": "particle-surname",
+      "traits": [
+        "particle-surname",
+        "dotted-initials",
+        "ellipsis-authors",
+        "long-name",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "s4jwRQsAAAAJ",
+      "name": "Ana Couto",
+      "publications": 109,
+      "reason": "unicode-dash-authors",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "jSB6BvEAAAAJ",
+      "name": "Gaby Odekerken",
+      "publications": 184,
+      "reason": "unicode-dash-authors",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "umNXsm4AAAAJ",
+      "name": "Helena Peres",
+      "publications": 220,
+      "reason": "unicode-dash-authors",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "CdvVaskAAAAJ",
+      "name": "Jacobus FA Jansen",
+      "publications": 407,
+      "reason": "unicode-dash-authors",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines",
+        "same-surname-different-person"
+      ]
+    },
+    {
+      "scholarId": "9YqWLuUAAAAJ",
+      "name": "Paula Enes",
+      "publications": 89,
+      "reason": "unicode-dash-authors",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "KWoTqRsAAAAJ",
+      "name": "Ryan Federo",
+      "publications": 58,
+      "reason": "unicode-dash-authors",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    },
+    {
+      "scholarId": "FUmCeWYAAAAJ",
+      "name": "Zhonghua Gou",
+      "publications": 261,
+      "reason": "unicode-dash-authors",
+      "traits": [
+        "unicode-dash-authors",
+        "ellipsis-authors",
+        "owner-variant-in-bylines"
+      ]
+    }
+  ]
+}

--- a/scripts/name-audit/run.ts
+++ b/scripts/name-audit/run.ts
@@ -1,0 +1,250 @@
+/**
+ * Author-name matching audit.
+ *
+ *   npx tsx scripts/name-audit/run.ts            # summary
+ *   npx tsx scripts/name-audit/run.ts --verbose  # per-profile detail
+ *   npx tsx scripts/name-audit/run.ts --json     # machine-readable
+ *
+ * Recomputes co-author metrics for the fixed sample in profiles.json using the
+ * live application code, then checks the invariants that user-reported name
+ * bugs violated. Reads cached profiles straight from scholar_cache, so it
+ * costs nothing and never touches the paid fetch path.
+ *
+ * Exits non-zero when a NEW failure appears. Cases listed as knownHard* in the
+ * fixture are reported separately: they are tracked limitations, not
+ * regressions, and the run stays green while they persist. Fixing one is
+ * expected to also remove it from the fixture.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { calculateCoAuthorMetrics } from '../../src/services/metrics/collaboration/co-author-metrics';
+import {
+  canonicalNameKey,
+  extractLastName,
+  foldNamePunctuation,
+  normalizeAuthorNames,
+  surnamesCompatible,
+} from '../../src/utils/names';
+
+const SUPABASE_URL = 'https://mixaxkywkojoclgbjjur.supabase.co';
+// Publishable key — safe to embed, same as client-side
+const SUPABASE_KEY = 'sb_publishable_oKej73idzSJ1eJqwmgF5WQ_m2rvKae5';
+
+interface FixtureProfile {
+  scholarId: string;
+  name: string;
+  publications: number;
+  reason: string;
+  traits: string[];
+  knownHardSelfListed?: string[];
+  knownHardDuplicatePairs?: string[];
+}
+
+interface Pub { title: string; authors: string[]; citations: number; year: number; venue?: string; type?: string }
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixture = JSON.parse(readFileSync(join(here, 'profiles.json'), 'utf8')) as {
+  profiles: FixtureProfile[];
+};
+
+const verbose = process.argv.includes('--verbose');
+const asJson = process.argv.includes('--json');
+/** Sweep every cached profile instead of the fixed sample. Broader coverage,
+ *  but the set drifts as the cache changes — use the sample for CI. */
+const sweepAll = process.argv.includes('--all');
+
+/** Initials of the given-name part, hyphenated names expanded per component. */
+function givenInitials(name: string): string[] {
+  return canonicalNameKey(name)
+    .split(/\s+/)
+    .slice(0, -1)
+    .flatMap(token => token.split('-'))
+    .map(token => token[0])
+    .filter(Boolean);
+}
+
+/** Do two names plausibly denote one person? Compatible surname plus one
+ *  initials sequence being a prefix of the other. Intentionally looser than
+ *  the production owner check so the audit surfaces borderline cases rather
+ *  than rubber-stamping whatever the current rules happen to accept. */
+function likelySamePerson(a: string, b: string): boolean {
+  const lastA = extractLastName(foldNamePunctuation(a));
+  const lastB = extractLastName(foldNamePunctuation(b));
+  if (!surnamesCompatible(lastA, lastB)) return false;
+  const ia = givenInitials(a);
+  const ib = givenInitials(b);
+  if (ia.length === 0 || ib.length === 0) return false;
+  const [short, long] = ia.length <= ib.length ? [ia, ib] : [ib, ia];
+  return short.every((ch, i) => ch === long[i]);
+}
+
+const TRUNCATION = /^[.…\s]+$/;
+
+interface Finding { profile: string; kind: string; detail: string; known: boolean }
+
+async function fetchProfile(scholarId: string): Promise<{ name: string; publications: Pub[] } | null> {
+  const url = `https://scholar.google.com/citations?user=${scholarId}`;
+  const endpoint = `${SUPABASE_URL}/rest/v1/scholar_cache?url=eq.${encodeURIComponent(url)}&select=data&limit=1`;
+  const res = await fetch(endpoint, {
+    headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` },
+  });
+  if (!res.ok) return null;
+  const rows = (await res.json()) as Array<{ data: { name?: string; publications?: Pub[] } }>;
+  const data = rows[0]?.data;
+  if (!data?.name || !data.publications?.length) return null;
+  return { name: data.name, publications: data.publications };
+}
+
+/** Every cached Google Scholar profile, paged. */
+async function fetchAllCached(): Promise<FixtureProfile[]> {
+  const out: FixtureProfile[] = [];
+  const seen = new Set<string>();
+  for (let offset = 0; ; offset += 500) {
+    const endpoint = `${SUPABASE_URL}/rest/v1/scholar_cache`
+      + `?select=url,data&url=like.https%3A%2F%2Fscholar.google.com%2Fcitations%3Fuser%3D*`
+      + `&limit=500&offset=${offset}`;
+    const res = await fetch(endpoint, {
+      headers: { apikey: SUPABASE_KEY, Authorization: `Bearer ${SUPABASE_KEY}` },
+    });
+    if (!res.ok) break;
+    const rows = (await res.json()) as Array<{ url: string; data: { name?: string; publications?: Pub[] } }>;
+    if (!rows.length) break;
+    for (const row of rows) {
+      const id = row.url.match(/user=([A-Za-z0-9_-]+)/)?.[1];
+      if (!id || seen.has(id)) continue;
+      if (!row.data?.name || !row.data.publications?.length) continue;
+      seen.add(id);
+      out.push({
+        scholarId: id,
+        name: row.data.name,
+        publications: row.data.publications.length,
+        reason: 'cache-sweep',
+        traits: [],
+      });
+    }
+    if (rows.length < 500) break;
+  }
+  return out;
+}
+
+async function main() {
+  const findings: Finding[] = [];
+  const rows: Array<Record<string, unknown>> = [];
+  let missing = 0;
+  let checked = 0;
+
+  const targets = sweepAll ? await fetchAllCached() : fixture.profiles;
+  // Keep the fixture's accepted findings when sweeping, so a full run still
+  // distinguishes tracked limitations from new problems.
+  const knownByProfile = new Map(fixture.profiles.map(p => [p.scholarId, p]));
+
+  for (const target of targets) {
+    const entry = sweepAll
+      ? { ...target, ...(knownByProfile.get(target.scholarId) ?? {}) }
+      : target;
+    const profile = await fetchProfile(entry.scholarId);
+    if (!profile) {
+      missing++;
+      if (verbose) console.log(`  SKIP  ${entry.name} (no longer in cache)`);
+      continue;
+    }
+    checked++;
+
+    // Same pipeline the app runs on every profile load.
+    const pubs = JSON.parse(JSON.stringify(profile.publications)) as Pub[];
+    normalizeAuthorNames(pubs);
+    const metrics = calculateCoAuthorMetrics(pubs as never, profile.name);
+    const coAuthors = metrics.topCoAuthors.map(c => c.name);
+
+    const knownSelf = new Set(entry.knownHardSelfListed ?? []);
+    const knownDup = new Set(entry.knownHardDuplicatePairs ?? []);
+
+    // A. the profile owner must never rank as their own collaborator
+    for (const name of coAuthors) {
+      if (likelySamePerson(name, profile.name)) {
+        findings.push({
+          profile: profile.name,
+          kind: 'self-listed',
+          detail: name,
+          known: knownSelf.has(name),
+        });
+      }
+    }
+
+    // B. truncation markers are not people
+    for (const name of coAuthors) {
+      if (TRUNCATION.test(name)) {
+        findings.push({ profile: profile.name, kind: 'truncation-marker', detail: name, known: false });
+      }
+    }
+
+    // C. two entries in one co-author list that denote the same person
+    for (let i = 0; i < coAuthors.length; i++) {
+      for (let j = i + 1; j < coAuthors.length; j++) {
+        if (likelySamePerson(coAuthors[i], coAuthors[j])) {
+          const pair = `${coAuthors[i]} ~ ${coAuthors[j]}`;
+          const alt = `${coAuthors[j]} ~ ${coAuthors[i]}`;
+          findings.push({
+            profile: profile.name,
+            kind: 'duplicate-co-authors',
+            detail: pair,
+            known: knownDup.has(pair) || knownDup.has(alt),
+          });
+        }
+      }
+    }
+
+    // D. over-filtering guard: a collaborative profile must yield collaborators
+    const multiAuthor = pubs.filter(p => (p.authors || []).length > 1).length;
+    if (multiAuthor >= 5 && coAuthors.length === 0) {
+      findings.push({
+        profile: profile.name,
+        kind: 'no-co-authors',
+        detail: `${multiAuthor} multi-author publications but no collaborators found`,
+        known: false,
+      });
+    }
+
+    rows.push({
+      name: profile.name,
+      reason: entry.reason,
+      publications: pubs.length,
+      topCoAuthor: metrics.topCoAuthor,
+      totalCoAuthors: metrics.totalCoAuthors,
+    });
+    if (verbose) {
+      console.log(`  ${profile.name}\n      top=${metrics.topCoAuthor || '(none)'}  coAuthors=${metrics.totalCoAuthors}  [${entry.reason}]`);
+    }
+  }
+
+  const regressions = findings.filter(f => !f.known);
+  const known = findings.filter(f => f.known);
+
+  if (asJson) {
+    console.log(JSON.stringify({ checked, missing, regressions, known, rows }, null, 2));
+  } else {
+    console.log(`\nname-audit: ${checked} profiles checked${missing ? `, ${missing} missing from cache` : ''}`);
+    const byKind = (list: Finding[]) => {
+      const m = new Map<string, number>();
+      for (const f of list) m.set(f.kind, (m.get(f.kind) ?? 0) + 1);
+      return [...m].map(([k, v]) => `${k}=${v}`).join('  ') || 'none';
+    };
+    console.log(`known limitations : ${byKind(known)}`);
+    console.log(`REGRESSIONS       : ${byKind(regressions)}`);
+    for (const f of regressions) {
+      console.log(`   ✗ [${f.kind}] ${f.profile}: ${f.detail}`);
+    }
+    if (verbose && known.length) {
+      console.log('\ntracked known-hard cases:');
+      for (const f of known) console.log(`   · [${f.kind}] ${f.profile}: ${f.detail}`);
+    }
+  }
+
+  process.exit(regressions.length > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('name-audit failed:', err);
+  process.exit(2);
+});

--- a/src/services/metrics/collaboration/co-author-metrics.ts
+++ b/src/services/metrics/collaboration/co-author-metrics.ts
@@ -51,21 +51,28 @@ function parseName(normalized: string): { given: string[]; last: string } {
   };
 }
 
-/** Same cleaning as normalizeName but keeps casing, so initials blocks stay
- *  detectable ("RFJ" vs "Ann"). */
+/** Same cleaning as normalizeName but keeps casing AND diacritics: casing is
+ *  what distinguishes an initials block ("RFJ") from a short given name
+ *  ("Ann"), and the diacritics are needed to tell "Schäfer" from "Schafer"
+ *  when matching against the "Schaefer" spelling. */
 function cleanKeepCase(name: string): string {
   return foldNamePunctuation(name)
-    .normalize('NFD').replace(/[̀-ͯ]/g, '')
     .replace(/[.,;:'"()]/g, '')
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+/** Strip diacritics for letter-shape tests, without lowercasing. */
+function bareLetters(token: string): string {
+  return token.normalize('NFD').replace(/[̀-ͯ]/g, '');
 }
 
 /** A compact block of initials: "R", "RFJ", "HHHW" — all caps, ≤5 letters —
  *  or a ≤2-char token, which is an initials form regardless of casing. */
 function isInitialsBlock(token: string): boolean {
   if (!token) return false;
-  return /^[A-Z]{1,5}$/.test(token) || token.length <= 2;
+  const bare = bareLetters(token);
+  return /^[A-Z]{1,5}$/.test(bare) || bare.length <= 2;
 }
 
 /** Expand given names into their initials sequence:
@@ -76,10 +83,13 @@ function initialsSequence(given: string[]): string[] {
   const out: string[] = [];
   for (const token of given) {
     for (const part of token.split('-').filter(Boolean)) {
+      // Compare on the diacritic-stripped letter so "Á" and "A" agree.
+      const bare = canonicalNameKey(part);
+      if (!bare) continue;
       if (isInitialsBlock(part)) {
-        for (const ch of part) out.push(ch.toLowerCase());
+        for (const ch of bare) out.push(ch);
       } else {
-        out.push(part[0].toLowerCase());
+        out.push(bare[0]);
       }
     }
   }
@@ -175,32 +185,82 @@ function isSameAuthor(nameA: string, nameB: string): boolean {
  *  the owner's first initial and publishes under two initials — rare and
  *  low-harm — and in exchange the owner never appears as their own collaborator. */
 function isProfileOwner(coAuthor: string, owner: string): boolean {
+  if (!isRealAuthorName(coAuthor)) return false;
   if (isSameAuthor(coAuthor, owner)) return true;
 
-  const a = parseName(normalizeName(coAuthor));
-  const b = parseName(normalizeName(owner));
-  if (!a.last || a.given.length === 0 || b.given.length === 0) return false;
-  // Surnames may differ by a maiden/married component ("MK Pein" vs
-  // "M Pein-Hackelbusch"): authors keep publishing under both, and without
-  // this they rank as their own most frequent collaborator.
-  if (!surnamesCompatible(a.last, b.last)) return false;
-
-  // Case-preserved parse: only the original casing distinguishes an initials
-  // block ("RFJ") from a short given name ("Ann").
+  // Case- and diacritic-preserving parse. Casing is what distinguishes an
+  // initials block ("RFJ") from a short given name ("Ann"), and the umlauts
+  // must survive for surname comparison ("Schäfer" vs "Schaefer") — the
+  // normalized parse has already stripped them.
   const aOrig = parseName(cleanKeepCase(coAuthor));
   const bOrig = parseName(cleanKeepCase(owner));
-  if (!aOrig.given.every(isInitialsBlock)) return false;
+  if (!aOrig.last || aOrig.given.length === 0 || bOrig.given.length === 0) return false;
 
   // The byline often carries more initials than the profile name
   // ("Marnik Dekimpe" → "MGM Dekimpe", "Richard F.J. Haans" → "RFJ Haans").
-  // Treat them as the same person when one initials sequence is a prefix of
-  // the other — a different first initial still means a different person.
+  // Same person when one initials sequence is a prefix of the other; a
+  // different initial anywhere still means a different person.
+  const initialsCompatible = (a: string[], b: string[]): boolean => {
+    if (a.length === 0 || b.length === 0) return false;
+    const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
+    return shorter.every((ch, i) => ch === longer[i]);
+  };
+
   const aInitials = initialsSequence(aOrig.given);
   const bInitials = initialsSequence(bOrig.given);
-  if (aInitials.length === 0 || bInitials.length === 0) return false;
-  const shorter = aInitials.length <= bInitials.length ? aInitials : bInitials;
-  const longer = aInitials.length <= bInitials.length ? bInitials : aInitials;
-  return shorter.every((ch, i) => ch === longer[i]);
+
+  // Surnames may differ by a maiden/married component ("MK Pein" vs
+  // "M Pein-Hackelbusch") or by spelling ("Schäfer"/"Schaefer"): authors keep
+  // publishing under all of them, and without this they rank as their own most
+  // frequent collaborator.
+  if (
+    surnamesCompatible(aOrig.last, bOrig.last)
+    && aOrig.given.every(isInitialsBlock)
+    && initialsCompatible(aInitials, bInitials)
+  ) {
+    return true;
+  }
+
+  // Compound surnames written with a space instead of a hyphen, and
+  // Spanish/Portuguese double surnames ("Joan Díaz-Calafat" vs "J Diaz
+  // Calafat"): the surname spills into tokens the parser read as given names.
+  // Compare the trailing tokens as a component SET, which must match exactly —
+  // a subset would merge "J García" into "Juan García López", i.e. anyone
+  // sharing one surname.
+  return compoundSurnamesMatch(aOrig, bOrig) && initialsCompatible(aInitials, bInitials);
+}
+
+/** Surname component sets built from the trailing tokens, for names whose
+ *  compound surname isn't marked by a hyphen. Only considers splits that leave
+ *  at least one given-name token, and only multi-component surnames — single
+ *  surnames are already handled by surnamesCompatible. */
+function surnameComponentSets(parsed: { given: string[]; last: string }): Array<Set<string>> {
+  const tokens = [...parsed.given, ...parsed.last.split(/\s+/).filter(Boolean)];
+  const sets: Array<Set<string>> = [];
+  for (let take = 1; take <= 2 && take < tokens.length; take++) {
+    const tail = tokens.slice(tokens.length - take);
+    const components = tail
+      .flatMap(token => token.split('-'))
+      .map(part => canonicalNameKey(part))
+      .filter(part => part.length >= 3);
+    if (components.length >= 2) sets.push(new Set(components));
+  }
+  return sets;
+}
+
+function compoundSurnamesMatch(
+  a: { given: string[]; last: string },
+  b: { given: string[]; last: string }
+): boolean {
+  const setsA = surnameComponentSets(a);
+  const setsB = surnameComponentSets(b);
+  for (const sa of setsA) {
+    for (const sb of setsB) {
+      if (sa.size !== sb.size) continue;
+      if ([...sa].every(part => sb.has(part))) return true;
+    }
+  }
+  return false;
 }
 
 // Venues that indicate non-journal output, used only for Google Scholar profiles

--- a/src/utils/names.ts
+++ b/src/utils/names.ts
@@ -49,12 +49,45 @@ export function canonicalNameKey(name: string): string {
 }
 
 /**
+ * Comparison key that spells umlauts and related letters out as the digraphs
+ * used when a name is typed on an ASCII keyboard: Müller → "mueller", so it
+ * matches a byline written "Mueller". `canonicalNameKey` strips the diacritic
+ * instead ("muller"), which matches "Muller"; comparing under both keys covers
+ * all three spellings a German or Nordic name appears in.
+ *
+ * Deliberately expands rather than collapses. Collapsing digraphs to the base
+ * vowel would also merge genuinely distinct surnames — measured against the
+ * cache it conflated Yu/Yue, Cho/Choe, Sun/Suen and Baur/Bauer.
+ */
+export function umlautExpandedKey(name: string): string {
+  return foldNamePunctuation(name)
+    .toLowerCase()
+    .replace(/ä/g, 'ae').replace(/ö/g, 'oe').replace(/ü/g, 'ue')
+    .replace(/ß/g, 'ss')
+    .replace(/æ/g, 'ae').replace(/ø/g, 'oe').replace(/å/g, 'aa')
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .replace(/[.,;:'"()]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** True when two name fragments match under either normalization — diacritic
+ *  stripped ("Müller" = "Muller") or umlaut expanded ("Müller" = "Mueller"). */
+export function nameFragmentsEquivalent(a: string, b: string): boolean {
+  if (!a || !b) return false;
+  return canonicalNameKey(a) === canonicalNameKey(b)
+    || umlautExpandedKey(a) === umlautExpandedKey(b);
+}
+
+/**
  * Split a surname into its meaningful components: "pein-hackelbusch" →
  * ["pein", "hackelbusch"]. Used to recognise maiden/married name pairs, where
  * one surname is a component of the other.
  */
 export function surnameComponents(lastName: string): string[] {
-  return canonicalNameKey(lastName)
+  // Punctuation-folded but NOT diacritic-stripped: callers compare components
+  // with nameFragmentsEquivalent, which needs the umlauts intact.
+  return foldNamePunctuation(lastName)
     .split(/[-\s]+/)
     .map(part => part.trim())
     .filter(Boolean);
@@ -68,21 +101,21 @@ export function surnameComponents(lastName: string): string[] {
  * unrelated surnames. Callers must additionally check given names.
  */
 export function surnamesCompatible(lastA: string, lastB: string): boolean {
-  const a = canonicalNameKey(lastA);
-  const b = canonicalNameKey(lastB);
-  if (!a || !b) return false;
-  if (a === b) return true;
+  if (!canonicalNameKey(lastA) || !canonicalNameKey(lastB)) return false;
+  // Compare the originals: canonicalizing first would strip the umlaut that
+  // the expanded-key comparison needs (Müller vs Mueller).
+  if (nameFragmentsEquivalent(lastA, lastB)) return true;
 
-  const partsA = surnameComponents(a);
-  const partsB = surnameComponents(b);
+  const partsA = surnameComponents(lastA);
+  const partsB = surnameComponents(lastB);
   if (partsA.length === 0 || partsB.length === 0) return false;
   // Only bridge when one side is a single surname contained in the other's
   // compound form — never merge two different compounds.
   const single = partsA.length === 1 ? partsA[0] : partsB.length === 1 ? partsB[0] : null;
-  if (!single || single.length < 3) return false;
+  if (!single || canonicalNameKey(single).length < 3) return false;
   const compound = partsA.length === 1 ? partsB : partsA;
   if (compound.length < 2) return false;
-  return compound.includes(single);
+  return compound.some(part => nameFragmentsEquivalent(part, single));
 }
 
 /**
@@ -175,26 +208,57 @@ export function normalizeAuthorNames(publications: { authors: string[] }[]): typ
     }
   }
 
-  // Build a fuzzy key for each name: "baselastname|firstinitial" (lowercased, prefix-stripped)
-  function fuzzyKey(name: string): string {
+  // Two fuzzy keys per name — "baselastname|firstinitial" under each surname
+  // normalization. A German name reaches us spelled three ways (Müller,
+  // Muller, Mueller); the diacritic-stripped key unites the first two and the
+  // umlaut-expanded key the first and third, so grouping under both keys
+  // brings all three together without merging unrelated surnames.
+  function fuzzyKeys(name: string): string[] {
     // Fold Unicode punctuation first so "Pein‐Hackelbusch" (U+2010) and
     // "Pein-Hackelbusch" (ASCII) land in the same group.
     const trimmed = foldNamePunctuation(name);
-    if (!trimmed) return '';
-    const lastName = extractLastName(trimmed);
-    const baseLast = canonicalNameKey(stripLastNamePrefix(lastName));
+    if (!trimmed) return [];
+    const lastName = stripLastNamePrefix(extractLastName(trimmed));
     const firstPart = trimmed.split(/\s+/)[0];
     const firstInitial = firstPart ? firstPart[0].toLowerCase() : '';
-    return `${baseLast}|${firstInitial}`;
+    const canon = canonicalNameKey(lastName);
+    const expanded = umlautExpandedKey(lastName);
+    if (!canon && !expanded) return [];
+    // Deliberately one shared namespace: an umlaut name's expanded key must be
+    // able to meet a digraph name's plain key ("Müller" → mueller ← "Mueller").
+    const keys = [`${canon}|${firstInitial}`];
+    if (expanded && expanded !== canon) keys.push(`${expanded}|${firstInitial}`);
+    return keys;
   }
 
-  // Group names by fuzzy key
+  // Union-find over names, joined by any shared key.
+  const parent = new Map<string, string>();
+  const find = (x: string): string => {
+    let root = x;
+    while (parent.get(root) !== root) root = parent.get(root)!;
+    while (parent.get(x) !== root) { const next = parent.get(x)!; parent.set(x, root); x = next; }
+    return root;
+  };
+  const union = (a: string, b: string) => {
+    const ra = find(a), rb = find(b);
+    if (ra !== rb) parent.set(ra, rb);
+  };
+  for (const name of nameFreq.keys()) if (!parent.has(name)) parent.set(name, name);
+  const keyOwner = new Map<string, string>();
+  for (const name of nameFreq.keys()) {
+    for (const key of fuzzyKeys(name)) {
+      const seen = keyOwner.get(key);
+      if (seen) union(name, seen);
+      else keyOwner.set(key, name);
+    }
+  }
+
   const groups = new Map<string, string[]>();
   for (const name of nameFreq.keys()) {
-    const key = fuzzyKey(name);
-    if (!key) continue;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key)!.push(name);
+    if (fuzzyKeys(name).length === 0) continue;
+    const root = find(name);
+    if (!groups.has(root)) groups.set(root, []);
+    groups.get(root)!.push(name);
   }
 
   // Count non-initial words before the last name (words with >2 chars that aren't the last name)
@@ -210,11 +274,12 @@ export function normalizeAuthorNames(publications: { authors: string[] }[]): typ
   for (const variants of groups.values()) {
     if (variants.length <= 1) continue;
 
-    // Safety check: all variants must have same base last name (prefix-stripped, case-insensitive)
-    const baseLastNames = new Set(variants.map(v =>
-      canonicalNameKey(stripLastNamePrefix(extractLastName(foldNamePunctuation(v))))
-    ));
-    if (baseLastNames.size > 1) continue;
+    // Safety check: every variant's base surname must be mutually equivalent —
+    // identical once diacritics are stripped, or once umlauts are spelled out.
+    const baseLastNames = variants.map(v =>
+      stripLastNamePrefix(extractLastName(foldNamePunctuation(v)))
+    );
+    if (!baseLastNames.every(l => nameFragmentsEquivalent(l, baseLastNames[0]))) continue;
 
     // Safety check: reject groups where variants have different numbers of
     // non-initial words before the last name (e.g. "J Bloemer" vs "J Sit Bloemer")


### PR DESCRIPTION
Follow-up to #292/#293, answering "are all the false-duplication classes actually covered?" — they were not. This adds the missing ones and a harness that makes the answer checkable.

## Matching improvements
- **German umlauts / ß**: `Müller`↔`Mueller`↔`Muller`, `Schäfer`↔`Schaefer`, `Köhler`↔`Koehler`, `Hübner`↔`Huebner`, `Strauß`↔`Strauss`.
- **Nordic**: `Møller`↔`Moeller`, `Åkesson`↔`Aakesson`, `Ærø`↔`Aeroe`, `Törnqvist`↔`Toernqvist`.
- **Spanish/Portuguese double surnames** written with a space instead of a hyphen: `Joan Díaz-Calafat` ↔ `J Diaz Calafat`, `María Antonia García Benau` ↔ `MA García-Benau`.
- Root bug behind several of these: diacritics were stripped *before* the comparison that needed them.

**Direction matters.** Umlauts are expanded (`ü`→`ue`), never collapsed (`ue`→`u`). Measured against the cache, collapsing merges genuinely distinct surnames — **Yu/Yue, Cho/Choe, Sun/Suen, Baur/Bauer** — so it is not worth the extra coverage. The one case that costs us is `Muller`↔`Mueller` when *neither* is spelled with the umlaut; that is tracked as a known limitation.

## The audit (`scripts/name-audit/`)
- **`cases.ts`** — 58 cases across eleven classes: hyphenated/compound surnames, maiden↔married, umlauts, Nordic, Spanish/Portuguese, multiple given names, particles, CJK/romanisation, apostrophes, truncation markers, and pairs of real distinct people. Every class has **negative controls**, so a matcher that merges everything fails rather than passes. Known limitations are asserted as `xfail` and reported if they start passing.
- **`run.ts`** — replays the live pipeline over a stratified 100-profile sample (`--all` sweeps every cached profile) checking four invariants: no self-listing, no truncation markers, no duplicate co-authors, and no over-filtering. Reads `scholar_cache` directly — costs nothing, never triggers a paid fetch. Exits non-zero only on new failures, so it is CI-ready.
- **`profiles.json`** — deterministic sample (seed 42) stratified so rare structural cases are all present rather than left to chance.

## Results
| | |
|---|---|
| matrix | **55 passing, 0 regressions, 3 tracked limitations** |
| all 326 cached profiles | **0 regressions** |
| self-listings on real data | 28 → **0** |

The three tracked limitations are documented in the README with *why* each is hard: `Muller`/`Mueller` (see above), matching on one surname of a double surname (would merge anyone sharing it), and a dropped apostrophe (indistinguishable from a genuine two-token surname).
