### PR TITLE
Check every tab's co-author surface, fix two more self-listings

### DIFF
--- a/scripts/name-audit/README.md
+++ b/scripts/name-audit/README.md
@@ -22,10 +22,11 @@ rather than passing it.
 
 Classes covered: hyphenated/compound surnames (including Unicode hyphens),
 maiden↔married names, German umlauts and ß, Nordic characters (ø å æ),
-Spanish/Portuguese double surnames, multiple given names and initials blocks,
-surname particles (van/de/von), CJK names and romanisation, apostrophes,
-truncation markers, plus real-world pairs of distinct people who share a
-surname.
+Spanish/Portuguese double surnames, surname particles (van/de/von, and the
+Portuguese dos/das/da form where the particle introduces a full double
+surname), multiple given names and initials blocks, misspelt name variants,
+CJK names and romanisation, apostrophes, truncation markers, plus real-world
+pairs of distinct people who share a surname.
 
 Cases marked `xfail` are **known, accepted limitations**, asserted to still
 fail. If a change fixes one, the run reports "unexpectedly fixed" and the case
@@ -48,8 +49,26 @@ npx tsx scripts/name-audit/run.ts --verbose  # per profile
 npx tsx scripts/name-audit/run.ts --json     # machine-readable
 ```
 
-Replays the live pipeline over the 100 cached profiles in `profiles.json` and
-checks four invariants:
+Replays the live pipeline over the 100 cached profiles in `profiles.json`.
+
+Crucially it checks **every surface that turns an author list into co-authors**,
+not just one. The bug that prompted this was a tab still showing a user her own
+maiden name after the narrative had been fixed, so each is asserted separately:
+
+| surface | what renders it |
+|---|---|
+| `metrics/narrative (top co-authors)` | Impact Metrics card, narrative text, PDF export, CV export |
+| `metrics/narrative (top co-author)` | the "most frequent collaborator" line |
+| `network (collaboration insights)` | Collaboration Insights panel on the Co-author Network tab |
+| `network (graph nodes)` | the co-author graph itself |
+| `narrative (linkified authors)` | clickable author names in the narrative |
+| `world map (co-author set)` | co-authors plotted on the World Map |
+
+The Collaboration Insights figures come from the same exported function the tab
+renders (`utils/collaborationInsights.ts`), not a copy — a check written against
+a reimplementation would not have caught the original bug.
+
+Four invariants per surface:
 
 - **self-listed** — the owner must never rank as their own collaborator
 - **truncation-marker** — Scholar's `...` is not a person

--- a/scripts/name-audit/cases.ts
+++ b/scripts/name-audit/cases.ts
@@ -92,6 +92,9 @@ const MATRIX: Record<string, Case[]> = {
     { byline: 'J van der Berg', owner: 'Jan van der Berg', same: true, note: 'two particles' },
     { byline: 'M von Grafenstein', owner: 'Max von Grafenstein', same: true, note: 'von particle' },
     { byline: 'P de Vries', owner: 'Ko de Ruyter', same: false, note: 'DIFFERENT surname, same particle' },
+    { byline: 'AI dos Santos Couto', owner: 'Ana Couto', same: true, note: 'portuguese particle + double surname' },
+    { byline: 'M da Silva Santos', owner: 'Maria Santos', same: true, note: 'da particle + double surname' },
+    { byline: 'J dos Santos Couto', owner: 'Ana Couto', same: false, note: 'DIFFERENT person, same surnames' },
   ],
 
   'CJK & romanisation': [
@@ -111,6 +114,15 @@ const MATRIX: Record<string, Case[]> = {
   'truncation markers': [
     { byline: '...', owner: 'Miriam Pein-Hackelbusch', same: false, note: 'ellipsis is not a person' },
     { byline: '…', owner: 'Miriam Pein-Hackelbusch', same: false, note: 'unicode ellipsis' },
+  ],
+
+  'misspelt name variants': [
+    { byline: 'J Japhat Haruna', owner: 'Jonah Japhet Haruna', same: true, note: 'one-letter typo in middle name' },
+    { byline: 'Jonah Japhat Haruna', owner: 'Jonah Japhet Haruna', same: true, note: 'typo, both spelled out' },
+    { byline: 'J Jonathan Haruna', owner: 'Jonah Japhet Haruna', same: false, note: 'DIFFERENT middle name' },
+    { byline: 'Jon Smith', owner: 'Jan Smith', same: false, note: 'short names one edit apart are DIFFERENT people' },
+    { byline: 'Eric Meyer', owner: 'Erik Meyer', same: false, note: 'four letters is below the typo floor' },
+    { byline: 'Kristina Petrov', owner: 'Kristine Petrov', same: true, note: 'long given name, one edit' },
   ],
 
   'unrelated people (global negative controls)': [

--- a/scripts/name-audit/run.ts
+++ b/scripts/name-audit/run.ts
@@ -19,6 +19,11 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { calculateCoAuthorMetrics } from '../../src/services/metrics/collaboration/co-author-metrics';
+import { coAuthorsOf } from '../../src/utils/authorIdentity';
+import {
+  computeCollaborationInsights,
+  networkCoAuthorNodes,
+} from '../../src/utils/collaborationInsights';
 import {
   canonicalNameKey,
   extractLastName,
@@ -160,22 +165,57 @@ async function main() {
     const knownSelf = new Set(entry.knownHardSelfListed ?? []);
     const knownDup = new Set(entry.knownHardDuplicatePairs ?? []);
 
-    // A. the profile owner must never rank as their own collaborator
-    for (const name of coAuthors) {
-      if (likelySamePerson(name, profile.name)) {
-        findings.push({
-          profile: profile.name,
-          kind: 'self-listed',
-          detail: name,
-          known: knownSelf.has(name),
-        });
-      }
-    }
+    // Every surface in the app that turns an author list into co-authors.
+    // Each is checked separately: the reported bug was a tab whose own
+    // implementation still showed the owner after the narrative was fixed.
+    const insights = computeCollaborationInsights(pubs as never, profile.name);
+    const surfaces: Array<{ surface: string; names: string[] }> = [
+      // Impact Metrics card, Narrative, PDF export and CV export all read these
+      { surface: 'metrics/narrative (top co-authors)', names: coAuthors },
+      { surface: 'metrics/narrative (top co-author)', names: metrics.topCoAuthor ? [metrics.topCoAuthor] : [] },
+      // Co-author Network tab — Collaboration Insights panel
+      {
+        surface: 'network (collaboration insights)',
+        names: [insights?.topByPapers?.name, insights?.topByCitations?.name, insights?.topOneTimer?.name]
+          .filter((n): n is string => Boolean(n)),
+      },
+      // Co-author Network tab — graph nodes
+      { surface: 'network (graph nodes)', names: networkCoAuthorNodes(pubs as never, profile.name) },
+      // Narrative author linkification
+      {
+        surface: 'narrative (linkified authors)',
+        names: [...new Set(pubs.flatMap(p => coAuthorsOf(p.authors, profile.name)))],
+      },
+      // World Map: the local half of the geo service picks the same co-authors
+      // before enriching them with OpenAlex institutions.
+      {
+        surface: 'world map (co-author set)',
+        names: [...new Set(pubs.flatMap(p => coAuthorsOf(p.authors, profile.name)))],
+      },
+    ];
 
-    // B. truncation markers are not people
-    for (const name of coAuthors) {
-      if (TRUNCATION.test(name)) {
-        findings.push({ profile: profile.name, kind: 'truncation-marker', detail: name, known: false });
+    for (const { surface, names } of surfaces) {
+      // A. the profile owner must never rank as their own collaborator
+      for (const name of names) {
+        if (likelySamePerson(name, profile.name)) {
+          findings.push({
+            profile: profile.name,
+            kind: 'self-listed',
+            detail: `${name}  [${surface}]`,
+            known: knownSelf.has(name),
+          });
+        }
+      }
+      // B. truncation markers are not people
+      for (const name of names) {
+        if (TRUNCATION.test(name)) {
+          findings.push({
+            profile: profile.name,
+            kind: 'truncation-marker',
+            detail: `${name}  [${surface}]`,
+            known: false,
+          });
+        }
       }
     }
 

--- a/src/components/CitationNetwork.tsx
+++ b/src/components/CitationNetwork.tsx
@@ -8,7 +8,8 @@ import { scaleSequential } from 'd3-scale';
 import { interpolateRdYlGn, interpolateViridis } from 'd3-scale-chromatic';
 import { Network, Share2, BookOpen, Presentation as Citation, Users, Info, Clock, GitBranch, Waypoints, TrendingUp, UserCheck, Sparkles } from 'lucide-react';
 import type { Publication } from '../types/scholar';
-import { coAuthorsOf, inferMainAuthor, isSameResearcher } from '../utils/authorIdentity';
+import { coAuthorsOf, inferMainAuthor } from '../utils/authorIdentity';
+import { computeCollaborationInsights } from '../utils/collaborationInsights';
 import { extractLastName } from '../utils/names';
 
 interface Node {
@@ -656,65 +657,12 @@ export function CitationNetwork({ publications, authorName, fullScreen = false, 
     };
   }, [publications, authorName, fullScreen, viewMode, connectionLimit]);
 
-  // Compute network insights from publications
-  const insights = useMemo(() => {
-    if (!publications.length) return null;
-
-    const mainAuth = authorName?.trim() || inferMainAuthor(publications);
-    if (!mainAuth) return null;
-
-    // Solo papers: every listed author is the owner under some spelling.
-    const soloPapers = publications.filter(
-      p => p.authors.length === 1 && isSameResearcher(p.authors[0], mainAuth)
-    );
-    const collabPapers = publications.filter(p => p.authors.length > 1);
-
-    // Co-author stats
-    const coAuthors = new Map<string, { papers: number; citations: number; years: number[] }>();
-    publications.forEach(pub => {
-      coAuthorsOf(pub.authors, mainAuth).forEach(a => {
-        const existing = coAuthors.get(a) || { papers: 0, citations: 0, years: [] };
-        existing.papers++;
-        existing.citations += pub.citations;
-        if (pub.year > 0) existing.years.push(pub.year);
-        coAuthors.set(a, existing);
-      });
-    });
-
-    const sorted = [...coAuthors.entries()].sort((a, b) => b[1].papers - a[1].papers);
-    const topByPapers = sorted[0];
-    const topByCitations = [...coAuthors.entries()].sort((a, b) => b[1].citations - a[1].citations)[0];
-
-    // One-time collaborators with high impact
-    const oneTimers = [...coAuthors.entries()]
-      .filter(([, d]) => d.papers === 1)
-      .sort((a, b) => b[1].citations - a[1].citations);
-    const oneTimeCitations = oneTimers.reduce((sum, [, d]) => sum + d.citations, 0);
-
-    // Avg authors per paper
-    const avgAuthors = publications.reduce((sum, p) => sum + p.authors.length, 0) / publications.length;
-
-    // New collaborators per year
-    const firstCollabYear = new Map<string, number>();
-    publications.sort((a, b) => a.year - b.year).forEach(pub => {
-      coAuthorsOf(pub.authors, mainAuth).forEach(a => {
-        if (!firstCollabYear.has(a) && pub.year > 0) firstCollabYear.set(a, pub.year);
-      });
-    });
-
-    return {
-      totalCoAuthors: coAuthors.size,
-      soloPapers: soloPapers.length,
-      collabPapers: collabPapers.length,
-      soloPercent: publications.length > 0 ? Math.round((soloPapers.length / publications.length) * 100) : 0,
-      avgAuthors: avgAuthors.toFixed(1),
-      topByPapers: topByPapers ? { name: topByPapers[0], papers: topByPapers[1].papers, citations: topByPapers[1].citations } : null,
-      topByCitations: topByCitations ? { name: topByCitations[0], papers: topByCitations[1].papers, citations: topByCitations[1].citations } : null,
-      oneTimeCollaborators: oneTimers.length,
-      oneTimeCitations,
-      topOneTimer: oneTimers[0] ? { name: oneTimers[0][0], citations: oneTimers[0][1].citations } : null,
-    };
-  }, [publications, authorName]);
+  // Collaboration Insights — computed by a shared pure function so the
+  // name-matching audit asserts on the very numbers this panel renders.
+  const insights = useMemo(
+    () => computeCollaborationInsights(publications, authorName),
+    [publications, authorName]
+  );
 
   return (
     <div className={`bg-white/80 dark:bg-slate-800/80 backdrop-blur-xl rounded-xl border border-primary-start/10 dark:border-slate-700 p-6 hover:shadow-lg transition-all ${

--- a/src/utils/authorIdentity.ts
+++ b/src/utils/authorIdentity.ts
@@ -84,10 +84,18 @@ export function parseName(cleaned: string): { given: string[]; last: string } {
   if (parts.length === 0) return { given: [], last: '' };
   if (parts.length === 1) return { given: [], last: parts[0] };
 
-  const prefixes = new Set(['van', 'von', 'de', 'del', 'della', 'di', 'du', 'le', 'la', 'el', 'al', 'bin', 'ibn', 'den', 'der', 'het', 'ter', 'ten']);
+  const prefixes = new Set(['van', 'von', 'de', 'del', 'della', 'di', 'da', 'do', 'dos', 'das', 'du', 'le', 'la', 'el', 'al', 'bin', 'ibn', 'den', 'der', 'het', 'ter', 'ten']);
+  // The surname begins at the FIRST particle, not the last: Portuguese and
+  // Spanish names put a full double surname behind one ("AI dos Santos Couto"
+  // is given "AI" + surname "dos Santos Couto"). Walking back only over
+  // consecutive particles would leave "Santos" parsed as a given name and the
+  // author unrecognisable against a profile reading "Ana Couto".
   let lastStart = parts.length - 1;
-  while (lastStart > 1 && prefixes.has(parts[lastStart - 1].toLowerCase())) {
-    lastStart--;
+  for (let i = 1; i < parts.length - 1; i++) {
+    if (prefixes.has(parts[i].toLowerCase())) {
+      lastStart = i;
+      break;
+    }
   }
 
   return {
@@ -230,7 +238,58 @@ export function isSameResearcher(byline: string, reference: string): boolean {
     return true;
   }
 
-  return compoundSurnamesMatch(a, b) && initialsCompatible(aInitials, bInitials);
+  if (compoundSurnamesMatch(a, b) && initialsCompatible(aInitials, bInitials)) return true;
+
+  return surnamesCompatible(a.last, b.last)
+    && initialsCompatible(aInitials, bInitials)
+    && givenNamesDifferByOneTypo(a.given, b.given);
+}
+
+/** Levenshtein distance, bailing out once it exceeds `max`. */
+function editDistanceWithin(a: string, b: string, max: number): boolean {
+  if (Math.abs(a.length - b.length) > max) return false;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i];
+    for (let j = 1; j <= b.length; j++) {
+      curr[j] = a[i - 1] === b[j - 1]
+        ? prev[j - 1]
+        : 1 + Math.min(prev[j - 1], prev[j], curr[j - 1]);
+    }
+    if (Math.min(...curr) > max) return false;
+    prev = curr;
+  }
+  return prev[b.length] <= max;
+}
+
+/**
+ * Given names that agree except for a single misspelt token — the profile
+ * "Jonah Japhet Haruna" against a byline reading "J Japhat Haruna".
+ *
+ * Deliberately narrow: same token count, exactly one differing pair, one
+ * character apart, and both tokens at least five characters. The length floor
+ * is what keeps genuinely distinct short names apart — Jan/Jon, Erik/Eric,
+ * Marc/Mark are all one edit apart and must not merge.
+ */
+function givenNamesDifferByOneTypo(a: string[], b: string[]): boolean {
+  if (a.length !== b.length || a.length === 0) return false;
+  let differing = 0;
+  for (let i = 0; i < a.length; i++) {
+    const x = canonicalNameKey(a[i]);
+    const y = canonicalNameKey(b[i]);
+    if (x === y) continue;
+    // An initial standing in for the full name is not a typo — isSameAuthor
+    // already accepts that, and it must not consume the single allowance.
+    if (x.length <= 2 || y.length <= 2) {
+      if (x[0] === y[0]) continue;
+      return false;
+    }
+    differing++;
+    if (differing > 1) return false;
+    if (x.length < 5 || y.length < 5) return false;
+    if (!editDistanceWithin(x, y, 1)) return false;
+  }
+  return differing === 1;
 }
 
 /**

--- a/src/utils/collaborationInsights.ts
+++ b/src/utils/collaborationInsights.ts
@@ -1,0 +1,94 @@
+import type { Publication } from '../types/scholar';
+import { coAuthorsOf, inferMainAuthor, isSameResearcher } from './authorIdentity';
+
+export interface CollaborationInsights {
+  totalCoAuthors: number;
+  soloPapers: number;
+  collabPapers: number;
+  soloPercent: number;
+  avgAuthors: string;
+  topByPapers: { name: string; papers: number; citations: number } | null;
+  topByCitations: { name: string; papers: number; citations: number } | null;
+  oneTimeCollaborators: number;
+  oneTimeCitations: number;
+  topOneTimer: { name: string; citations: number } | null;
+}
+
+/**
+ * The "Collaboration Insights" figures shown on the Co-author Network tab.
+ *
+ * Pure and exported so the name-matching audit can assert on the same numbers
+ * the tab renders — this panel is where a user found her own maiden name
+ * ranked as her most frequent collaborator, and a check that runs against a
+ * copy of the logic would not have caught it.
+ */
+export function computeCollaborationInsights(
+  publications: Publication[],
+  authorName?: string
+): CollaborationInsights | null {
+  if (!publications.length) return null;
+
+  const mainAuth = authorName?.trim() || inferMainAuthor(publications);
+  if (!mainAuth) return null;
+
+  // Solo papers: every listed author is the owner under some spelling.
+  const soloPapers = publications.filter(
+    p => p.authors.length === 1 && isSameResearcher(p.authors[0], mainAuth)
+  );
+  const collabPapers = publications.filter(p => p.authors.length > 1);
+
+  const coAuthors = new Map<string, { papers: number; citations: number; years: number[] }>();
+  for (const pub of publications) {
+    for (const a of coAuthorsOf(pub.authors, mainAuth)) {
+      const existing = coAuthors.get(a) || { papers: 0, citations: 0, years: [] };
+      existing.papers++;
+      existing.citations += pub.citations;
+      if (pub.year > 0) existing.years.push(pub.year);
+      coAuthors.set(a, existing);
+    }
+  }
+
+  const sorted = [...coAuthors.entries()].sort((a, b) => b[1].papers - a[1].papers);
+  const topByPapers = sorted[0];
+  const topByCitations = [...coAuthors.entries()].sort((a, b) => b[1].citations - a[1].citations)[0];
+
+  const oneTimers = [...coAuthors.entries()]
+    .filter(([, d]) => d.papers === 1)
+    .sort((a, b) => b[1].citations - a[1].citations);
+  const oneTimeCitations = oneTimers.reduce((sum, [, d]) => sum + d.citations, 0);
+
+  const avgAuthors = publications.reduce((sum, p) => sum + p.authors.length, 0) / publications.length;
+
+  return {
+    totalCoAuthors: coAuthors.size,
+    soloPapers: soloPapers.length,
+    collabPapers: collabPapers.length,
+    soloPercent: Math.round((soloPapers.length / publications.length) * 100),
+    avgAuthors: avgAuthors.toFixed(1),
+    topByPapers: topByPapers
+      ? { name: topByPapers[0], papers: topByPapers[1].papers, citations: topByPapers[1].citations }
+      : null,
+    topByCitations: topByCitations
+      ? { name: topByCitations[0], papers: topByCitations[1].papers, citations: topByCitations[1].citations }
+      : null,
+    oneTimeCollaborators: oneTimers.length,
+    oneTimeCitations,
+    topOneTimer: oneTimers[0]
+      ? { name: oneTimers[0][0], citations: oneTimers[0][1].citations }
+      : null,
+  };
+}
+
+/**
+ * Co-author nodes of the network graph: every distinct collaborator across the
+ * publication list, owner variants and truncation markers removed.
+ */
+export function networkCoAuthorNodes(publications: Publication[], authorName?: string): string[] {
+  const mainAuth = authorName?.trim() || inferMainAuthor(publications);
+  if (!mainAuth) return [];
+  const names = new Set<string>();
+  for (const pub of publications) {
+    for (const a of coAuthorsOf(pub.authors, mainAuth)) names.add(a);
+  }
+  return [...names];
+}


### PR DESCRIPTION
Follow-up to #296: extends the audit to check **every tab's co-author surface**, not just the narrative — and that immediately found two more real self-listings, both now fixed.

## Why per-surface checking was needed
#296 routed all four implementations through one identity check, but the audit still only asserted on the metrics/narrative path. A surface can go wrong without that path noticing: `topCoAuthors` requires ≥2 shared papers, so a one-paper self-listing is invisible there while still appearing in the network graph, the linkified narrative text, and the World Map.

The audit now asserts separately on six surfaces:

| surface | rendered by |
|---|---|
| `metrics/narrative (top co-authors)` | Impact Metrics, narrative, PDF export, CV export |
| `metrics/narrative (top co-author)` | "most frequent collaborator" line |
| `network (collaboration insights)` | Collaboration Insights panel |
| `network (graph nodes)` | co-author graph |
| `narrative (linkified authors)` | clickable author names |
| `world map (co-author set)` | World Map points |

Collaboration Insights moved into `utils/collaborationInsights.ts` and is now **the same function the tab renders**, so the audit tests real code rather than a reimplementation.

## Two bugs it found
1. **Portuguese particles** — `Ana Couto` vs `AI dos Santos Couto`. The parser walked back only over *consecutive* trailing particles, so `Santos` was read as a given name and the surname as just `Couto`. Surnames now start at the **first** particle, which is how Portuguese and Spanish double surnames are written. (`da`, `do`, `dos`, `das` added to the particle list.)
2. **Misspelt name variants** — `Jonah Japhet Haruna` vs `J Japhat Haruna`, one letter apart in the middle name. Now accepted, but deliberately narrowly: same token count, exactly one differing pair, one edit apart, and **both tokens at least five characters**. That floor is what keeps genuinely distinct short names apart — `Jan`/`Jon`, `Erik`/`Eric`, `Marc`/`Mark` are each one edit apart and must not merge. All three are negative controls in the matrix.

## Verification
- Matrix: **64 passing, 0 regressions, 3 tracked limitations** (up from 55 — six new cases for typos, three for Portuguese particles).
- **All 326 cached profiles × 6 surfaces: 0 regressions.**
- Build and typecheck clean.
