### PR TITLE
Make credit grants atomic and stop clients writing credit columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "research-portfolio",
-  "version": "0.13.0-beta",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "research-portfolio",
-      "version": "0.13.0-beta",
+      "version": "0.14.0",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@supabase/supabase-js": "^2.107.0",
@@ -2891,7 +2891,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -4173,18 +4172,6 @@
       "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
       "dependencies": {
         "robust-predicates": "^3.0.2"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/detect-node-es": {
@@ -5932,280 +5919,6 @@
       "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
-      }
-    },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {

--- a/supabase/functions/report-profile/index.ts
+++ b/supabase/functions/report-profile/index.ts
@@ -82,60 +82,35 @@ Deno.serve(async (req) => {
       userId = user?.id ?? null;
     }
 
-    // Decide the grant before inserting, so the report row records what was given.
-    let creditsToGrant = 0;
-    let capReached = false;
-    if (userId) {
-      const { data: priorRows, error: priorError } = await supabase
-        .from('profile_reports')
-        .select('credits_granted')
-        .eq('user_id', userId);
-      if (priorError) {
-        console.error('report-profile: prior credits lookup failed:', priorError);
-      } else {
-        const alreadyGranted = (priorRows ?? []).reduce(
-          (sum: number, row: { credits_granted: number | null }) => sum + (row.credits_granted ?? 0),
-          0
-        );
-        creditsToGrant = Math.max(0, Math.min(REPORT_CREDITS, REPORT_CREDIT_CAP - alreadyGranted));
-        capReached = creditsToGrant === 0;
-      }
-    }
-
-    const { error: insertError } = await supabase.from('profile_reports').insert({
-      author_id: authorId ?? null,
-      author_name: authorName ?? null,
-      reporter_email: reporterEmail?.trim() || null,
-      message: message.trim(),
-      page_url: pageUrl ?? null,
-      user_id: userId,
-      credits_granted: creditsToGrant,
+    // Save the report and grant the credits in ONE database transaction. The
+    // cap check has to happen under a row lock: when it was done here — read
+    // the running total, then insert, then credit — two requests fired at once
+    // both read "nothing granted yet" and both paid out, so the ceiling could
+    // be walked past at will.
+    const { data: granted, error: rpcError } = await supabase.rpc('submit_profile_report', {
+      p_message: message,
+      p_author_id: authorId ?? null,
+      p_author_name: authorName ?? null,
+      p_reporter_email: reporterEmail ?? null,
+      p_page_url: pageUrl ?? null,
+      p_user_id: userId,
+      p_credits: REPORT_CREDITS,
+      p_cap: REPORT_CREDIT_CAP,
     });
 
-    if (insertError) {
-      console.error('report-profile: insert failed:', insertError);
+    if (rpcError) {
+      console.error('report-profile: submit failed:', rpcError);
       return json({ error: 'Could not save your report. Please try again.' }, 500, req);
     }
 
-    if (creditsToGrant > 0 && userId) {
-      const { error: creditError } = await supabase.rpc('increment_credits', {
-        p_user_id: userId,
-        p_amount: creditsToGrant,
-      });
-      if (creditError) {
-        // The report is saved and matters more than the credits; report the
-        // grant honestly as zero rather than claiming credits that didn't land.
-        console.error('report-profile: credit grant failed:', creditError);
-        await supabase.from('profile_reports')
-          .update({ credits_granted: 0 })
-          .eq('user_id', userId)
-          .eq('message', message.trim());
-        return json({ ok: true, creditsGranted: 0, signedIn: true, capReached: false }, 200, req);
-      }
-    }
-
+    const creditsGranted = typeof granted === 'number' ? granted : 0;
     return json(
-      { ok: true, creditsGranted: creditsToGrant, signedIn: Boolean(userId), capReached },
+      {
+        ok: true,
+        creditsGranted,
+        signedIn: Boolean(userId),
+        capReached: Boolean(userId) && creditsGranted === 0,
+      },
       200,
       req
     );

--- a/supabase/functions/submit-feedback/index.ts
+++ b/supabase/functions/submit-feedback/index.ts
@@ -84,66 +84,29 @@ Deno.serve(async (req) => {
       }
     }
 
-    // Query total credits already granted to this user from feedback
-    const { data: sumData, error: sumError } = await supabase
-      .from('feedback')
-      .select('credits_granted')
-      .eq('user_id', userId);
-
-    if (sumError) {
-      console.error('Error querying feedback credits:', sumError);
-      return new Response(
-        JSON.stringify({ error: 'Failed to process feedback' }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const totalCreditsGranted = (sumData ?? []).reduce(
-      (sum: number, row: { credits_granted: number }) => sum + (row.credits_granted ?? 0),
-      0
-    );
-
-    const isFirstSubmission = (sumData ?? []).length === 0;
-
-    // Calculate credits to grant
-    let creditsToGrant: number;
-    if (totalCreditsGranted >= FEEDBACK_CREDIT_CAP) {
-      creditsToGrant = 0;
-    } else {
-      const earned = isFirstSubmission ? FIRST_SUBMISSION_CREDITS : SUBSEQUENT_CREDITS;
-      creditsToGrant = Math.min(earned, FEEDBACK_CREDIT_CAP - totalCreditsGranted);
-    }
-
-    // Insert feedback record
-    const { error: insertError } = await supabase.from('feedback').insert({
-      user_id: userId,
-      rating: rating ?? null,
-      comment: comment ?? null,
-      credits_granted: creditsToGrant,
-      profile_viewed: profileViewed ?? null,
-      source,
+    // Save the feedback and grant credits in ONE transaction. Doing the cap
+    // check here — read the running total, then insert, then credit — let two
+    // simultaneous submissions both read the same total and both pay out.
+    const { data: grantedRaw, error: rpcError } = await supabase.rpc('submit_feedback_with_credits', {
+      p_user_id: userId,
+      p_rating: rating ?? null,
+      p_comment: comment ?? null,
+      p_profile_viewed: profileViewed ?? null,
+      p_source: source,
+      p_first_credits: FIRST_SUBMISSION_CREDITS,
+      p_subsequent_credits: SUBSEQUENT_CREDITS,
+      p_cap: FEEDBACK_CREDIT_CAP,
     });
 
-    if (insertError) {
-      console.error('Error inserting feedback:', insertError);
+    if (rpcError) {
+      console.error('Error saving feedback:', rpcError);
       return new Response(
         JSON.stringify({ error: 'Failed to save feedback' }),
         { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    // Grant credits if applicable
-    if (creditsToGrant > 0) {
-      const { error: rpcError } = await supabase.rpc('increment_credits', {
-        p_user_id: userId,
-        p_amount: creditsToGrant,
-      });
-
-      if (rpcError) {
-        console.error('Error granting credits:', rpcError);
-        // Feedback is already saved — log the error but don't fail the response
-      }
-    }
+    const creditsToGrant: number = typeof grantedRaw === 'number' ? grantedRaw : 0;
 
     const message = creditsToGrant > 0
       ? `Thank you for your feedback! You've earned ${creditsToGrant} credit${creditsToGrant !== 1 ? 's' : ''}.`

--- a/supabase/migrations/20260723_atomic_credit_grants.sql
+++ b/supabase/migrations/20260723_atomic_credit_grants.sql
@@ -1,0 +1,148 @@
+-- Credit-grant integrity for feedback and profile error reports.
+-- Applied directly to production 2026-07-23.
+--
+-- Both edge functions granted credits as read-then-write: sum what the account
+-- had already been given, decide the amount, insert the row, then credit. Two
+-- requests fired at the same time both read the same "already granted" total
+-- and both paid out, so the lifetime caps (12 for reports, 20 for feedback)
+-- could be walked past with a handful of parallel requests.
+--
+-- Worse, the caps were computed from tables the client could write directly:
+-- profile_reports accepted any INSERT and feedback accepted any row with a
+-- matching user_id, both including `credits_granted`. Inserting a row with a
+-- negative value inflated the remaining headroom, so the cap never bound.
+--
+-- Both grants now happen inside one transaction that locks the account's
+-- credits row, and clients may no longer write the credit columns at all.
+
+-- Report submission: cap check, row insert and credit grant under one lock.
+CREATE OR REPLACE FUNCTION public.submit_profile_report(
+  p_message text,
+  p_author_id text DEFAULT NULL,
+  p_author_name text DEFAULT NULL,
+  p_reporter_email text DEFAULT NULL,
+  p_page_url text DEFAULT NULL,
+  p_user_id uuid DEFAULT NULL,
+  p_credits integer DEFAULT 3,
+  p_cap integer DEFAULT 12
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_granted integer := 0;
+  v_already integer := 0;
+BEGIN
+  IF p_user_id IS NOT NULL THEN
+    PERFORM 1 FROM user_credits WHERE user_id = p_user_id FOR UPDATE;
+    IF NOT FOUND THEN
+      INSERT INTO user_credits (user_id, credits_remaining, total_purchased)
+      VALUES (p_user_id, 0, 0)
+      ON CONFLICT (user_id) DO NOTHING;
+      PERFORM 1 FROM user_credits WHERE user_id = p_user_id FOR UPDATE;
+    END IF;
+
+    -- GREATEST(...,0): a negative row must not raise the headroom.
+    SELECT COALESCE(SUM(GREATEST(credits_granted, 0)), 0) INTO v_already
+    FROM profile_reports WHERE user_id = p_user_id;
+
+    v_granted := GREATEST(0, LEAST(p_credits, p_cap - v_already));
+  END IF;
+
+  INSERT INTO profile_reports (
+    author_id, author_name, reporter_email, message, page_url, user_id, credits_granted
+  ) VALUES (
+    p_author_id, p_author_name, NULLIF(btrim(coalesce(p_reporter_email,'')), ''),
+    btrim(p_message), p_page_url, p_user_id, v_granted
+  );
+
+  IF v_granted > 0 THEN
+    -- credits_remaining only. increment_credits() also bumps total_purchased,
+    -- which made feedback-only accounts count as paying customers in the admin
+    -- dashboard (5 "purchasing users" against 4 real ones).
+    UPDATE user_credits
+    SET credits_remaining = credits_remaining + v_granted
+    WHERE user_id = p_user_id;
+  END IF;
+
+  RETURN v_granted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.submit_profile_report(text,text,text,text,text,uuid,integer,integer)
+  FROM public, anon, authenticated;
+
+-- Feedback submission: same shape, first submission earns more than repeats.
+CREATE OR REPLACE FUNCTION public.submit_feedback_with_credits(
+  p_user_id uuid,
+  p_rating integer DEFAULT NULL,
+  p_comment text DEFAULT NULL,
+  p_profile_viewed text DEFAULT NULL,
+  p_source text DEFAULT 'button',
+  p_first_credits integer DEFAULT 5,
+  p_subsequent_credits integer DEFAULT 2,
+  p_cap integer DEFAULT 20
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_granted integer := 0;
+  v_already integer := 0;
+  v_count integer := 0;
+  v_earned integer;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'user_id is required';
+  END IF;
+
+  PERFORM 1 FROM user_credits WHERE user_id = p_user_id FOR UPDATE;
+  IF NOT FOUND THEN
+    INSERT INTO user_credits (user_id, credits_remaining, total_purchased)
+    VALUES (p_user_id, 0, 0)
+    ON CONFLICT (user_id) DO NOTHING;
+    PERFORM 1 FROM user_credits WHERE user_id = p_user_id FOR UPDATE;
+  END IF;
+
+  SELECT COALESCE(SUM(GREATEST(credits_granted, 0)), 0), COUNT(*)
+  INTO v_already, v_count
+  FROM feedback WHERE user_id = p_user_id;
+
+  v_earned := CASE WHEN v_count = 0 THEN p_first_credits ELSE p_subsequent_credits END;
+  v_granted := GREATEST(0, LEAST(v_earned, p_cap - v_already));
+
+  INSERT INTO feedback (user_id, rating, comment, credits_granted, profile_viewed, source)
+  VALUES (p_user_id, p_rating, p_comment, v_granted, p_profile_viewed, p_source);
+
+  IF v_granted > 0 THEN
+    UPDATE user_credits
+    SET credits_remaining = credits_remaining + v_granted
+    WHERE user_id = p_user_id;
+  END IF;
+
+  RETURN v_granted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.submit_feedback_with_credits(uuid,integer,text,text,text,integer,integer,integer)
+  FROM public, anon, authenticated;
+
+-- Clients may not write the credit columns the caps are computed from.
+-- Anonymous error reporting still works — it just cannot self-credit.
+DROP POLICY IF EXISTS "Anyone can submit a report" ON public.profile_reports;
+CREATE POLICY "Public can submit an uncredited report" ON public.profile_reports
+  FOR INSERT TO anon, authenticated
+  WITH CHECK (user_id IS NULL AND credits_granted = 0);
+
+DROP POLICY IF EXISTS "Users can insert own feedback" ON public.feedback;
+CREATE POLICY "Users can insert own uncredited feedback" ON public.feedback
+  FOR INSERT TO authenticated
+  WITH CHECK (auth.uid() = user_id AND credits_granted = 0);
+
+-- The admin dashboard reads analytics_events, but RLS had no SELECT policy for
+-- it: the panel silently rendered empty rather than reporting an error.
+CREATE POLICY "Admin can read analytics_events" ON public.analytics_events
+  FOR SELECT TO authenticated
+  USING ((auth.jwt() ->> 'email') = 'jonasheller89@gmail.com');


### PR DESCRIPTION
Found by a security review of the whole app. Two independent ways to mint unlimited credits, plus an admin panel that has been silently empty.

## 1. Credit caps could be walked past (both grant paths)
`report-profile` and `submit-feedback` both granted credits as read-then-write: sum what the account had already been given, decide the amount, insert the row, then credit. Nothing tied those steps together, so **concurrent requests all read the same "already granted" total and all paid out**. A handful of parallel requests mints credits well past the 12 / 20 lifetime caps, repeatably.

## 2. The caps were computed from client-writable tables
Worse, the caps were derived from tables the client could write directly — `profile_reports` accepted **any** insert (`WITH CHECK (true)`), `feedback` accepted any row with a matching `user_id`, and both include `credits_granted`. Inserting a single row with a **negative** `credits_granted` raised the remaining headroom, so the cap never bound again. No race needed.

## Fix
Both grants now happen inside one transaction that takes `SELECT … FOR UPDATE` on the account's credits row, so concurrent calls serialise (`submit_profile_report`, `submit_feedback_with_credits`). The running total is summed with `GREATEST(credits_granted, 0)` so a poisoned row cannot add headroom, and clients may no longer write the credit columns at all:

- `profile_reports` insert now requires `user_id IS NULL AND credits_granted = 0` — anonymous error reporting still works, it just can't self-credit.
- `feedback` insert now requires `credits_granted = 0`.

This also removes the fragile rollback that scoped an update by `user_id` + message text, which could zero out an earlier, already-paid grant when two reports shared the same text.

## 3. Admin analytics panel was silently empty
`analytics_events` had RLS enabled with **no SELECT policy**, so the admin dashboard's query returned zero rows rather than an error — the panel has been rendering empty. Added an admin SELECT policy matching the other admin tables.

## 4. Thank-you credits no longer inflate `total_purchased`
`increment_credits` bumps `total_purchased` as well as `credits_remaining`, so feedback and report credits made non-paying accounts look like customers — the admin dashboard counted **5 "purchasing users" against 4 real ones**. The new functions touch `credits_remaining` only. (Existing inflated values are left as-is; `credit_purchases` remains the accurate revenue source.)

## Verification
- Cap enforcement tested against a real account inside a deliberately rolled-back transaction: **8 requests × 3 credits attempted → exactly 12 granted**, balance delta exactly 12, nothing persisted.
- Anonymous submissions grant 0.
- Confirmed with the public anon key that no table leaks: only `profile_views` and `claimed_profiles` are readable, both intentionally public.
- Verified the admin-only tables (`client_errors`, `edge_function_errors`, `feedback`, `profile_reports`) are correctly gated to the admin email.
- Test rows removed; build clean.
