### PR TITLE
Make error reporting prominent and reward it immediately

### DIFF
--- a/src/components/ResearcherNarrative.tsx
+++ b/src/components/ResearcherNarrative.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react'
 import { FileText, TrendingUp, Users, BookOpen, Award, Flag, Loader2, Check, Search } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { logCaughtError } from '../lib/errorLogger';
+import { useAuth } from '../contexts/AuthContext';
 import type { Author, CoAuthorGeoData, FieldNormalizedMetrics } from '../types/scholar';
 import type { PIndexResult } from '../services/openalex/pindex';
 import { findJournalRanking } from '../data/journalRankings';
@@ -867,10 +868,15 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
   const fieldMetricsParagraph = useMemo(() => generateFieldMetricsParagraph(data.fieldMetrics), [data.fieldMetrics]);
   const geoParagraph = useMemo(() => generateGeoParagraph(geoData), [geoData]);
   const citationDistParagraph = useMemo(() => generateCitationDistributionParagraph(data.metrics, data.totalCitations), [data.metrics, data.totalCitations]);
+  const { refreshCredits } = useAuth();
   const [showReport, setShowReport] = useState(false);
   const [reportMsg, setReportMsg] = useState('');
   const [reportEmail, setReportEmail] = useState('');
   const [reportStatus, setReportStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
+  const [reportError, setReportError] = useState<string | null>(null);
+  const [reportResult, setReportResult] = useState<
+    { creditsGranted: number; signedIn: boolean; emailLeft: boolean } | null
+  >(null);
 
   const scholarId = new URLSearchParams(window.location.search).get('user')
     || window.location.pathname.replace(/^\//, '').replace(/\/$/, '')
@@ -984,25 +990,50 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
   const handleReport = async () => {
     if (!reportMsg.trim()) return;
     setReportStatus('sending');
-    const { error } = await supabase.from('profile_reports').insert({
-      author_id: scholarId,
-      author_name: data.name,
-      reporter_email: reportEmail || null,
-      message: reportMsg.trim(),
-      page_url: window.location.href,
-    });
-    if (error) {
-      console.error('[Report] Insert failed:', error);
+    setReportError(null);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const res = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/report-profile`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
+          },
+          body: JSON.stringify({
+            authorId: scholarId,
+            authorName: data.name,
+            reporterEmail: reportEmail.trim() || null,
+            message: reportMsg.trim(),
+            pageUrl: window.location.href,
+          }),
+        }
+      );
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body?.error || 'Could not send your report.');
+      setReportResult({
+        creditsGranted: body.creditsGranted ?? 0,
+        signedIn: Boolean(body.signedIn),
+        emailLeft: Boolean(reportEmail.trim()),
+      });
+      // Credits land server-side; refresh the header so the new balance shows.
+      if (body.creditsGranted > 0) refreshCredits();
+      setReportStatus('sent');
+    } catch (err) {
+      logCaughtError(err, 'profile', 'ResearcherNarrative', 'submit-report');
+      setReportError(err instanceof Error ? err.message : 'Could not send your report.');
       setReportStatus('idle');
-      return;
     }
-    setReportStatus('sent');
-    setTimeout(() => {
-      setShowReport(false);
-      setReportMsg('');
-      setReportEmail('');
-      setReportStatus('idle');
-    }, 2000);
+  };
+
+  const closeReport = () => {
+    setShowReport(false);
+    setReportMsg('');
+    setReportEmail('');
+    setReportError(null);
+    setReportResult(null);
+    setReportStatus('idle');
   };
 
   return (
@@ -1013,32 +1044,72 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
           Research Profile
         </h3>
         <button
-          onClick={() => setShowReport(!showReport)}
-          className="inline-flex items-center gap-1 text-[10px] text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-          title="Report an error in this profile"
+          onClick={() => (showReport ? closeReport() : setShowReport(true))}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-full border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-900/20 text-amber-800 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-900/40 hover:border-amber-400 transition-colors"
+          title="Report an error in this profile — you'll get 3 credits as thanks"
         >
-          <Flag className="h-3 w-3" />
-          Report error
+          <Flag className="h-3.5 w-3.5" />
+          Report an error
+          <span className="text-[10px] font-semibold text-amber-700 dark:text-amber-400">+3 credits</span>
         </button>
       </div>
 
       {showReport && (
         <div className="mb-4 bg-gray-50 dark:bg-slate-800 rounded-lg p-4 border border-gray-200 dark:border-slate-700">
-          {reportStatus === 'sent' ? (
-            <div className="flex items-center gap-2 text-sm text-emerald-600">
-              <Check className="h-4 w-4" />
-              Thanks! We'll review this.
+          {reportStatus === 'sent' && reportResult ? (
+            <div className="space-y-2">
+              <div className="flex items-start gap-2">
+                <Check className="h-4 w-4 text-emerald-600 flex-shrink-0 mt-0.5" />
+                <div className="text-sm text-gray-700 dark:text-gray-300 space-y-2">
+                  <p>
+                    <strong className="text-gray-900 dark:text-gray-100">Sorry about that — and thank you.</strong>{' '}
+                    Wrong data on your own profile is genuinely annoying, and reports like
+                    yours are how we find these problems.
+                  </p>
+                  {reportResult.creditsGranted > 0 ? (
+                    <p className="text-emerald-700 dark:text-emerald-400 font-medium">
+                      We've added {reportResult.creditsGranted} free credits to your account right away.
+                    </p>
+                  ) : reportResult.signedIn ? (
+                    <p className="text-gray-500 dark:text-gray-400">
+                      You've already received the maximum thank-you credits — the report still helps just as much.
+                    </p>
+                  ) : (
+                    <p className="text-gray-500 dark:text-gray-400">
+                      Create a free account and future reports earn you 3 credits each.
+                    </p>
+                  )}
+                  <p>
+                    {reportResult.emailLeft
+                      ? "We'll follow up by email once we've looked into it."
+                      : 'We review every report. Next time you can leave an email if you\'d like a reply.'}
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={closeReport}
+                className="ml-6 px-3 py-1.5 text-xs font-medium text-white bg-[#2d7d7d] hover:bg-[#1f5c5c] rounded-lg transition-colors"
+              >
+                Close
+              </button>
             </div>
           ) : (
             <>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                Spotted something wrong? Let us know and we'll fix it.
+              <p className="text-xs text-gray-600 dark:text-gray-300 mb-1.5">
+                Spotted something wrong? Tell us and we'll fix it —{' '}
+                <strong className="text-amber-700 dark:text-amber-400">you'll get 3 credits straight away</strong> as thanks.
+              </p>
+              <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-2">
+                Most common problems: a co-author who is actually you under another
+                spelling (maiden name, umlaut, or extra initials), an open-access
+                percentage that looks too low, a wrong affiliation, or missing or
+                duplicated publications.
               </p>
               <textarea
                 value={reportMsg}
                 onChange={e => setReportMsg(e.target.value)}
-                placeholder="Describe the error (e.g., 'Wrong affiliation', 'Missing publications'...)"
-                rows={2}
+                placeholder="Describe the error — e.g. 'my top co-author is my own maiden name' or 'most of my papers are open access but it shows 0%'"
+                rows={3}
                 className="w-full px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-gray-100 focus:border-[#2d7d7d] focus:ring-1 focus:ring-[#2d7d7d] outline-none resize-none mb-2"
                 maxLength={1000}
               />
@@ -1046,9 +1117,14 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
                 type="email"
                 value={reportEmail}
                 onChange={e => setReportEmail(e.target.value)}
-                placeholder="Your email (optional, for follow-up)"
+                placeholder="Your email (optional — so we can tell you when it's fixed)"
                 className="w-full px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-gray-100 focus:border-[#2d7d7d] focus:ring-1 focus:ring-[#2d7d7d] outline-none mb-2"
               />
+              {reportError && (
+                <p className="text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 px-3 py-2 rounded-lg mb-2">
+                  {reportError}
+                </p>
+              )}
               <div className="flex items-center gap-2">
                 <button
                   onClick={handleReport}
@@ -1060,7 +1136,7 @@ export function ResearcherNarrative({ data, geoData, onSearch, pIndexResult }: R
                   ) : 'Submit report'}
                 </button>
                 <button
-                  onClick={() => { setShowReport(false); setReportMsg(''); setReportEmail(''); }}
+                  onClick={closeReport}
                   className="px-3 py-1.5 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
                 >
                   Cancel

--- a/supabase/functions/report-profile/index.ts
+++ b/supabase/functions/report-profile/index.ts
@@ -1,0 +1,146 @@
+import { createClient } from "npm:@supabase/supabase-js@2.39.3";
+
+/**
+ * Profile error reports, with an immediate thank-you credit grant.
+ *
+ * Reports are the main way data-quality bugs reach us, so the flow stays open
+ * to anonymous visitors — the report is what matters, the account is not.
+ * Signed-in reporters get credits right away; anonymous ones can't be credited,
+ * and the client tells them so rather than promising something we can't give.
+ *
+ * Deploy with: supabase functions deploy report-profile --no-verify-jwt
+ */
+
+const ALLOWED_ORIGINS = [
+  'https://scholarfolio.org',
+  'https://www.scholarfolio.org',
+  'https://scholarfolio.netlify.app',
+  'http://localhost:5173',
+];
+
+function isAllowedOrigin(origin: string): boolean {
+  if (ALLOWED_ORIGINS.includes(origin)) return true;
+  return /^https:\/\/[a-z0-9-]+--scholarfolio\.netlify\.app$/.test(origin);
+}
+
+function corsHeaders(req: Request): Record<string, string> {
+  const origin = req.headers.get('Origin') || '';
+  return {
+    'Access-Control-Allow-Origin': isAllowedOrigin(origin) ? origin : ALLOWED_ORIGINS[0],
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  };
+}
+
+const supabase = createClient(
+  Deno.env.get('SUPABASE_URL') ?? '',
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+);
+
+/** Credits granted per accepted report. */
+const REPORT_CREDITS = 3;
+/** Lifetime ceiling per account, so reporting can't be farmed for credits. */
+const REPORT_CREDIT_CAP = 12;
+
+function json(body: unknown, status: number, req: Request): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders(req) });
+  }
+  if (req.method !== 'POST') {
+    return json({ error: 'Method not allowed' }, 405, req);
+  }
+
+  try {
+    const body = await req.json().catch(() => ({}));
+    const { authorId, authorName, message, reporterEmail, pageUrl } = body as {
+      authorId?: string; authorName?: string; message?: string;
+      reporterEmail?: string; pageUrl?: string;
+    };
+
+    if (typeof message !== 'string' || !message.trim()) {
+      return json({ error: 'A description of the problem is required.' }, 400, req);
+    }
+    if (message.length > 2000) {
+      return json({ error: 'Description must be at most 2000 characters.' }, 400, req);
+    }
+    if (reporterEmail && (typeof reporterEmail !== 'string' || reporterEmail.length > 320)) {
+      return json({ error: 'Invalid email address.' }, 400, req);
+    }
+
+    // Optional auth: a missing or stale token still files the report.
+    let userId: string | null = null;
+    const jwt = (req.headers.get('Authorization') || '').replace('Bearer ', '');
+    if (jwt) {
+      const { data: { user } } = await supabase.auth.getUser(jwt);
+      userId = user?.id ?? null;
+    }
+
+    // Decide the grant before inserting, so the report row records what was given.
+    let creditsToGrant = 0;
+    let capReached = false;
+    if (userId) {
+      const { data: priorRows, error: priorError } = await supabase
+        .from('profile_reports')
+        .select('credits_granted')
+        .eq('user_id', userId);
+      if (priorError) {
+        console.error('report-profile: prior credits lookup failed:', priorError);
+      } else {
+        const alreadyGranted = (priorRows ?? []).reduce(
+          (sum: number, row: { credits_granted: number | null }) => sum + (row.credits_granted ?? 0),
+          0
+        );
+        creditsToGrant = Math.max(0, Math.min(REPORT_CREDITS, REPORT_CREDIT_CAP - alreadyGranted));
+        capReached = creditsToGrant === 0;
+      }
+    }
+
+    const { error: insertError } = await supabase.from('profile_reports').insert({
+      author_id: authorId ?? null,
+      author_name: authorName ?? null,
+      reporter_email: reporterEmail?.trim() || null,
+      message: message.trim(),
+      page_url: pageUrl ?? null,
+      user_id: userId,
+      credits_granted: creditsToGrant,
+    });
+
+    if (insertError) {
+      console.error('report-profile: insert failed:', insertError);
+      return json({ error: 'Could not save your report. Please try again.' }, 500, req);
+    }
+
+    if (creditsToGrant > 0 && userId) {
+      const { error: creditError } = await supabase.rpc('increment_credits', {
+        p_user_id: userId,
+        p_amount: creditsToGrant,
+      });
+      if (creditError) {
+        // The report is saved and matters more than the credits; report the
+        // grant honestly as zero rather than claiming credits that didn't land.
+        console.error('report-profile: credit grant failed:', creditError);
+        await supabase.from('profile_reports')
+          .update({ credits_granted: 0 })
+          .eq('user_id', userId)
+          .eq('message', message.trim());
+        return json({ ok: true, creditsGranted: 0, signedIn: true, capReached: false }, 200, req);
+      }
+    }
+
+    return json(
+      { ok: true, creditsGranted: creditsToGrant, signedIn: Boolean(userId), capReached },
+      200,
+      req
+    );
+  } catch (err) {
+    console.error('report-profile error:', err);
+    return json({ error: 'Server error' }, 500, req);
+  }
+});

--- a/supabase/migrations/20260722_profile_report_credits.sql
+++ b/supabase/migrations/20260722_profile_report_credits.sql
@@ -1,0 +1,20 @@
+-- Thank-you credits for profile error reports.
+-- Applied directly to production 2026-07-22.
+--
+-- Reporting a data error now grants the reporter 3 credits immediately. The
+-- grant is made server-side by the `report-profile` edge function (deployed
+-- --no-verify-jwt), which needs to know how much a given account has already
+-- received so reporting can't be farmed for credits.
+--
+-- user_id is nullable on purpose: anonymous visitors must still be able to
+-- report errors — that is how most data-quality bugs reach us — they simply
+-- receive no credits.
+
+ALTER TABLE public.profile_reports
+  ADD COLUMN IF NOT EXISTS user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS credits_granted integer NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.profile_reports.user_id IS
+  'Reporter when signed in; null for anonymous reports. Used to cap the thank-you credit grant.';
+COMMENT ON COLUMN public.profile_reports.credits_granted IS
+  'Credits granted for this report (0 for anonymous or once the per-user cap is reached).';


### PR DESCRIPTION
Makes the profile error report entry point visible, tells people what usually goes wrong, and rewards the report immediately.

Prompted by the Miriam Pein-Hackelbusch report (#292/#293), which reached us via LinkedIn rather than the in-app button — the button was 10px grey text at the edge of a section header.

## Changes
- **Prominent entry point** — amber pill button reading "Report an error · +3 credits" instead of faint grey text.
- **Says what to look for**, using the problems we actually see: a co-author who is really you under another spelling (maiden name, umlaut, extra initials), an open-access percentage that looks too low, a wrong affiliation, missing or duplicated publications. The placeholder now shows two real examples.
- **Credits are promised up front** and granted on submission.
- **New post-submission message**: apologises for the error, confirms the 3 credits landed, says we'll follow up by email if one was left, and thanks them.
- New `report-profile` edge function (deployed `--no-verify-jwt`) replaces the direct table insert so credits can be granted server-side.

## Credits
3 per report, granted immediately, capped at 12 per account so reporting can't be farmed. Anonymous reporting stays fully supported — it is how most data-quality bugs reach us — and those reporters are told a free account earns credits on future reports rather than being promised something they don't get. If the credit grant fails the report is still saved and the response honestly reports zero.

`profile_reports` gains nullable `user_id` and `credits_granted` (migration recorded; already applied in production).

## Verified live
- Empty message → 400; `GET` → 405; anonymous report → saved, `creditsGranted: 0`.
- `increment_credits(p_user_id uuid, p_amount integer)` signature matches the call.
- Test row deleted; build and typecheck clean.
